### PR TITLE
[tanslation] Fix src/plugins/dbviewer/dialogs.cpp comments

### DIFF
--- a/src/plugins/dbviewer/dialogs.cpp
+++ b/src/plugins/dbviewer/dialogs.cpp
@@ -815,9 +815,9 @@ void CFindDialog::Transfer(CTransferInfo& ti)
                     FIND_HISTORY_SIZE, FindHistory);
     /*
   if (ti.Type == ttDataToWindow)
-  { // initialize the searched text according to the selection in the viewer (parent of this dialog)
+  { // initialize the search text from the selection in the viewer (the parent of this dialog)
     CWindowsObject *win = WindowsManager.GetWindowPtr(Parent);
-    if (win != NULL && win->Is(otViewerWindow))  // double-check that this is a viewer window
+    if (win != NULL && win->Is(otViewerWindow))  // make sure this is a viewer window
     {
       CViewerWindow *view = (CViewerWindow *)win;
       char buf[FIND_TEXT_LEN];


### PR DESCRIPTION
## Summary
- Refines two comments in `src/plugins/dbviewer/dialogs.cpp`.
- Keeps the inactive sample block layout unchanged and applies only the approved comment wording.

## Verification
- `git diff --check -- src/plugins/dbviewer/dialogs.cpp`
- Windows-side `node --experimental-strip-types src\cli.ts guard ... --file src/plugins/dbviewer/dialogs.cpp`
- Guard completed with one checked file and zero violations.

## Model
- OpenAI GPT-5.4 through Codex and GitHub Copilot.
- Provider telemetry: 3 calls, 39,746 total tokens, 2 Copilot request units.
