### PR TITLE
[tanslation] Fix src/plugins/ftp/ctrlcon3.cpp comments

### DIFF
--- a/src/plugins/ftp/ctrlcon3.cpp
+++ b/src/plugins/ftp/ctrlcon3.cpp
@@ -64,7 +64,7 @@ void CSendCmdUserIfaceWaitWnd::Init(HWND parent, const char* logCmd, const char*
 {
     char buf[500];
     char errBuf[300];
-    if (waitWndText == NULL) // standard text of the wait window
+    if (waitWndText == NULL) // use the standard wait window text
     {
         lstrcpyn(errBuf, logCmd, 300); // trim the CRLF from the command
         char* s = errBuf + strlen(errBuf);
@@ -153,7 +153,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
     CSetWaitCursorWindow* winParent = NULL;
     if (parentIsEnabled) // we cannot leave the parent enabled (the wait window is not modal)
     {
-        // store the focus from 'parent' (if the focus is not from 'parent', store NULL)
+        // save the current focus in 'parent' (if focus is not in 'parent', store NULL)
         focusedWnd = GetFocus();
         HWND hwnd = focusedWnd;
         while (hwnd != NULL && hwnd != parent)
@@ -229,7 +229,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
 
             if (aborting && auxCanSendOOBData)
             {
-                // notify the server about the abort (see RFC 959 - sending the ABOR command)
+                // notify the server of the abort (see RFC 959: sending the ABOR command)
                 HANDLES(EnterCriticalSection(&SocketCritSect));
                 if (Socket != INVALID_SOCKET &&
                     BytesToWriteCount == 0) // "always true" (all data should have been sent)
@@ -319,11 +319,11 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                     {
                         if (userIface->HandleESC(parent, state == sfcsSendCommand, allowCmdAbort))
                         {                                                  // cancel
-                            if (allowCmdAbort && state == sfcsSendCommand) // cancel for the command -> start aborting the command
+                            if (allowCmdAbort && state == sfcsSendCommand) // command cancel -> start aborting the command
                             {
                                 state = sfcsAbortCommand;
-                                // allBytesWritten = TRUE;   // we must wait until the command is sent before starting to send the abort
-                                // we will not display the wait window again; in theory sending should never stall -> ignore it (the user will wait without the wait window)
+                                // allBytesWritten = TRUE;   // we must wait until the command is sent before starting the abort
+                                // we will not show the wait dialog again; in theory, sending should never stall, so we do not handle it (the user will wait without the dialog)
                             }
                             else // cannot use abort (we must close the connection) or cancel while aborting the command
                             {
@@ -380,14 +380,14 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                             { // replies of type FTP_D1_MAYBESUCCESS are logged only (we are waiting for the server's "last word")
                                 if (event != ccsevClosed)
                                 {
-                                    if (!aborting) // send command
-                                    {              // state can also be sfcsAbortCommand; then we must abort the command even if it succeeded just now (the user ordered an abort)
+                                    if (!aborting) // send the command unless it is being aborted
+                                    {              // state can also be sfcsAbortCommand; then we must abort the command even if it has just succeeded (the user requested an abort)
                                         if (state != sfcsAbortCommand)
                                         {
                                             state = sfcsDone;
                                             *ftpReplyCode = replyCode;
                                             CopyStr(ftpReplyBuf, ftpReplyBufSize, reply, replySize);
-                                            ret = TRUE; // SUCCESS, we have the server's reply! (for sending we only care about a single server reply)
+                                            ret = TRUE; // SUCCESS, we have the server reply! (when sending, only one server reply matters)
                                         }
                                         // else; // continue waiting for the abort command (we have not sent ABOR yet)
                                         SkipFTPReply(replySize);
@@ -408,8 +408,8 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                                         {
                                             // this is the reply for the sent or aborted command; we will still try to read
                                             // additional server replies (some servers send one more for ABOR)
-                                            if (!cmdReplyReceived) // return the first reply (it should belong to the command but it may be
-                                            {                      // for ABOR as well) - ignore any possible second reply (to ABOR)
+                                            if (!cmdReplyReceived) // return the first reply (it should belong to the command, but it may also be for ABOR)
+                                            {                      // ignore any possible second reply (to ABOR)
                                                 state = sfcsDone;
                                                 *ftpReplyCode = replyCode;
                                                 CopyStr(ftpReplyBuf, ftpReplyBufSize, reply, replySize);
@@ -493,7 +493,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                         switch (event)
                         {
                         case ccsevUserIfaceFinished:
-                            break; // CanFinishSending() will hopefully return TRUE now
+                            break; // CanFinishSending() should return TRUE now
 
                         case ccsevTimeout:
                         {
@@ -563,7 +563,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                     switch (event)
                     {
                     // case ccsevESC:   // (the user cannot press ESC during a 0 ms timeout)
-                    case ccsevTimeout: // no message is waiting -> display the error from Write directly
+                    case ccsevTimeout: // no message is pending -> display the error from Write directly
                     {
                         opFatalErrorTextID = !aborting ? IDS_SENDCOMMANDERROR : IDS_ABORTCOMMANDERROR;
                         opFatalError = error;
@@ -622,7 +622,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
 
                         if (event == ccsevClosed)
                         {
-                            if (state == sendState) // close without a cause
+                            if (state == sendState) // unexpected close
                             {
                                 fatalErrorTextID = IDS_CONNECTIONLOSTERROR;
                                 state = sfcsFatalError;
@@ -653,7 +653,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
                 Logs.LogMessage(logUID, buf, -1, TRUE); // add the last error text to the log
             }
             fatalErrLogMsg = TRUE;
-            if (canRetry == NULL || donotRetry) // "retry" is not possible or does not make sense
+            if (canRetry == NULL || donotRetry) // "retry" is not possible or useful
             {
                 *s = 0;
                 SalamanderGeneral->SalMessageBox(parent, buf, LoadStr(IDS_FTPERRORTITLE),
@@ -707,7 +707,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
         }
     }
 
-    if (parentIsEnabled) // if we disabled the parent, enable it again
+    if (parentIsEnabled) // if the parent was disabled, enable it again
     {
         // remove the wait cursor over the parent
         if (winParent != NULL)
@@ -744,7 +744,7 @@ BOOL CControlConnectionSocket::SendFTPCommand(HWND parent, const char* ftpCmd, c
             SetupKeepAliveTimer();
         }
     }
-    else // connection interrupted or timeout (the socket cannot be used anymore)
+    else // connection interrupted or timed out (the socket is no longer usable)
     {
         CloseSocket(NULL); // close the socket (if it is open); the system will attempt a "graceful" shutdown (we will not learn the result)
         Logs.SetIsConnected(logUID, IsConnected());
@@ -795,7 +795,7 @@ BOOL CControlConnectionSocket::GetCurrentWorkingPath(HWND parent, char* path, in
             HANDLES(EnterCriticalSection(&SocketCritSect));
             if (FTP_DIGIT_1(ftpReplyCode) == FTP_D1_SUCCESS && // success is returned (should be 257)
                     FTPGetDirectoryFromReply(replyBuf, (int)strlen(replyBuf), WorkingPath, FTP_MAX_PATH) ||
-                FTP_DIGIT_1(ftpReplyCode) != FTP_D1_SUCCESS) // failure returned (e.g. "not defined; use CWD to set the working directory") -> temporarily use an empty path
+                FTP_DIGIT_1(ftpReplyCode) != FTP_D1_SUCCESS) // failed (e.g. "not defined; use CWD to set the working directory") -> temporarily use an empty path
             {
                 if (FTP_DIGIT_1(ftpReplyCode) != FTP_D1_SUCCESS)
                     WorkingPath[0] = 0; // temporarily use an empty path
@@ -896,8 +896,8 @@ BOOL CControlConnectionSocket::SendChangeWorkingPath(BOOL notInPanel, BOOL leftP
             const char* p;
 
             BOOL needChangeDir = i == 0 && reconnected && startPath != NULL; // after reconnect try to set 'startPath' again
-            if (i == 0 && !reconnected && startPath != NULL)                 // we have been connected for a while, check
-            {                                                                // whether the working directory matches 'startPath'
+            if (i == 0 && !reconnected && startPath != NULL) // we have been connected for a while; check whether the working directory matches 'startPath'
+            {
                 // use the cache; under normal circumstances the path should be there
                 if (GetCurrentWorkingPath(parent, newPath, FTP_MAX_PATH, FALSE, &canRetry, retryMsgBuf, 300))
                 {
@@ -1041,8 +1041,8 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
         if (path[0] == 0) // only right after connecting - otherwise the path change (Shift+F7) to
         {                 // a relative path (e.g. "ftp://localhost") is ignored
                           // + when optimizing ChangePath() called right after obtaining the working directory
-            // forceRefresh should be only FALSE + it is always preceded by a GetCurrentWorkingPath() call -> it should always
-            // take the path from the cache (does not touch the connection)
+            // forceRefresh should only be FALSE, and this is always preceded by a GetCurrentWorkingPath() call, so it should always
+            // use the cached path (without touching the connection)
             ret = GetCurrentWorkingPath(parent, path, pathBufSize, forceRefresh, NULL, NULL, 0);
             if (ret)
             {
@@ -1052,7 +1052,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
         }
         else
         {
-            if (parsedPath &&                    // except for connecting from the "Connect to FTP Server" dialog it is always TRUE
+            if (parsedPath &&                    // parsedPath is always TRUE except when connecting from the "Connect to FTP Server" dialog
                 (*path == '/' || *path == '\\')) // 'path' always starts with '/' or '\\' ("always true")
             {
                 pathType = GetFTPServerPathType(path + 1);
@@ -1060,7 +1060,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                     pathType == ftpsptOS2 && GetFTPServerPathType("") == ftpsptOS2) // OS/2 paths get confused with the Unix path "/C:/path", so distinguish OS/2 paths even just by the SYST reply
                 {                                                                   // VMS + MVS + IBM_z/VM + OS/2 do not have '/' or '\\' at the start of the path
                     memmove(path, path + 1, strlen(path) + 1);                      // remove the '/' or '\\' character from the start of the path
-                    if (path[0] == 0)                                               // generic root -> supplement it according to the system type
+                    if (path[0] == 0)                                               // generic root -> fill it in according to the system type
                     {
                         if (pathType == ftpsptOpenVMS)
                             lstrcpyn(path, "[000000]", pathBufSize);
@@ -1074,7 +1074,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                                 {
                                     if (rescuePath[0] == 0 || !FTPGetIBMz_VMRootPath(path, pathBufSize, rescuePath))
                                     {
-                                        lstrcpyn(path, "/", pathBufSize); // the tested server supported the Unix root "/"; maybe someone will report it, then we will handle it further...
+                                        lstrcpyn(path, "/", pathBufSize); // the tested server supported the Unix root "/"; maybe someone will report this, then we will handle it further...
                                     }
                                 }
                                 else
@@ -1083,7 +1083,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                                     {
                                         if (rescuePath[0] == 0 || !FTPGetOS2RootPath(path, pathBufSize, rescuePath))
                                         {
-                                            lstrcpyn(path, "/", pathBufSize); // try at least the Unix root "/", we know nothing else; maybe someone will report it, then we will handle it further...
+                                            lstrcpyn(path, "/", pathBufSize); // try at least the Unix root "/"; we do not know anything else; maybe someone will report this, then we will handle it further...
                                         }
                                     }
                                 }
@@ -1141,8 +1141,8 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                 pathType = GetFTPServerPathType(path);
                 rescuePath[0] = 0; // do not try it next time (avoid loops)
             }
-            else // no need to report any error (listing already reported an error); we quietly tried
-            {    // to find an accessible path (which did not work)
+            else // no need to report any error (listing already reported an error); we tried silently
+            {    // to find an accessible path, but it did not work
                 ret = FALSE;
             }
         }
@@ -1168,7 +1168,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
         strcat(listCmd, "\r\n");
         BOOL isFTPS = EncryptControlConnection == 1;
         int useListingsCacheAux = UseListingsCache;
-        BOOL resuscitateKeepAlive = (IsConnected() && KeepAliveEnabled && KeepAliveMode == kamNone); // if keep-alive has already turned off (revival time expired), we must restart it
+        BOOL resuscitateKeepAlive = (IsConnected() && KeepAliveEnabled && KeepAliveMode == kamNone); // if keep-alive has already turned off (the resuscitation interval expired), we must restart it
         KeepAliveStart = GetTickCount();                                                             // beware, it is not enough to do it simply; 'resuscitateKeepAlive' must be used
         HANDLES(LeaveCriticalSection(&SocketCritSect));
 
@@ -1259,7 +1259,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                                             errBuf[0] = 0; // any possible message is unnecessary; the printed error would only be confusing
                                         }
                                     }
-                                    break; // fatal error or success (path changed) + possibly: the path is cached, take the listing from the cache
+                                    break; // fatal error or success (path changed); possibly: the path is cached and the listing is taken from the cache
                                 }
                             }
                             else
@@ -1293,7 +1293,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                                 lstrcpyn(path, rescuePath, pathBufSize);
                                 fileNameAlreadyCut = TRUE;
                                 pathType = GetFTPServerPathType(path);
-                                rescuePath[0] = 0; // do not try it next time (avoid loops)
+                                rescuePath[0] = 0; // do not try it again next time (avoid loops)
                             }
                             else
                             {
@@ -1307,7 +1307,7 @@ BOOL CControlConnectionSocket::ChangeWorkingPath(BOOL notInPanel, BOOL leftPanel
                                             *pathWasCut = TRUE; // we are on a path other than the requested one
                                         if (pathBufSize > 0)
                                             path[0] = 0; // there is no current path on the server
-                                        break;           // go try listing...
+                                        break;           // try listing now...
                                     }
                                 }
                                 else
@@ -1406,7 +1406,7 @@ void CControlConnectionSocket::GiveConnectionToWorker(CFTPWorker* newWorker, HWN
     if (IsConnected()) // only if the connection is open
     {
         // first stop keep-alive:
-        // store the focus from 'parent' (if the focus is not from 'parent', store NULL)
+        // save the focus from 'parent' (if the focus is not in 'parent', store NULL)
         HWND focusedWnd = GetFocus();
         HWND hwnd = focusedWnd;
         while (hwnd != NULL && hwnd != parent)
@@ -1588,7 +1588,7 @@ void CControlConnectionSocket::GetConnectionFromWorker(CFTPWorker* workerWithCon
             // restart keep-alive
             ReleaseKeepAlive();
             WaitForEndOfKeepAlive(SalamanderGeneral->GetMsgBoxParent(), 0); // cannot open the wait window (it is in state 'kamNone')
-            SetupKeepAliveTimer(TRUE);                                      // set up the keep-alive timer; trigger the keep-alive command right away (we do not know how long the connection was inactive, so let us avoid losing it)
+            SetupKeepAliveTimer(TRUE);                                      // set up the keep-alive timer; run the keep-alive command immediately (the connection may have been inactive for an unknown length of time, so avoid losing it unnecessarily)
         }
     }
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/ctrlcon3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Manual cleanup after provider apply tightened three awkward comment splits before final guard verification.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, Copilot SDK model `gpt-5.4`, and `--copilot-reasoning high`.
- 301 comment units, 301 review results, 301 resolved results, and 301 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/ctrlcon3.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/ftp/ctrlcon3.cpp` passed.

## Telemetry
- Total: 40 provider calls, 524717 estimated tokens.
- Codex-family: 33 calls, 287191 estimated tokens across codex and codex-resolve.
- Copilot SDK: 7 calls, 237526 estimated tokens, 127968 input tokens, 23670 output tokens, 14 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
