### PR TITLE
Simplified .clang-format with DisableFormat: true

### DIFF
--- a/src/common/dep/.clang-format
+++ b/src/common/dep/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/7zip/7za/c/.clang-format
+++ b/src/plugins/7zip/7za/c/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/7zip/7za/cpp/.clang-format
+++ b/src/plugins/7zip/7za/cpp/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/automation/generated/.clang-format
+++ b/src/plugins/automation/generated/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/checksum/tomcrypt/.clang-format
+++ b/src/plugins/checksum/tomcrypt/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/ftp/openssl/.clang-format
+++ b/src/plugins/ftp/openssl/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/ieviewer/cmark-gfm/.clang-format
+++ b/src/plugins/ieviewer/cmark-gfm/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/mmviewer/ogg/vorbis/.clang-format
+++ b/src/plugins/mmviewer/ogg/vorbis/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/mmviewer/wma/wmsdk/.clang-format
+++ b/src/plugins/mmviewer/wma/wmsdk/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/pictview/exif/libexif/.clang-format
+++ b/src/plugins/pictview/exif/libexif/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/pictview/exif/libjpeg/.clang-format
+++ b/src/plugins/pictview/exif/libjpeg/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/pictview/twain/.clang-format
+++ b/src/plugins/pictview/twain/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/portables/wtl/.clang-format
+++ b/src/plugins/portables/wtl/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/tar/bzip/.clang-format
+++ b/src/plugins/tar/bzip/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/unchm/chmlib/.clang-format
+++ b/src/plugins/unchm/chmlib/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/core/.clang-format
+++ b/src/plugins/winscp/core/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/forms/.clang-format
+++ b/src/plugins/winscp/forms/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/packages/.clang-format
+++ b/src/plugins/winscp/packages/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/putty/.clang-format
+++ b/src/plugins/winscp/putty/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/resource/.clang-format
+++ b/src/plugins/winscp/resource/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/winscp/windows/.clang-format
+++ b/src/plugins/winscp/windows/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/plugins/wmobile/rapi/.clang-format
+++ b/src/plugins/wmobile/rapi/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/sfx7zip/7zip/.clang-format
+++ b/src/sfx7zip/7zip/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/sfx7zip/branch/.clang-format
+++ b/src/sfx7zip/branch/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false

--- a/src/sfx7zip/lzma/.clang-format
+++ b/src/sfx7zip/lzma/.clang-format
@@ -1,2 +1,1 @@
 DisableFormat: true
-SortIncludes: false


### PR DESCRIPTION
SortIncludes workaround is no longer needed, see https://stackoverflow.com/questions/55833838/clang-format-still-formatting-with-disableformat-true