### PR TITLE
[tanslation] Fix src/plugins/dbviewer/csvlib/csvlib.cpp comments

### DIFF
--- a/src/plugins/dbviewer/csvlib/csvlib.cpp
+++ b/src/plugins/dbviewer/csvlib/csvlib.cpp
@@ -21,7 +21,7 @@
 #include "csvlib.h"
 
 // only an optimization detail
-extern BOOL IsAlphaNumeric[256]; // TRUE/FALSE array for characters (FALSE = not a letter nor a digit)
+extern BOOL IsAlphaNumeric[256]; // TRUE/FALSE array for characters (FALSE = not a letter or digit)
 extern BOOL IsAlpha[256];
 
 #define SizeOf(x) (sizeof(x) / sizeof(x[0]))
@@ -194,7 +194,7 @@ CCSVParser<CChar>::CCSVParser(const char* filename,
         bIsBigEndian = BOM == 0xFFFE;
     }
     else
-    { // Detect UTF8
+    { // Detect UTF-8
         BYTE b[3];
         fread(b, 1, 3, File);
         if (!memcmp(b, "\xEF\xBB\xBF", 3))


### PR DESCRIPTION
## Summary

- Refines the IsAlphaNumeric FALSE comment so it reads as natural English while preserving the original Czech meaning.
- Standardizes the UTF-8 detection comment spelling.
- No parser, encoding, buffer, or compiled-code behavior changes.

## Review

- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot usage is tracked as request units; this run consumed 2 Copilot request units.
- Provider telemetry recorded 6 total calls and 137,133 total tokens.

## Verification

- Ran the sequential comments review workflow with full prompt and Copilot event logging.
- Manually inspected the final git diff for comment-only changes.
- Ran git diff --check for src/plugins/dbviewer/csvlib/csvlib.cpp.
- Reran comment guard against the delivery checkout; it passed for the touched file.
