### PR TITLE
[tanslation] Fix src/plugins/automation/aututils.h comments

### DIFF
--- a/src/plugins/automation/aututils.h
+++ b/src/plugins/automation/aututils.h
@@ -52,7 +52,7 @@ void DisplayException(EXCEPINFO& ei, bool bFree = true);
 /// Releases resources associated with the EXCEPINFO structure.
 void FreeException(EXCEPINFO& ei);
 
-/// Formats textual description of the system error code.
+/// Formats a textual description of the system error code.
 void FormatErrorText(
     HRESULT hrCode,
     TCHAR* pszBuffer,
@@ -67,10 +67,10 @@ UINT HashString(__in_z PCTSTR s);
 void QuadWordToVariant(LARGE_INTEGER q, __out VARIANT* var);
 void QuadWordToVariant(const CQuadWord& q, __out VARIANT* var);
 
-/// Retrieved property value from the IDispatch interface.
+/// Retrieves a property value from the IDispatch interface.
 /// \param pdisp Pointer to the IDispatch interface.
 /// \param name Name of the property to retrieve.
-/// \param result Property value.
+/// \param result Receives the property value.
 HRESULT DispPropGet(IDispatch* pdisp, PCWSTR name, VARIANT* result);
 HRESULT DispPropGet(IUnknown* punk, PCWSTR name, VARIANT* result);
 
@@ -84,6 +84,6 @@ int ButtonToFriendlyNumber(int button);
 /// See CScriptInfo::ExecuteWorker for detailed explanation.
 void ResetKeyboardState();
 
-/// Checks if the script execution was aborted and if so, fills appropriately
-/// the exception information.
+/// Checks whether script execution was aborted and, if so, fills the
+/// exception information accordingly.
 HRESULT CheckAbort(__in class CScriptInfo* pScriptInfo, __out EXCEPINFO* pExcepInfo);


### PR DESCRIPTION
## Summary
- Tightens translated utility API comments in src/plugins/automation/aututils.h.
- Clarifies error text formatting, IDispatch property retrieval, result output semantics, and abort exception reporting.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/aututils.h.
- Stage counts matched: 15 comment units, 15 review results, 15 resolved results, 15 apply results.
- Apply results: 3 applied, 11 kept_target, 1 noop.
- Manual diff review corrected escaped Doxygen parameter tags back to valid `\param` tags.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/aututils.h with 0 violations.

## Telemetry
- Total requests: 3.
- Estimated total tokens: 57,709.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 19,709.
- Copilot output tokens: 3,523.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
