### PR TITLE
[tanslation] Fix src/plugins/ftp/fs2.cpp comments

### DIFF
--- a/src/plugins/ftp/fs2.cpp
+++ b/src/plugins/ftp/fs2.cpp
@@ -7,7 +7,7 @@
 int CSimpleListPluginDataInterface::ListingColumnWidth = 0;      // LO/HI-WORD: left/right panel: width of the Raw Listing column
 int CSimpleListPluginDataInterface::ListingColumnFixedWidth = 0; // LO/HI-WORD: left/right panel: does the Raw Listing column have a fixed width?
 
-// Global variables where I store pointers to Salamander's global variables
+// Global variables that store pointers to Salamander's global variables
 const CFileData** TransferFileData = NULL;
 int* TransferIsDir = NULL;
 char* TransferBuffer = NULL;
@@ -385,7 +385,7 @@ BOOL CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fs
     if (lastErrorState == fesFatal)
     {
         TargetPanelPath[0] = 0; // the connection failed, no path change in the target panel
-        return FALSE;           // fatal error, stop
+        return FALSE;           // fatal error, abort
     }
 
     // Treat a hard refresh as distrust of the path; drop from the disk cache all files
@@ -411,7 +411,7 @@ BOOL CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fs
         TotalConnectAttemptNum = 1; // opening the connection = first attempt to open it
         InformAboutUnknownSrvType = TRUE;
 
-        BOOL parsedPath = TRUE; // TRUE = path obtained from the user part; need to decide whether to trim '/' or '\\' at the start
+        BOOL parsedPath = TRUE; // TRUE = path obtained from the user-part; need to determine whether to trim a leading '/' or '\\'
         ControlConnection = new CControlConnectionSocket;
         if (ControlConnection == NULL || !ControlConnection->IsGood())
         {
@@ -1168,7 +1168,7 @@ BOOL CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
                             {
                                 serverType->CompiledAutodetCond = CompileAutodetectCond(HandleNULLStr(serverType->AutodetectCond),
                                                                                         NULL, NULL, NULL, NULL, 0);
-                                if (serverType->CompiledAutodetCond == NULL) // can only fail due to lack of memory
+                                if (serverType->CompiledAutodetCond == NULL) // this can only be a low-memory error
                                 {
                                     err = TRUE;
                                     break;
@@ -1205,8 +1205,8 @@ BOOL CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
                         serverType = serverTypeList->At(i);
                         if (!serverType->ParserAlreadyTested) // only if we have not tried it yet
                         {
-                            // serverType is selected, try its parser on the listing
-                            // serverType->ParserAlreadyTested = TRUE;  // unnecessary, not used afterwards
+                            // serverType has been selected; try its parser on the listing
+                            // serverType->ParserAlreadyTested = TRUE;  // unnecessary, not used later
                             if (ParseListing(dir, &pluginData, serverType, &err, isVMS, NULL, FALSE, NULL, NULL) || err)
                             {
                                 if (!err)
@@ -1260,7 +1260,7 @@ BOOL CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
                 pluginData = &SimpleListPluginDataInterface; // ATTENTION: the change may also affect obtaining the data interface in CPluginFSInterface::ChangeAttributes!
                 dir->SetValidData(VALID_DATA_NONE);
                 dir->SetFlags(SALDIRFLAG_CASESENSITIVE | SALDIRFLAG_IGNOREDUPDIRS); // probably unnecessary, but everything is treated as case-sensitive so this should be safe
-                if (!PathListingIsBroken &&                                         // if the listing is not OK, rather use an empty listing
+                if (!PathListingIsBroken &&                                         // if the listing is not OK, use an empty listing instead
                     PathListingLen > 0)
                 {
                     char* beg = PathListing;


### PR DESCRIPTION
## Summary
- Refines English comments in `src/plugins/ftp/fs2.cpp` to better match the original Czech intent.
- Clarifies pointer storage, fatal path-change abort behavior, user-part path trimming, low-memory parser-condition failure, parser selection, unused parser-test state, and broken-listing fallback wording.
- Changes are comment-only; no executable code, identifiers, control flow, declarations, or formatting-sensitive structure were changed.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, AST grounding through clang, `--review-provider auto`, and Copilot SDK `--copilot-reasoning high`.
- 181 comment units, 181 review results, 181 resolved results, and 181 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/fs2.cpp` in strict and ignore-whitespace modes with 0 violations.
- `git diff --check -- src/plugins/ftp/fs2.cpp` passed.

## Telemetry
- Total: 18 provider calls, 177626 estimated tokens.
- Codex-family: 15 calls, 86235 estimated tokens across codex, codex-audit, and codex-resolve.
- Copilot SDK: 3 calls, 91391 estimated tokens, 50859 input tokens, 6484 output tokens, 6 copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
