### PR TITLE
Correcting spelling of David Andrs' last name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,5 +1,5 @@
 ﻿== Open Salamander Core and Plugins
-David Andrs
+David Andrš
 Lukáš Cerman
 Jakub Červený
 Tomáš Jelínek


### PR DESCRIPTION
I typically spell my last name without diacritical marks, since with it, it creates confusion in international communication. However, it confuses people in the Czech republic, since there are both Andrs and Andrš families.

UTF is widely accepted and working these days, so we can safely use it.