### PR TITLE
[tanslation] Fix src/plugins/ftp/ssl.h comments

### DIFF
--- a/src/plugins/ftp/ssl.h
+++ b/src/plugins/ftp/ssl.h
@@ -96,7 +96,7 @@ typedef const char* (*TX509_verify_cert_error_string)(long n);
 typedef X509* (*TSSL_get_peer_certificate)(const SSL* SSL);
 typedef STACK_OF(X509) * (*TSSL_get_peer_cert_chain)(const SSL* s);
 typedef STACK_OF(SSL_COMP) * (*TSSL_COMP_get_compression_methods)(void);
-typedef SSL_SESSION* (*TSSL_get1_session)(SSL* ssl); /* obtain a reference count */
+typedef SSL_SESSION* (*TSSL_get1_session)(SSL* ssl); /* obtain a session and increment its reference count */
 typedef void (*TSSL_SESSION_free)(SSL_SESSION* ses);
 typedef long (*TSSL_ctrl)(SSL* ssl, int cmd, long larg, void* parg);
 typedef int (*TSSL_set_session)(SSL* to, SSL_SESSION* session);


### PR DESCRIPTION
## Summary
- Refines the translated comment in `src/plugins/ftp/ssl.h`.
- Keeps the change comment-only; no executable code was modified.
- Clarifies that `SSL_get1_session` obtains a session and increments its reference count.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, and Copilot SDK `--copilot-reasoning high`.
- 22 comment units, 22 review results, 22 resolved results, and 22 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/ssl.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/ftp/ssl.h` passed.
- The initial apply stage wrote the approved draft but did not materialize the delivery checkout, so the approved draft was copied into the branch explicitly and guard was rerun against the real checkout.

## Telemetry
- Total: 3 provider calls, 33401 estimated tokens.
- Codex-family: 2 calls, 2620 estimated tokens across codex and codex-resolve.
- Copilot SDK: 1 call, 30781 estimated tokens, 16788 input tokens, 2089 output tokens, 2 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
