### PR TITLE
[tanslation] Fix src/plugins/dbviewer/dbviewer.h comments

### DIFF
--- a/src/plugins/dbviewer/dbviewer.h
+++ b/src/plugins/dbviewer/dbviewer.h
@@ -109,7 +109,7 @@ enum CViewerWindowEnablerEnum
 class CViewerWindow : public CWindow
 {
 public:
-    HANDLE Lock; // 'lock' object or NULL (goes to the signaled state once the file is closed)
+    HANDLE Lock; // 'lock' object or NULL (becomes signaled only after the file is closed)
     CRendererWindow Renderer;
     int ConversionsCount; // number of conversions retrieved including "Don't convert"; without separators
     CCSVConfig CfgCSV;
@@ -124,7 +124,7 @@ public:
     HIMAGELIST HHotToolBarImageList;  // toolbar and menu in a colored variant
 
     DWORD Enablers[vweCount];
-    BOOL IsSrcFileSelected; // valid only if Enablers[vweSelSrcFile]==TRUE: TRUE/FALSE source file is selected/unselected
+    BOOL IsSrcFileSelected; // valid only if Enablers[vweSelSrcFile]==TRUE: TRUE/FALSE means the source file is selected/unselected
 
 public:
     CViewerWindow(int enumFilesSourceUID, int enumFilesCurrentIndex);


### PR DESCRIPTION
## Summary
- Refines two DBViewer header comments in `src/plugins/dbviewer/dbviewer.h`.
- Clarifies the lock object signal timing and the `IsSrcFileSelected` TRUE/FALSE contract.

## Verification
- `git diff --check -- src/plugins/dbviewer/dbviewer.h`
- `node --experimental-strip-types src/cli.ts guard --target-root /mnt/d/Source/OpenSal/salamander_janrysavy_delivery --translation-source /mnt/d/Source/OpenSal/salamander_janrysavy_delivery --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir artifacts/src-plugins-dbviewer-dbviewer-h-review-20260410-run1 --file src/plugins/dbviewer/dbviewer.h --review-provider auto --copilot-model gpt-5.4 --copilot-reasoning high --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --include-audit-only`
- Guard report passed in strict and ignore-whitespace modes with no non-comment changes detected.

## Model
- OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Provider telemetry: 2 calls, 45,159 total tokens, 2 Copilot request units.
