### PR TITLE
[tanslation] Fix src/plugins/ftp/dialogs4.cpp comments

### DIFF
--- a/src/plugins/ftp/dialogs4.cpp
+++ b/src/plugins/ftp/dialogs4.cpp
@@ -179,8 +179,8 @@ void CEditSrvTypeColumnDlg::Transfer(CTransferInfo& ti)
         }
         else
         {
-            // if the user has custom text, pull it out, otherwise use indexes from the last selection
-            // in the combo (finding the index by looking up the string in the list is impossible, duplicate strings may occur)
+            // if the user has custom text, retrieve it; otherwise use the indexes from the last selection
+            // in the combo box (finding the index by looking up the string in the list is impossible because duplicate strings may occur)
             if (LastUsedIndexForName == -1)
                 GetWindowText(comboName, bufName, STC_NAME_MAX_SIZE);
             if (LastUsedIndexForDescr == -1)
@@ -957,7 +957,7 @@ void CSrvTypeTestParserDlg::LoadTextFromFile()
 
             HANDLES(CloseHandle(file));
             SetCursor(oldCur);
-            if (err != NO_ERROR) // print the error
+            if (err != NO_ERROR) // display the error
             {
                 sprintf(buf, LoadStr(IDS_SRVTYPE_READRAWLISTERR), SalamanderGeneral->GetErrorText(err));
                 SalamanderGeneral->SalMessageBox(HWindow, buf, LoadStr(IDS_FTPERRORTITLE),


### PR DESCRIPTION
## Summary
- Refines approved English comment translations in src/plugins/ftp/dialogs4.cpp.
- Preserves C++ behavior; only comments were changed.
- Clarifies combo-box custom text handling and file-load error display comments.
- Manually corrected one generated comment indentation issue before delivery.

Model: OpenAI GPT-5.4

## Verification
- Ran the full prompt-logging review pipeline with AST grounding and Copilot high reasoning for deep batches.
- Applied resolved review output to a fresh delivery branch based on OpenSalamander/salamander main.
- Ran git diff --check for src/plugins/ftp/dialogs4.cpp.
- Re-ran comment guard against the delivery checkout; strict and ignore-whitespace modes passed.
- Inspected the final diff and confirmed only comment text changed.

## Provider telemetry
- Codex CLI routed work: 7 requests, 49042 tokens.
- Copilot routed work: 2 requests, 64060 tokens, 4 Copilot request units billed.
- Total: 9 requests, 113102 tokens.
- Note: Copilot billing is request-unit based, not token based.
