### PR TITLE
GitHub Comments Guard Workflow: run in both 'strict' and 'ignore-whitespace' mode

### DIFF
--- a/src/zip.h
+++ b/src/zip.h
@@ -16,10 +16,9 @@ class CProgressBar;
 class CStaticText;
 
 class CZIPUnpackProgress : public CCommonDialog
-
-  {
+{
 protected:
-    const char* RemapNameFrom; // TESTGUARD
+    const char* RemapNameFrom; // mapovani jmen z tmp-adresare
     const char* RemapNameTo;   // na jmeno archivu, ze ktereho vybalujeme
     BOOL FileProgress;         // pro variantu s jednim progressem: TRUE="File:", FALSE="Total:"
 


### PR DESCRIPTION
This pull request enhances the PR comments guard workflow by introducing a matrix strategy to run validation in both strict and relaxed (ignore-whitespace) modes, improving flexibility and reliability of comment-only change enforcement. The changes also refactor the PowerShell script to support these modes and clarify job logs.

**Workflow configuration improvements:**

* Added a matrix strategy to the `comment-only` job in `.github/workflows/pr-comments-guard.yml` to run in both `strict` and `ignore-whitespace` modes, and updated the job name to include the active mode for clearer logs.

**Script and environment updates:**

* Passed the selected mode as an environment variable (`COMMENT_GUARD_MODE`) to the PowerShell script and set a default to `strict` if not specified.
* Refactored the diff command in the script to include `--ignore-all-space` when running in `ignore-whitespace` mode, allowing the workflow to ignore whitespace-only changes when desired.