### PR TITLE
[tanslation] Fix src/plugins/ftp/ftp3.cpp comments

### DIFF
--- a/src/plugins/ftp/ftp3.cpp
+++ b/src/plugins/ftp/ftp3.cpp
@@ -95,7 +95,7 @@ void CServerTypeList::Load(HWND parent, HKEY regKey, CSalamanderRegistryAbstract
                 TRACE_E(LOW_MEMORY);
                 break;
             }
-            if (!item->Load(parent, subKey, registry)) // loading failed, we ignore this item
+            if (!item->Load(parent, subKey, registry)) // loading failed, ignore this item
             {
                 delete item;
             }
@@ -318,7 +318,7 @@ void CFTPServerList::CheckProxyServersUID(CFTPProxyServerList& ftpProxyServerLis
         if (s->ProxyServerUID != -1 && s->ProxyServerUID != -2 &&
             !ftpProxyServerList.IsValidUID(s->ProxyServerUID))
         {
-            s->ProxyServerUID = -2; // validate the UID by switching to "default"
+            s->ProxyServerUID = -2; // make the UID valid by switching to "default"
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refines two English comments in `src/plugins/ftp/ftp3.cpp` to better match the original Czech intent.
- Clarifies ignoring a failed server-type load and making an invalid proxy-server UID valid by switching to the default setting.
- Changes are comment-only; no executable code, identifiers, declarations, control flow, persisted formats, or data layout were changed.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, AST grounding through clang, `--review-provider auto`, and Copilot SDK `--copilot-reasoning high`.
- 240 comment units, 240 review results, 240 resolved results, and 240 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/ftp3.cpp` in strict and ignore-whitespace modes with 0 violations and no preprocessing failures.
- `git diff --check -- src/plugins/ftp/ftp3.cpp` passed.

## Telemetry
- Total: 12 provider calls, 129947 estimated tokens.
- Codex-family: 10 calls, 74897 estimated tokens across codex and codex-resolve.
- Copilot SDK: 2 calls, 55050 estimated tokens, 31777 input tokens, 1769 output tokens, 4 copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
