### PR TITLE
[tanslation] Fix src/plugins/automation/automationplug.cpp comments

### DIFF
--- a/src/plugins/automation/automationplug.cpp
+++ b/src/plugins/automation/automationplug.cpp
@@ -281,8 +281,8 @@ MENU_TEMPLATE_ITEM PluginMenu[] =
         0,
         CAutomationMenuExtInterface::CmdRunFocusedScript,
         TRUE, // callGetState
-        0,    // or-mask (ignored id callGetState == TRUE)
-        0,    // and-mask (ignored id callGetState == TRUE)
+        0,    // or-mask (ignored if callGetState == TRUE)
+        0,    // and-mask (ignored if callGetState == TRUE)
         MENU_SKILLLEVEL_ALL);
 
     // open script menu
@@ -296,10 +296,10 @@ MENU_TEMPLATE_ITEM PluginMenu[] =
         0,
         MENU_SKILLLEVEL_ALL);
 
-    // for our menu items we set callGetState to TRUE, so the
-    // GetMenuItemState will be always called for the items which
-    // forces our plugin to be loaded before first menu popup
-    // and the items get refreshed
+    // for our menu items we set callGetState to TRUE, so
+    // GetMenuItemState is always called for those items,
+    // which forces our plugin to load before the first menu popup
+    // and refreshes the items
 
     if (g_oScriptLookup.GetCount() > 0)
     {
@@ -319,8 +319,8 @@ MENU_TEMPLATE_ITEM PluginMenu[] =
         AddScriptContainerToMenu(pRootContainer, salamander, 0);
     }
 
-    // Salamander manages the icon list itself, so we must everytime
-    // create a copy of that list that we pass to menu builder.
+    // Salamander manages the icon list itself, so we must always
+    // create a copy of the list that we pass to the menu builder.
     CGUIIconListAbstract* pListCopy = SalamanderGUI->CreateIconList();
     if (pListCopy)
     {


### PR DESCRIPTION
## Summary
- Tightens translated menu-related comments in src/plugins/automation/automationplug.cpp.
- Clarifies callGetState mask handling, forced plugin load before the first menu popup, item refresh behavior, and icon-list copying.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/automationplug.cpp.
- Stage counts matched: 37 comment units, 37 review results, 37 resolved results, 37 apply results.
- Apply results: 4 applied, 15 kept_target, 18 noop.
- Manual diff review found only comment changes.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/automationplug.cpp with 0 violations.

## Telemetry
- Total requests: 3.
- Estimated total tokens: 55,594.
- Copilot SDK requests: 2.
- Copilot request units: 4.
- Copilot input tokens: 28,756.
- Copilot output tokens: 1,846.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
