### PR TITLE
[tanslation] Fix src/plugins/dbviewer/dbflib/dbflib.h comments

### DIFF
--- a/src/plugins/dbviewer/dbflib/dbflib.h
+++ b/src/plugins/dbviewer/dbflib/dbflib.h
@@ -153,14 +153,14 @@ typedef struct _dbf_header
     U32 recordsCnt;    /* total number of records in file */
     U32 fieldsCnt;     /* number of fields per record, including memo fields */
     U32 memoFieldsCnt; /* number of memo fields per record */
-    U32 recordSize;    /* total size of record as in master DBF file */
+    U32 recordSize;    /* total record size as in the master DBF file */
     U32 headerSize;    /* total size of file header */
     U32 codePage;      /* codepage of DBF_FLDTYPE_CHAR fields */
 } DBF_HEADER, *DBF_HEADER_PTR;
 
 typedef struct _dbf_field
 {
-    U32 len;         /* total len of field in bytes */
+    U32 len;         /* total field length in bytes */
     U32 decimals;    /* count of decimal digits */
     U32 posInRecord; /* position of field in record */
     U8 type;         /* see DBF_FTYPE_XXX */


### PR DESCRIPTION
## Summary

- Clarifies DBF_HEADER recordSize wording.
- Expands DBF_FIELD len comment to total field length in bytes.
- No structure layout, parser, or compiled-code behavior changes.

## Review

- Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Copilot usage is tracked as request units; this run consumed 8 Copilot request units.
- Provider telemetry recorded 9 total calls and 205,632 total tokens.

## Verification

- Ran the sequential comments review workflow with full prompt and Copilot event logging.
- Materialized the approved draft into the delivery checkout after apply wrote only draft output.
- Manually inspected the final git diff for comment-only changes.
- Ran git diff --check for src/plugins/dbviewer/dbflib/dbflib.h.
- Reran comment guard against the delivery checkout; it passed for the touched file.
