### PR TITLE
[tanslation] Fix src/plugins/ftp/fs1.cpp comments

### DIFF
--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -4,7 +4,7 @@
 
 #include "precomp.h"
 
-// FS-name assigned by Salamander after loading the plug-in
+// FS-name assigned by Salamander after loading the plugin
 char AssignedFSName[MAX_PATH] = "";
 int AssignedFSNameLen = 0;
 
@@ -305,7 +305,7 @@ void CPluginInterfaceForFS::CloseFS(CPluginFSInterfaceAbstract* fs)
                 break;
             }
         }
-        if (!found) // "i == FTPConnections.Count" is not enough (there is Delete(i))
+        if (!found) // "i == FTPConnections.Count" is not enough because Delete(i) is called
             TRACE_E("Unexpected situation in CPluginInterfaceForFS::CloseFS(): FS not found in FTPConnections.");
 
         delete ((CPluginFSInterface*)fs); // to call the correct destructor
@@ -691,7 +691,7 @@ void CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* p
                 fs->MakeUserPart(newUserPart, FTP_USERPART_SIZE, newPath);
                 if (SalamanderGeneral->ChangePanelPathToPluginFS(panel, pluginFSName, newUserPart))
                 {
-                    fs->TopIndexMem.Push(type, backupPath, topIndex); // remember the top-index for the return
+                    fs->TopIndexMem.Push(type, backupPath, topIndex); // remember the top index for returning
                 }
             }
         }
@@ -756,7 +756,7 @@ void CTopIndexMem::Push(CFTPServerPathType type, const char* path, int topIndex)
         ok = FTPIsTheSameServerPath(type, testPath, Path);
     }
 
-    if (ok) // it follows -> remember the next top-index
+    if (ok) // continues from the current path -> remember the next top-index
     {
         if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // we need to discard the first top-index from memory
         {
@@ -788,13 +788,13 @@ BOOL CTopIndexMem::FindAndPop(CFTPServerPathType type, const char* path, int& to
             topIndex = TopIndexes[--TopIndexesCount];
             return TRUE;
         }
-        else // we no longer have this value (it was not stored or low memory removed it)
+        else // we no longer have this value (it was not stored, or it was discarded due to low memory)
         {
             Clear();
             return FALSE;
         }
     }
-    else // query for another path -> clear the memory, a long jump occurred
+    else // query for a different path -> clear memory, a long jump occurred
     {
         Clear();
         return FALSE;


### PR DESCRIPTION
## Summary
- Refines approved English comment translations in src/plugins/ftp/fs1.cpp.
- Preserves C++ behavior; only comments were changed.
- Clarifies assigned filesystem naming, FTP connection removal checks, remembered top-index behavior, path continuation, low-memory discard handling, and long-jump memory clearing.

Model: OpenAI GPT-5.4

## Verification
- Ran the full prompt-logging review pipeline with AST grounding and Copilot high reasoning for deep batches.
- Applied resolved review output to a fresh delivery branch based on OpenSalamander/salamander main.
- Ran git diff --check for src/plugins/ftp/fs1.cpp.
- Re-ran comment guard against the delivery checkout; strict and ignore-whitespace modes passed.
- Inspected the final diff and confirmed only comment text changed.

## Provider telemetry
- Codex CLI routed work: 8 requests, 39359 tokens.
- Copilot routed work: 2 requests, 59954 tokens, 4 Copilot request units billed.
- Total: 10 requests, 99313 tokens.
- Note: Copilot billing is request-unit based, not token based.
