### PR TITLE
[tanslation] Fix src/plugins/automation/engassoc.cpp comments

### DIFF
--- a/src/plugins/automation/engassoc.cpp
+++ b/src/plugins/automation/engassoc.cpp
@@ -122,8 +122,8 @@ HRESULT CScriptEngineAssociations::QueryHardcodedScriptEngineAssociation(
     PCTSTR pszExt,
     __out CLSID* clsidEngine)
 {
-    // Windows really makes hard time for us to use the JScript engine.
-    // Use hardcoded association for .js files if everything else fails.
+    // Windows really makes it hard for us to use the JScript engine.
+    // Use a hardcoded association for .js files if everything else fails.
 
     if (_tcsicmp(pszExt, _T(".js")) == 0)
     {


### PR DESCRIPTION
## Summary
- Refines the src/plugins/automation/engassoc.cpp JScript fallback comment to fix awkward grammar while preserving the technical meaning.
- Keeps the change limited to comments; no executable code or declarations changed.

## Review Notes
- Original Czech baseline: OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b.
- Inline PR review comments include the original source wording and rationale for the changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 4 comment units, with 4 review results, 4 resolved results, and 4 apply results.
- Apply results: 1 applied, 3 kept_target.
- git diff --check for src/plugins/automation/engassoc.cpp passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 2
- Total tokens recorded: 53,134
- Total billing units recorded: 2 copilot_request_units
- Provider/model: copilot-sdk gpt-5.4, 1 call, 2 request units
- Provider/model: codex-resolve gpt-5.4, 1 call
