### PR TITLE
[tanslation] Fix src/plugins/automation/cfgdlg.cpp comments

### DIFF
--- a/src/plugins/automation/cfgdlg.cpp
+++ b/src/plugins/automation/cfgdlg.cpp
@@ -61,9 +61,9 @@ INT_PTR CAutomationConfigDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lPa
         HWND hwndList = GetDlgItem(HWindow, IDC_DIRLIST);
         if (hwndFrom == hwndList || GetParent(hwndFrom) == hwndList)
         {
-            // command forwarded from the list view,
-            // do not pass it to the CDialog::DialogProc
-            // since if it is IDOK the dialog will close
+            // command forwarded from the list view;
+            // do not pass it to CDialog::DialogProc,
+            // because IDOK would close the dialog
             return FALSE;
         }
 
@@ -330,8 +330,8 @@ BOOL CAutomationConfigDialog::OnDirListBeginLabelEdit(NMLVDISPINFO* nmlv)
     _ASSERTE(IsWindow(hwndEdit));
 
     // autocomplete must be attached before we subclass
-    // the edit control to not mess the subclass chain
-    // while unsubclassing
+    // the edit control so as not to disrupt the subclass chain
+    // during unsubclassing
     SHAutoComplete(hwndEdit, SHACF_FILESYS_DIRS);
 
     SubclassLabelEdit(hwndEdit);
@@ -383,9 +383,9 @@ BOOL CAutomationConfigDialog::OnDirListEndLabelEdit(NMLVDISPINFO* nmlv)
     // accept the edited text
     SetWindowLongPtr(HWindow, DWLP_MSGRESULT, TRUE);
 
-    // the width of the column might be changed,
-    // defer recalcing the width once the new text will
-    // be set after we return from this notification handler
+    // the column width might change;
+    // defer recalculating it until the new text is set
+    // after we return from this notification handler
     PostMessage(HWindow, WM_USER_RECALCWIDTH, 0, 0);
 
     DirSelChanged();


### PR DESCRIPTION
## Summary
- Tightens translated dialog configuration comments in src/plugins/automation/cfgdlg.cpp.
- Clarifies list-view command forwarding, autocomplete setup before subclassing, and deferred column-width recalculation.
- Keeps executable code unchanged; this PR is comment-only.

## Model
OpenAI GPT-5.4

## Verification
- Sequential pipeline completed scan, ground, review, resolve, apply, and guard for src/plugins/automation/cfgdlg.cpp.
- Stage counts matched: 19 comment units, 19 review results, 19 resolved results, 19 apply results.
- Apply results: 3 applied, 14 kept_target, 2 noop.
- Manual diff review found only comment changes.
- git diff --check passed.
- Comment guard passed for src/plugins/automation/cfgdlg.cpp with 0 violations.

## Telemetry
- Total requests: 3.
- Estimated total tokens: 69,431.
- Copilot SDK requests: 1.
- Copilot request units: 2.
- Copilot input tokens: 17,701.
- Copilot output tokens: 3,693.
- Copilot billing note: Copilot is accounted by request units, not by direct token-priced billing; token counts are retained as telemetry.

## Czech Source Context
Inline review comments were generated from the pipeline artifacts and include the original Czech wording plus the reason for each changed comment.
