### PR TITLE
[tanslation] Fix src/plugins/automation/entry.cpp comments

### DIFF
--- a/src/plugins/automation/entry.cpp
+++ b/src/plugins/automation/entry.cpp
@@ -69,7 +69,7 @@ static void WINAPI HTMLHelpCallback(HWND hWindow, UINT helpID)
 
 /// Returns the object representing the plugin.
 /// \param salamander Pointer to the CSalamanderPluginEntryAbstract interface.
-/// \return If the function succeeds, the return value is pointer to the
+/// \return If the function succeeds, the return value is a pointer to the
 ///         plugin object. If the function fails, the return value is NULL.
 CPluginInterfaceAbstract*
     WINAPI
@@ -131,9 +131,9 @@ CPluginInterfaceAbstract*
     return &g_oAutomationPlugin;
 }
 
-/// Returns version of Open Salamander required to run this plugin.
-/// \return The return value is required version of Open Salamander.
-///         For list of version values see \e spl_vers.h.
+/// Returns the version of Open Salamander required to run this plugin.
+/// \return The return value is the required version of Open Salamander.
+///         For a list of version values, see \e spl_vers.h.
 int WINAPI SalamanderPluginGetReqVer()
 {
     return LAST_VERSION_OF_SALAMANDER;


### PR DESCRIPTION
## Summary
- Refines two Doxygen comments in src/plugins/automation/entry.cpp for idiomatic English.
- Keeps the change limited to comments; no executable code or declarations changed.

## Review Notes
- Original Czech baseline: OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b.
- Inline PR review comments include the original source wording and rationale for each changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 20 comment units, with 20 review results, 20 resolved results, and 20 apply results.
- Apply results: 2 applied, 17 kept_target, 1 noop.
- git diff --check for src/plugins/automation/entry.cpp passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 2
- Total tokens recorded: 32,164
- Total billing units recorded: 2 copilot_request_units
- Provider/model: codex gpt-5.4, 1 call
- Provider/model: copilot-sdk gpt-5.4, 1 call, 2 request units
