### PR TITLE
[tanslation] Fix src/plugins/dbviewer/parser.h comment

### DIFF
--- a/src/plugins/dbviewer/parser.h
+++ b/src/plugins/dbviewer/parser.h
@@ -26,7 +26,7 @@ bool IsUTF8Encoded(const char* s, int cnt);
 
 struct CFieldInfo
 {
-    char* Name;     // if NULL, the required length is stored into NameMax
+    char* Name;     // if Name is NULL, the required length is stored in NameMax
     int NameMax;    // if Name != NULL, specifies the buffer size (NameMax equals the number of characters plus the terminator)
     BOOL LeftAlign; // where the text should be aligned when displayed
     int TextMax;    // maximum number of characters shown in this column; -1 if unknown to the parser


### PR DESCRIPTION
## Summary
- Refines the `CFieldInfo::Name` comment in `src/plugins/dbviewer/parser.h`.
- Makes the NULL case explicit and uses clearer buffer-length wording.

## Verification
- `git diff --check -- src/plugins/dbviewer/parser.h`
- Windows-side `node --experimental-strip-types src\cli.ts guard ... --file src/plugins/dbviewer/parser.h`
- Guard completed with one checked file and zero violations.

## Model
- OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Provider telemetry: 2 calls, 36,454 total tokens, 2 Copilot request units.
