### PR TITLE
[tanslation] Fix src/plugins/automation/abortmodal.cpp comments

### DIFF
--- a/src/plugins/automation/abortmodal.cpp
+++ b/src/plugins/automation/abortmodal.cpp
@@ -128,7 +128,7 @@ HRESULT AbortableModalDialogWrapper(
     {
         hr = SALAUT_E_ABORT;
 
-        // Pump out the WM_QUIT we generated. The eventual messages
+        // Pump out the WM_QUIT we generated. Any messages
         // before WM_QUIT are lost.
         MSG msg;
         while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))


### PR DESCRIPTION
## Summary
- Tightens one translated comment in src/plugins/automation/abortmodal.cpp.
- Clarifies the WM_QUIT pump behavior: messages queued before the generated WM_QUIT are discarded.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/abortmodal.cpp.
- Stage counts matched: 4 comment units, 4 review results, 4 resolved results, 4 apply results.
- Apply results: 1 applied, 3 kept_target.
- Manual diff review found only one comment change.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/abortmodal.cpp with 0 violations.

## Telemetry
- Total requests: 2.
- Estimated total tokens: 23,871.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 13,789.
- Copilot output tokens: 1,348.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
