### PR TITLE
[tanslation] Fix src/plugins/ftp/ctrlcon4.cpp comments

### DIFF
--- a/src/plugins/ftp/ctrlcon4.cpp
+++ b/src/plugins/ftp/ctrlcon4.cpp
@@ -47,7 +47,7 @@ BOOL CControlConnectionSocket::SetCurrentTransferMode(HWND parent, BOOL asciiMod
                            &ftpReplyCode, ftpReplyBuf, ftpReplyBufSize, FALSE, FALSE, TRUE,
                            canRetry, retryMsg, retryMsgBufSize, NULL))
         {
-            if (FTP_DIGIT_1(ftpReplyCode) == FTP_D1_SUCCESS) // success is returned (should be 200)
+            if (FTP_DIGIT_1(ftpReplyCode) == FTP_D1_SUCCESS) // a success reply was received (it should be 200)
             {
                 HANDLES(EnterCriticalSection(&SocketCritSect));
                 leaveSect = TRUE;
@@ -60,7 +60,7 @@ BOOL CControlConnectionSocket::SetCurrentTransferMode(HWND parent, BOOL asciiMod
             ret = FALSE; // error -> connection closed
     }
 
-    if (leaveSect) // the requested transfer mode is already set successfully
+    if (leaveSect) // the requested transfer mode has already been set successfully
     {
         if (success != NULL)
             *success = TRUE;
@@ -234,7 +234,7 @@ BOOL CSendCmdUserIfaceForListAndDownload::CanFinishSending(int replyCode, BOOL* 
 
 void CSendCmdUserIfaceForListAndDownload::BeforeWaitingForFinish(int replyCode, BOOL* useTimeout)
 {
-    if (FTP_DIGIT_1(replyCode) != FTP_D1_SUCCESS) // LIST does not return success - it may not close
+    if (FTP_DIGIT_1(replyCode) != FTP_D1_SUCCESS) // LIST did not return success, so the data connection may not close at all
     {                                             // the data connection (e.g., WarFTPD) - wait for the remaining data, but preferably with a timeout
         *useTimeout = TRUE;
         //    DataConnection->CloseSocketEx(NULL);   // to have something to show in the Show Raw Listing panel we must fetch the remaining data
@@ -269,8 +269,8 @@ void CSendCmdUserIfaceForListAndDownload::HandleESCWhenWaitingForFinish(HWND par
     if (esc)
     {
         // WaitWnd.SetText(LoadStr(IDS_LISTWNDABORTINGCOMMAND)); // unnecessary, the window will not be shown again
-        // while the user decides how to respond to the abort, the data connection may finish (that is why
-        // the dialog says "listing may be incomplete") - then it makes sense to ignore the abort
+                // while the user decides whether to abort, the data connection may finish (hence the
+                // "listing may be incomplete" message); then it makes sense to ignore the abort
         if (DataConnection->IsTransfering(NULL) || DataConnection->IsFlushingDataToDisk())
         {
             DataConnection->CancelConnectionAndFlushing(); // close the "data connection"; the system attempts a "graceful" shutdown (we will not learn the result)
@@ -392,7 +392,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                     DWORD ip;
                     unsigned short port;
                     if (FTP_DIGIT_1(ftpReplyCode) == FTP_D1_SUCCESS &&      // success (should be 227)
-                        FTPGetIPAndPortFromReply(replyBuf, -1, &ip, &port)) // managed to obtain IP and port
+                        FTPGetIPAndPortFromReply(replyBuf, -1, &ip, &port)) // successfully obtained the IP address and port
                     {
                         dataConnection->SetPassive(ip, port, logUID);
                         dataConnection->PassiveConnect(NULL); // the first attempt; the result does not matter (it is checked later)
@@ -410,7 +410,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                 {
                     ok = FALSE;
                     if (canRetry)
-                        retryMsgAux = retryMsgBuf; // "retry" is allowed; go to the next reconnect
+                        retryMsgAux = retryMsgBuf; // "retry" is allowed; move on to the next reconnect attempt
                     else
                     {
                         *fatalError = TRUE; // fatal error
@@ -438,7 +438,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                     {                                            // error -> connection closed
                         ok = FALSE;
                         if (canRetry)
-                            retryMsgAux = retryMsgBuf; // "retry" is allowed; go to the next reconnect
+                            retryMsgAux = retryMsgBuf; // "retry" is allowed; proceed to the next reconnect attempt
                         else
                         {
                             *fatalError = TRUE; // fatal error
@@ -446,11 +446,11 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                         }
                     }
                 }
-                else // failed to open the "listen" socket for receiving the data connection from the server ->
+                else // failed to open the "listen" socket for receiving the data connection from the server, so treat it as a closed connection
                 {    // connection closed (so that the standard Retry can be used)
                     ok = FALSE;
                     if (canRetry)
-                        retryMsgAux = retryMsgBuf; // "retry" is allowed; go to the next reconnect
+                        retryMsgAux = retryMsgBuf; // "retry" is allowed; move on to the next reconnect attempt
                     else
                     {
                         *fatalError = TRUE; // fatal error
@@ -459,14 +459,14 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                 }
             }
 
-            if (ok) // if we are still connected, switch the transfer mode to ASCII (ignore success)
+            if (ok) // if we are still connected, switch the transfer mode to ASCII (ignore the result)
             {
                 ok = SetCurrentTransferMode(parent, TRUE, NULL, NULL, 0, forceRefresh, &canRetry,
                                             retryMsgBuf, 300);
                 if (!ok) // error -> connection closed
                 {
                     if (canRetry)
-                        retryMsgAux = retryMsgBuf; // "retry" is allowed; go to the next reconnect
+                        retryMsgAux = retryMsgBuf; // "retry" is allowed; proceed to the next reconnect attempt
                     else
                     {
                         *fatalError = TRUE; // fatal error
@@ -513,8 +513,8 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
 
                             *pathListingIsBroken = TRUE; // to make it clear that the returned listing is not OK (VxWorks: while listing it can report "error reading entry: 16" and return "550 no files found or ...")
                         }
-                        // VMS returns 550 for an empty directory: we cannot leave the path and the listing can easily
-                        // be considered OK (it can even be cached - it was not interrupted and the server
+                        // VMS returns 550 for an empty directory: we cannot leave this path, and the listing can safely
+                        // be treated as OK (it can even be cached - it was not interrupted, and the server
                         // will most likely not return a different listing)
                         // ret = FALSE;   // stop - the path cannot be listed -> a path change is required
 
@@ -562,7 +562,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                                     if (FTP_DIGIT_1(ftpReplyCode) == FTP_D1_SUCCESS ||
                                         FTP_DIGIT_2(ftpReplyCode) != FTP_D2_CONNECTION ||
                                         noDataTrTimeout || sslErrorOccured != SSLCONERR_NOERROR)
-                                    { // if we do not have a description of the network error from the server, we settle for the system description
+                                    { // if we do not have a network error description from the server, use the system description
                                         systErr = TRUE;
                                         if (!trModeHint)
                                             trModeHint = err == WSAETIMEDOUT || sslErrorOccured != SSLCONERR_NOERROR;
@@ -610,7 +610,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                     if (userIface.WasAborted()) // the user aborted the listing, which terminated the connection (for example on sunsolve.sun.com (Sun Unix) or ftp.chg.ru) - finish with an error (an incomplete listing)
                     {
                         ok = FALSE;   // do not display the "list can be incomplete" message; the user was warned during abort
-                        if (canRetry) // take over the message for the message box that announces the connection interruption
+                        if (canRetry) // take over the message for the message box that reports the connection interruption
                         {
                             HANDLES(EnterCriticalSection(&SocketCritSect));
                             if (ConnectionLostMsg != NULL)
@@ -665,7 +665,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                                                       retryMsgBuf, 300))
                             {
                                 if (strcmp(cmdBuf, path) == 0) // we have the desired working directory on the server
-                                                               // (assumption: the server returns the same working-path string)
+// (assumption: the server always returns the same working-directory string)
                                 {
                                     pathError = FALSE;
                                     ok = TRUE; // successful reconnect; list again
@@ -709,7 +709,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                         }
                     }
                 }
-                else // reconnect failed - finish with an error (an incomplete listing)
+                else // reconnect failed; end with an error (incomplete listing)
                 {
                     SalamanderGeneral->SalMessageBox(parent, LoadStr(IDS_UNABLETOREADLIST),
                                                      LoadStr(IDS_FTPERRORTITLE),
@@ -745,7 +745,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                                              MB_OK | MB_ICONEXCLAMATION);
         }
 
-        *pathListingIsIncomplete = !ok; // TRUE in case of a failure/interruption/connection error
+        *pathListingIsIncomplete = !ok; // TRUE on connection failure, interruption, or error
         *pathListingMayBeOutdated = FALSE;
 
         // store the date when the listing was created
@@ -787,7 +787,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                                                     *pathListingStartTime);
             }
         }
-        else // failure/interruption/connection error = return at least what we have (the user already knows that "list can be incomplete")
+        else // on failure, interruption, or a connection error, return at least what we have (the user already knows that "list can be incomplete")
         {
             if (*allocatedListing != NULL)
             { // the buffer does not contain a complete listing -> trim it at the last line ending (CRLF or LF) to make it easier to work with
@@ -795,7 +795,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
                 char* s = start + *allocatedListingLen;
                 while (s > start && *(s - 1) != '\n')
                     s--;
-                if (s < start + *allocatedListingLen) // there is a place to write the null terminator (just for easier debugging)
+                if (s < start + *allocatedListingLen) // there is room to write the null terminator (just for easier debugging)
                     *s = 0;                           // either at the start of the buffer or after the last LF
                 *allocatedListingLen = (int)(s - start);
             }
@@ -803,7 +803,7 @@ BOOL CControlConnectionSocket::ListWorkingPath(HWND parent, const char* path, ch
     }
     if (dataConnection != NULL) // release and possibly close the "data connection"
     {
-        if (dataConnection->IsConnected())       // close the "data connection"; the system attempts a "graceful"
+        if (dataConnection->IsConnected())       // close the "data connection"; the system will attempt a graceful shutdown
             dataConnection->CloseSocketEx(NULL); // shutdown (we will not learn the result)
         DeleteSocket(dataConnection);
     }
@@ -1056,8 +1056,8 @@ void CControlConnectionSocket::SetupNextKeepAliveTimer()
 #endif
 
     if (!KeepAliveCmdAllBytesWritten)
-    { // this should never happen because the server's reply arrives only after the complete command is written
-        // of the command (the command is always written at once; it is just a few bytes)
+    { // this should never happen because the server's reply arrives only after the complete
+        // command has been written (the command is always written at once; it is only a few bytes)
         TRACE_E("Unexpected situation in CControlConnectionSocket::SetupNextKeepAliveTimer(): KeepAliveCmdAllBytesWritten==FALSE!");
         KeepAliveCmdAllBytesWritten = TRUE;
     }
@@ -1081,7 +1081,7 @@ void CControlConnectionSocket::SetupNextKeepAliveTimer()
         }
         else
         {
-            KeepAliveMode = kamNone;                                         // we should no longer perform keep-alive (there is no point in protecting the connection anymore)
+            KeepAliveMode = kamNone;                                         // do not perform keep-alive anymore (protecting the connection is no longer useful)
             Logs.LogMessage(LogUID, LoadStr(IDS_LOGMSGKASTOPPED), -1, TRUE); // notify the user that the keep-alive mode has stopped
         }
     }
@@ -1133,7 +1133,7 @@ void CControlConnectionSocket::ReleaseKeepAlive()
     // if the "data connection" is open, close it; it certainly will not be needed now
     if (closeDataCon != NULL)
     {
-        if (closeDataCon->IsConnected())       // close the "data connection"; the system attempts a "graceful"
+        if (closeDataCon->IsConnected())       // close the "data connection"; the system will attempt a graceful shutdown
             closeDataCon->CloseSocketEx(NULL); // shutdown (we will not learn the result)
         DeleteSocket(closeDataCon);            // release the "data connection" through a SocketsThread method call
     }
@@ -1236,7 +1236,7 @@ void CControlConnectionSocket::ReceiveTimer(DWORD id, void* param)
                     BOOL listenError;
                     if (!keepAliveDataConAux->OpenForListeningWithProxy(localIP, localPort, &listenError, &error))
                     { // failed to open the "listen" socket for receiving the data connection from
-                        // the server (a local operation, this should almost never happen) and it can also be
+                        // the server (a local operation, so this should almost never happen); it can also be
                         // an error when connecting to the proxy server
                         Logs.LogMessage(logUID, LoadStr(listenError ? IDS_LOGMSGOPENACTDATACONERROR : IDS_LOGMSGOPENACTDATACONERROR2), -1, TRUE);
                     }
@@ -1380,7 +1380,7 @@ CListingCacheItem::CListingCacheItem(const char* host, unsigned short port, cons
     if (CachedListing != NULL && cachedListing != NULL)
     {
         memcpy(CachedListing, cachedListing, cachedListingLen);
-        CachedListing[cachedListingLen] = 0; // once it is allocated there, make it null-terminated for debugging purposes
+        CachedListing[cachedListingLen] = 0; // If it is already allocated, make it null-terminated for debugging purposes
     }
     else
         err = TRUE;
@@ -1496,7 +1496,7 @@ BOOL CListingCache::GetPathListing(const char* host, unsigned short port, const 
         if (*cachedListing != NULL)
         {
             memcpy(*cachedListing, item->CachedListing, item->CachedListingLen);
-            (*cachedListing)[item->CachedListingLen] = 0; // once it is allocated there, make it null-terminated for debugging purposes
+            (*cachedListing)[item->CachedListingLen] = 0; // since it is already allocated, make it null-terminated for debugging purposes
             *cachedListingLen = item->CachedListingLen;
         }
         else
@@ -1620,7 +1620,7 @@ void CListingCache::AcceptChangeOnPathNotification(const char* userPart, BOOL in
 
     HANDLES(EnterCriticalSection(&CacheCritSect));
 
-    int delIndex = 0; // variables for deleting in blocks (shifting the array is O(N*N), so we optimize)
+    int delIndex = 0; // variables for block deletion (shifting the array is O(N*N), so we optimize)
     int delCount = 0;
     int i;
     for (i = 0; i < Cache.Count; i++)


### PR DESCRIPTION
## Summary
- Fix translated comments in src/plugins/ftp/ctrlcon4.cpp against current main
- Keep the delivery scoped to comment-only changes validated by comment guard
- Carry reviewed Czech-origin context into inline PR comments with rationale notes

Model: OpenAI GPT-5.4

## Verification
- node --experimental-strip-types src/sequential-review.ts with full prompt logging, auto provider routing, and Copilot high reasoning
- node --experimental-strip-types src/cli.ts guard on the upstream artifact
- node --experimental-strip-types src/cli.ts apply --mode apply into the clean delivery clone
- node --experimental-strip-types src/cli.ts guard on the clean delivery clone
- git diff --check for src/plugins/ftp/ctrlcon4.cpp

## Telemetry
- Codex: 21 requests, 319746 tokens
- Copilot: 4 requests, 134776 tokens, 8 request units billed
- Total: 25 requests, 454522 tokens
