### PR TITLE
[tanslation] Fix src/plugins/automation/guicomponent.h comments

### DIFF
--- a/src/plugins/automation/guicomponent.h
+++ b/src/plugins/automation/guicomponent.h
@@ -17,7 +17,7 @@
 #include "guidefs.h"
 
 /// Component base class.
-/// You never use this class directly, you must create inherited class.
+/// Never use this class directly; create a derived class instead.
 class CSalamanderGuiComponentBase : public ISalamanderGuiComponentInternal
 {
 private:


### PR DESCRIPTION
## Summary
- Refines the src/plugins/automation/guicomponent.h component base class comment for idiomatic English and correct OO terminology.
- Keeps the change limited to comments; no executable code or declarations changed.

## Review Notes
- Original Czech baseline: OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b.
- Inline PR review comments include the original source wording and rationale for the changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 32 comment units, with 32 review results, 32 resolved results, and 32 apply results.
- Apply results: 1 applied, 19 kept_target, 12 noop.
- git diff --check for src/plugins/automation/guicomponent.h passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 3
- Total tokens recorded: 40,385
- Total billing units recorded: 2 copilot_request_units
- Provider/model: codex gpt-5.4, 1 call
- Provider/model: copilot-sdk gpt-5.4, 1 call, 2 request units
- Provider/model: codex-resolve gpt-5.4, 1 call
