### PR TITLE
[tanslation] Fix src/plugins/automation/abortmodal.h comments

### DIFF
--- a/src/plugins/automation/abortmodal.h
+++ b/src/plugins/automation/abortmodal.h
@@ -15,10 +15,10 @@
 
 #define WM_SAL_ABORTMODAL (WM_APP + 0)
 
-/// Wraps a modal dialog into the dialog that can be forcibly aborted by the user.
-/// \param pfnDialogFn Function to display the modal dialog.
-/// \param pContext User defined value to be passed to the dialog function.
-/// \return If the modal dialog was successfully executed, the return value is S_OK.
+/// Wraps a modal dialog in a dialog that the user can forcibly abort.
+/// \param pfnDialogFn Function that displays the modal dialog.
+/// \param pContext User-defined value passed to the dialog function.
+/// \return If the modal dialog was executed successfully, the return value is S_OK.
 ///         If the modal dialog was aborted, the return value is SALAUT_E_ABORT.
 HRESULT AbortableModalDialogWrapper(
     __in class CScriptInfo* pScript,


### PR DESCRIPTION
## Summary
- Tightens the Doxygen comment for AbortableModalDialogWrapper in src/plugins/automation/abortmodal.h.
- Clarifies the wrapper description, parameter wording, and success return text.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/abortmodal.h.
- Stage counts matched: 3 comment units, 3 review results, 3 resolved results, 3 apply results.
- Apply results: 1 applied, 2 kept_target.
- Manual diff review found only comment changes.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/abortmodal.h with 0 violations.

## Telemetry
- Total requests: 1.
- Estimated total tokens: 24,703.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 13,958.
- Copilot output tokens: 889.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
