### PR TITLE
[tanslation] Fix src/plugins/ftp/menu.cpp comments

### DIFF
--- a/src/plugins/ftp/menu.cpp
+++ b/src/plugins/ftp/menu.cpp
@@ -22,7 +22,7 @@ CPluginInterfaceForMenuExt::GetMenuItemState(int id, DWORD eventMask)
     case FTPCMD_TRMODEBINARY:
     {
         CPluginFSInterfaceAbstract* fs = SalamanderGeneral->GetPanelPluginFS(PANEL_SOURCE);
-        if (fs != NULL) // it is our FS; otherwise it would be NULL
+        if (fs != NULL) // our FS; otherwise it would be NULL
         {
             return ((CPluginFSInterface*)fs)->GetTransferModeCmdState(id);
         }


### PR DESCRIPTION
## Summary
- Refines one translated inline comment in src/plugins/ftp/menu.cpp.
- Keeps the change comment-only; no executable code was modified.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with --prompt-log-mode full, --copilot-event-log full, AST grounding through clang, --review-provider auto, and Copilot SDK --copilot-reasoning high.
- 54 comment units, 54 review results, 54 resolved results, and 54 apply results.
- Branch-target comment guard passed for src/plugins/ftp/menu.cpp in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- The approved draft had to be materialized into the delivery checkout explicitly after apply reported changes_target=true but left the worktree clean; guard was rerun against the actual worktree afterwards.
- git diff --check -- src/plugins/ftp/menu.cpp passed.

## Telemetry
- Total: 5 provider calls, 101616 estimated tokens.
- Codex-family: 2 calls, 10121 estimated tokens.
- Copilot SDK: 3 calls, 91495 estimated tokens, 51189 input tokens, 4978 output tokens, 6 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
