### PR TITLE
[tanslation] Fix src/plugins/dbviewer/csvlib/csvlib.h comments

### DIFF
--- a/src/plugins/dbviewer/csvlib/csvlib.h
+++ b/src/plugins/dbviewer/csvlib/csvlib.h
@@ -25,7 +25,7 @@ enum CCSVParserTextQualifier
 struct CCSVColumn
 {
     DWORD MaxLength; // maximum number of characters in the column
-    char* Name;      // allocated column name or NULL if it does not exist
+    char* Name;      // allocated column name, or NULL if the column has no name
     // temporary variables filled during FetchRecord
     DWORD First;
     DWORD Length;
@@ -75,11 +75,11 @@ public:
     virtual CCSVParserStatus FetchRecord(DWORD index) = 0;
 
 protected:
-    // if the column does not exist at columnIndex, add a new one with MaxLength = columnLen
+    // if the column at columnIndex does not exist yet, add a new one with MaxLength = columnLen
     // returns FALSE if the column could not be added to the array
-    // if the column already exists, extend columnLen only when it is larger than
-    // the current MaxLength value in that column
-    // returns TRUE if the addition/update of the column succeeded
+    // if the column already exists, set its MaxLength to columnLen only if it is greater than the
+    // current MaxLength value in that column
+    // returns TRUE if adding/updating the column succeeded
     BOOL SetLongerColumn(int columnIndex, DWORD columnLen);
 
     struct CLineRating


### PR DESCRIPTION
## Summary

- Clarifies the CSV column name pointer comment.
- Rewrites the SetLongerColumn comment block to describe add/update behavior directly.
- No structure, API, parser, or compiled-code behavior changes.

## Review

- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot usage is tracked as request units; this run consumed 2 Copilot request units.
- Provider telemetry recorded 2 total calls and 46,383 total tokens.

## Verification

- Ran the sequential comments review workflow with full prompt and Copilot event logging.
- Materialized the approved draft into the delivery checkout after apply wrote only draft output.
- Manually inspected the final git diff for comment-only changes.
- Ran git diff --check for src/plugins/dbviewer/csvlib/csvlib.h.
- Reran comment guard against the delivery checkout; it passed for the touched file.
