### PR TITLE
[tanslation] Fix src/plugins/automation/abortpalette.cpp comments

### DIFF
--- a/src/plugins/automation/abortpalette.cpp
+++ b/src/plugins/automation/abortpalette.cpp
@@ -293,8 +293,8 @@ unsigned CScriptAbortPaletteThread::Body()
                 // We cannot delete the SC_CLOSE menu item,
                 // since that would not disable the close button
                 // on the title bar on Vista+ with Aero.
-                // Moreover the item cannot be referenced by
-                // position but by command only.
+                // Moreover, the item cannot be referenced
+                // by position, only by command.
                 EnableMenuItem(hSysMenu, SC_CLOSE, MF_BYCOMMAND | MF_GRAYED);
             }
             else if (uId != SC_MOVE)


### PR DESCRIPTION
## Summary
- Tightens one translated system menu comment in src/plugins/automation/abortpalette.cpp.
- Clarifies that the SC_CLOSE menu item is referenced by command, not by position.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/abortpalette.cpp.
- Stage counts matched: 15 comment units, 15 review results, 15 resolved results, 15 apply results.
- Apply results: 1 applied, 13 kept_target, 1 noop.
- Manual diff review found only comment changes.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/abortpalette.cpp with 0 violations.

## Telemetry
- Total requests: 2.
- Estimated total tokens: 30,157.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 14,545.
- Copilot output tokens: 1,450.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
