### PR TITLE
[tanslation] Fix src/plugins/automation/raiserr.h comments

### DIFF
--- a/src/plugins/automation/raiserr.h
+++ b/src/plugins/automation/raiserr.h
@@ -15,7 +15,7 @@
 
 void RaiseError(LPCOLESTR pszDescription, REFIID riid, LPCOLESTR pszProgId);
 
-/// \param nIdDescription Idenfier of the string in the language
+/// \param nIdDescription Identifier of the string in the language
 ///        module that describes the error.
 void RaiseError(int nIdDescription, REFIID riid, LPCOLESTR pszProgId);
 


### PR DESCRIPTION
## Summary
- Corrects the `nIdDescription` Doxygen parameter comment in `src/plugins/automation/raiserr.h`.
- Fixes the typo `Idenfier` to `Identifier` while preserving the existing `\param` syntax and comment wrapping.
- Applies only a comment-only change; declarations, behavior, resources, and binary logic are unchanged.

## Review Notes
- Model: OpenAI GPT-5.4 through GitHub Copilot.
- Copilot telemetry is reported in request units rather than token-priced USD cost.
- Provider telemetry: 1 call, 20,529 total tokens, 12,998 input tokens, 747 output tokens, 2 `copilot_request_units`.
- During final diff review, the generated draft was tightened so the Doxygen command remains `\param` rather than a doubled backslash.

## Verification
- Ran the sequential review pipeline for `src/plugins/automation/raiserr.h` with full prompt and Copilot event logging.
- Reviewed `apply-results.jsonl` and the final git diff.
- Ran `git diff --check -- src/plugins/automation/raiserr.h`.
- Reran comment guard against the materialized checkout; guard passed for `src/plugins/automation/raiserr.h` with zero violations.
