### PR TITLE
[tanslation] Fix src/plugins/automation/scriptlist.h comments

### DIFF
--- a/src/plugins/automation/scriptlist.h
+++ b/src/plugins/automation/scriptlist.h
@@ -70,7 +70,7 @@ private:
     IActiveScriptError* m_pHardError;
     bool m_bSiteErrorDisplayed; ///< Message box shown in site's OnScriptError.
     class CScriptEngineShim* m_pShim;
-    HANDLE m_hAbortEvent; ///< Manually reset event signaled when the user requested abort.
+    HANDLE m_hAbortEvent; ///< Manual-reset event signaled when the user requests abort.
     HWND m_hwndAbortTarget;
 
     // statistics stuff


### PR DESCRIPTION
## Summary
- Clarifies the inline member comment for `m_hAbortEvent` in `src/plugins/automation/scriptlist.h`.
- Identifies the handle as a manual-reset event and describes that it is signaled when the user requests abort.
- Keeps the patch comment-only; class layout and behavior are unchanged.

## Review Notes
- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot telemetry is reported in request units rather than token-priced USD cost.
- Provider telemetry: 2 calls, 38,970 total tokens, 11,923 input tokens, 424 output tokens, 2 `copilot_request_units`.
- The calls included one Codex lite review call and one Copilot deep review call.

## Verification
- Ran the sequential review pipeline for `src/plugins/automation/scriptlist.h` with full prompt and Copilot event logging.
- Reviewed `apply-results.jsonl`, the generated draft, and the final git diff.
- Ran `git diff --check -- src/plugins/automation/scriptlist.h`.
- Reran comment guard against the materialized checkout; guard passed for `src/plugins/automation/scriptlist.h` with zero violations.
