### PR TITLE
[tanslation] Fix src/plugins/automation/dispimpl.h comments

### DIFF
--- a/src/plugins/automation/dispimpl.h
+++ b/src/plugins/automation/dispimpl.h
@@ -24,11 +24,11 @@
     }
 
 /*
-	We must implement IDispatchEx for the very stupid VBScript engine.
-	We used to use simple StdDispatch implementation, but VB insists
-	on IDispatchEx and if it doesn't get it it simply !!!CASTS!!!
-	the interface pointer to the IDispatch which is not very good
-	with the aggregated StdDispatch interface and it caused strange
+	We must implement IDispatchEx for the VBScript engine.
+	We used to use a simple StdDispatch implementation, but VB requires
+	IDispatchEx and if it does not get it, it simply casts
+	the interface pointer to IDispatch, which does not work well
+	with the aggregated StdDispatch interface and caused strange
 	crashes.
 */
 
@@ -210,8 +210,8 @@ public:
 
         if (SUCCEEDED(hr) && pVarResult != NULL && V_VT(pVarResult) == VT_DISPATCH)
         {
-            // it seems that std DispInvoke is not able
-            // to coerce return value to proper pointer to
+            // it seems that standard DispInvoke is not able
+            // to coerce the return value to a proper pointer to
             // IDispatch in case of dual interface objects
 
             IDispatch* pdisp;


### PR DESCRIPTION
## Summary
- Refines the `src/plugins/automation/dispimpl.h` IDispatchEx implementation comment to remove colloquial wording and improve grammar while preserving the technical meaning.
- Refines the DispInvoke return-value comment by expanding `std` to `standard` and adding missing articles.

## Review Notes
- Original Czech baseline: `OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b`.
- Scope: comments only; no code, declaration, preprocessor, or resource changes.
- Inline PR review comments include the original Czech-derived/source wording and rationale for each changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 52 comment units, with 52 review results, 52 resolved results, and 52 apply results.
- Apply results: 2 applied, 9 kept_target, 41 noop.
- `git diff --check -- src/plugins/automation/dispimpl.h` passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 1
- Total tokens recorded: 18,915
- Total billing units recorded: 0
- Provider/model: codex gpt-5.4, 1 call
