### PR TITLE
[tanslation] Fix src/plugins/automation/guicontainer.cpp comments

### DIFF
--- a/src/plugins/automation/guicontainer.cpp
+++ b/src/plugins/automation/guicontainer.cpp
@@ -248,7 +248,7 @@ HRESULT CSalamanderGuiContainerBase::ContainerPutMember(
         }
         else
         {
-            // Setting non-existent member to NULL is no-op.
+            // Setting a non-existent member to NULL is a no-op.
             _ASSERT(pComponent == NULL);
         }
 
@@ -281,7 +281,7 @@ HRESULT CSalamanderGuiContainerBase::ContainerPutMember(
 
     if (FAILED(hr))
     {
-        // It's not a component.
+        // Not a component.
 
         if (pComponent)
         {


### PR DESCRIPTION
## Summary
- Refines two implementation comments in src/plugins/automation/guicontainer.cpp for idiomatic English.
- Keeps the change limited to comments; no executable code or declarations changed.

## Review Notes
- Original Czech baseline: OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b.
- Inline PR review comments include the original source wording and rationale for each changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 15 comment units, with 15 review results, 15 resolved results, and 15 apply results.
- Apply results: 2 applied, 13 kept_target.
- git diff --check for src/plugins/automation/guicontainer.cpp passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 2
- Total tokens recorded: 32,901
- Total billing units recorded: 2 copilot_request_units
- Provider/model: codex gpt-5.4, 1 call
- Provider/model: copilot-sdk gpt-5.4, 1 call, 2 request units
