### PR TITLE
[tanslation] Fix src/plugins/automation/scriptsite.cpp comments

### DIFF
--- a/src/plugins/automation/scriptsite.cpp
+++ b/src/plugins/automation/scriptsite.cpp
@@ -195,10 +195,10 @@ HRESULT CScriptSite::OnStateChange(
 HRESULT CScriptSite::OnScriptError(
     /* [in] */ __RPC__in_opt IActiveScriptError* pScriptError)
 {
-    // May be NULL if the error raises during the parsing phase.
+    // May be NULL if the error occurs during the parsing phase.
     if (m_pExecInfo != NULL)
     {
-        // The abort palette is no longer needed, hide it now.
+        // The abort palette is no longer needed; delete it now.
         delete m_pExecInfo->pAbortPalette;
         m_pExecInfo->pAbortPalette = NULL;
     }
@@ -220,10 +220,10 @@ HRESULT CScriptSite::OnScriptError(
 
     FreeException(ei);
 
-    // Never ever try to return anything else than S_OK here.
+    // Never return anything other than S_OK here.
     // If JScript.dll returns CTL_E_OUTOFMEMORY because of infinite
-    // recursion (see Redmine #782 bug) it keeps calling OnScriptError
-    // again and again if we return anything else than S_OK.
+    // recursion (see Redmine #782), it keeps calling OnScriptError
+    // repeatedly unless we return S_OK.
 
     return S_OK;
 }
@@ -382,10 +382,10 @@ HRESULT STDMETHODCALLTYPE CScriptSite::OnScriptErrorDebug(
     /* [out] */ BOOL* pfEnterDebugger,
     /* [out] */ BOOL* pfCallOnScriptErrorWhenContinuing)
 {
-    // May be NULL if the error raises during the parsing phase.
+    // May be NULL if the error occurs during the parsing phase.
     if (m_pExecInfo != NULL)
     {
-        // The abort palette is no longer needed, hide it now.
+        // The abort palette is no longer needed; delete it now.
         delete m_pExecInfo->pAbortPalette;
         m_pExecInfo->pAbortPalette = NULL;
     }


### PR DESCRIPTION
## Summary
- Improves reviewed script error handling comments in `src/plugins/automation/scriptsite.cpp`.
- Clarifies parsing-phase error wording, abort-palette deletion wording, and the `S_OK` return requirement for repeated JScript error callbacks.
- Keeps the patch comment-only; COM behavior and error handling are unchanged.

## Review Notes
- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot telemetry is reported in request units rather than token-priced USD cost.
- Provider telemetry: 2 calls, 37,034 total tokens, 16,331 input tokens, 2,730 output tokens, 2 `copilot_request_units`.
- The calls included one Codex lite review call and one Copilot deep review call.
- Final manual review corrected an over-indented continuation comment before commit.

## Verification
- Ran the sequential review pipeline for `src/plugins/automation/scriptsite.cpp` with full prompt and Copilot event logging.
- Reviewed `apply-results.jsonl`, the generated draft, and the final git diff.
- Ran `git diff --check -- src/plugins/automation/scriptsite.cpp`.
- Reran comment guard against the materialized checkout; guard passed for `src/plugins/automation/scriptsite.cpp` with zero violations.
