### PR TITLE
[tanslation] Fix src/plugins/ftp/dialogs8.cpp comments

### DIFF
--- a/src/plugins/ftp/dialogs8.cpp
+++ b/src/plugins/ftp/dialogs8.cpp
@@ -297,7 +297,7 @@ CServersListbox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             break;
         }
         }
-        break; // let the keys pass through, the listbox should not handle them, no problem
+        break; // let the keys pass through; the listbox should not handle them
     }
 
     case WM_LBUTTONDBLCLK:
@@ -977,7 +977,7 @@ CRenameDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                             checkboxName[0] != 0 ? checkboxName : LoadStr(IDS_QUICKCONNECT));
                     SetDlgItemText(HWindow, IDC_COPYFOCUSEDSRV, buf);
                 }
-                else // new server type + empty list = necessary to hide/disable the "copy from" checkbox
+                else // new server type + empty list = need to hide/disable the "copy from" checkbox
                 {
                     ShowWindow(GetDlgItem(HWindow, IDC_COPYFOCUSEDSRV), SW_HIDE);
                 }
@@ -1193,7 +1193,7 @@ void CConfigPageAdvanced::Validate(CTransferInfo& ti)
     int num;
     int arr[] = {IDE_SRVREPLIESTIMEOUT, IDE_DELAYBETWCONRETR, IDE_CONNECTRETRIES,
                  IDE_NODATATRTIMEOUT, IDE_RESUMEMINFILESIZE, IDE_RESUMEOVERLAP, -1};
-    BOOL gzthzero[] = {TRUE, FALSE, FALSE, TRUE, TRUE, FALSE, -1}; // testing > 0 (TRUE) or >= 0 (FALSE)
+    BOOL gzthzero[] = {TRUE, FALSE, FALSE, TRUE, TRUE, FALSE, -1}; // test > 0 (TRUE) or >= 0 (FALSE)
     int i;
     for (i = 0; arr[i] != -1; i++)
     {


### PR DESCRIPTION
## Summary
- Refines approved English comment translations in src/plugins/ftp/dialogs8.cpp.
- Preserves C++ behavior; only comments were changed.
- Clarifies listbox key passthrough behavior, the empty-list copy-from checkbox path, and timeout validation comparison comments.

Model: OpenAI GPT-5.4

## Verification
- Ran the full prompt-logging review pipeline with AST grounding and Copilot high reasoning for deep batches.
- Applied resolved review output to a fresh delivery branch based on OpenSalamander/salamander main.
- Ran git diff --check for src/plugins/ftp/dialogs8.cpp.
- Re-ran comment guard against the delivery checkout; strict and ignore-whitespace modes passed.
- Inspected the final diff and confirmed only comment text changed.

## Provider telemetry
- Codex CLI routed work: 13 requests, 41515 tokens.
- Copilot routed work: 2 requests, 52236 tokens, 4 Copilot request units billed.
- Total: 15 requests, 93751 tokens.
- Note: Copilot billing is request-unit based, not token based.
