### PR TITLE
[tanslation] Fix src/plugins/automation/aututils.cpp comments

### DIFF
--- a/src/plugins/automation/aututils.cpp
+++ b/src/plugins/automation/aututils.cpp
@@ -128,9 +128,9 @@ static int DisplayError(
 
 static void AdjustSourcePosition(ULONG& line, LONG& col, CScriptEngineShim* pShim)
 {
-    // Some engines return zero-based line number, others one-based
-    // try to normalize to one-base line numbers since it is more
-    // natural for humans and editors start counting from one too.
+    // Some engines return zero-based line numbers, others one-based.
+    // Try to normalize to one-based line numbers since that is more
+    // natural for humans, and editors start counting from one too.
 
     if (pShim != NULL)
     {
@@ -293,7 +293,7 @@ void QuadWordToVariant(const CQuadWord& q, __out VARIANT* var)
     }
     else
     {
-        // 64b integer is not OLE Automation type, coerce to double
+        // 64-bit integer is not an OLE Automation type; coerce to double
         V_VT(var) = VT_R8;
         V_R8(var) = (double)q.Value;
     }
@@ -310,7 +310,7 @@ void QuadWordToVariant(LARGE_INTEGER q, __out VARIANT* var)
     }
     else
     {
-        // 64b integer is not OLE Automation type, coerce to double
+        // 64-bit integer is not an OLE Automation type; coerce to double
         V_VT(var) = VT_R8;
         V_R8(var) = (double)q.QuadPart;
     }


### PR DESCRIPTION
## Summary
- Tightens translated utility comments in src/plugins/automation/aututils.cpp.
- Clarifies one-based source-position normalization and the OLE Automation fallback from 64-bit integers to double.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/aututils.cpp.
- Stage counts matched: 11 comment units, 11 review results, 11 resolved results, 11 apply results.
- Apply results: 3 applied, 8 kept_target.
- Manual diff review found only comment changes.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/aututils.cpp with 0 violations.

## Telemetry
- Total requests: 3.
- Estimated total tokens: 67,965.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 16,717.
- Copilot output tokens: 2,578.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
