### PR TITLE
[tanslation] Fix src/plugins/dbviewer/data.h comments

### DIFF
--- a/src/plugins/dbviewer/data.h
+++ b/src/plugins/dbviewer/data.h
@@ -65,7 +65,7 @@ public:
     BOOL Open(const char* fileName);
     void Close();
 
-    // return TRUE if the database is open and all variables are initialized
+    // returns TRUE if the database is open
     BOOL IsOpened() { return Parser != NULL; }
 
     // "", "dbf", "csv"


### PR DESCRIPTION
## Summary

- Aligns the IsOpened comment with the actual Parser != NULL check.
- Removes the unsupported claim that all variables are initialized.
- No parser, state-management, layout, or compiled-code behavior changes.

## Review

- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot usage is tracked as request units; this run consumed 2 Copilot request units.
- Provider telemetry recorded 3 total calls and 49,271 total tokens.

## Verification

- Ran the sequential comments review workflow with full prompt and Copilot event logging.
- Materialized the approved draft into the delivery checkout after apply wrote only draft output.
- Manually inspected the final git diff for comment-only changes.
- Ran git diff --check for src/plugins/dbviewer/data.h.
- Reran comment guard against the delivery checkout; it passed for the touched file.
