### PR TITLE
[tanslation] Fix src/plugins/automation/processlist.h comments

### DIFF
--- a/src/plugins/automation/processlist.h
+++ b/src/plugins/automation/processlist.h
@@ -13,6 +13,6 @@
 
 #pragma once
 
-// returns TRUE when window 'hWnd' belongs to process with 'dwProcessId'
-// function walks through parent processes
+// Returns TRUE when window 'hWnd' belongs to the process with 'dwProcessId'.
+// The function walks through parent processes.
 BOOL WindowBelongsToProcessID(HWND hWnd, DWORD dwProcessId);


### PR DESCRIPTION
## Summary
- Refines the src/plugins/automation/processlist.h API comment for idiomatic English.
- Keeps the change limited to comments; no executable code or declarations changed.

## Review Notes
- Original Czech baseline: OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b.
- Inline PR review comments include the original source wording and rationale for the changed comment.

## Model
- Model: OpenAI GPT-5.4
- Review provider: auto
- Copilot reasoning: high
- Copilot billing note: Copilot is billed by request units, not by token-priced usage in this workflow.

## Verification
- Sequential review processed 3 comment units, with 3 review results, 3 resolved results, and 3 apply results.
- Apply results: 1 applied, 2 kept_target.
- git diff --check for src/plugins/automation/processlist.h passed.
- Comment guard was re-run against the materialized delivery checkout and passed with 0 violations.
- Final git diff was manually reviewed for comment-only changes.

## Telemetry
- Total provider calls: 1
- Total tokens recorded: 23,183
- Total billing units recorded: 2 copilot_request_units
- Provider/model: copilot-sdk gpt-5.4, 1 call, 2 request units
