### PR TITLE
[tanslation] Fix src/plugins/automation/salamanderaut.cpp comments

### DIFF
--- a/src/plugins/automation/salamanderaut.cpp
+++ b/src/plugins/automation/salamanderaut.cpp
@@ -119,7 +119,7 @@ static void WINAPI ShowMsgBoxProc(void* pContext)
 
     if (msgbox.nDlgResult == 0)
     {
-        // the most probable reason of failure is invalid arguments
+        // the most likely reason for the failure is invalid arguments
         // to SalMessageBoxEx
         return E_INVALIDARG;
     }
@@ -891,7 +891,7 @@ static void CALLBACK ShowQuestionDialogProc(void* pContext)
 
         if (FAILED(hr))
         {
-            // TODO: report better error, st. like "panel object expected"
+            // TODO: report a better error, e.g. "panel object expected"
             return hr;
         }
     }


### PR DESCRIPTION
## Summary
- Improves two source comments in `src/plugins/automation/salamanderaut.cpp`.
- Rewords the `SalMessageBoxEx` invalid-argument failure comment for clearer English.
- Expands the TODO abbreviation `st.` to `e.g.` in the panel-object error comment.

## Review Notes
- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot telemetry is reported in request units rather than token-priced USD cost.
- Provider telemetry: 3 calls, 32,267 total tokens, 14,932 input tokens, 1,975 output tokens, 2 `copilot_request_units`.
- Two calls were Codex lite review calls and one call was a Copilot deep review call.
- The final diff is comment-only and was manually inspected before PR creation.

## Verification
- Ran the sequential review pipeline for `src/plugins/automation/salamanderaut.cpp` with full prompt and Copilot event logging.
- Reviewed `apply-results.jsonl`, the generated draft, and the final git diff.
- Ran `git diff --check -- src/plugins/automation/salamanderaut.cpp`.
- Reran comment guard against the materialized checkout; guard passed for `src/plugins/automation/salamanderaut.cpp` with zero violations.
