### PR TITLE
[tanslation] Fix src/plugins/7zip/7zclient.h comments

### DIFF
--- a/src/plugins/7zip/7zclient.h
+++ b/src/plugins/7zip/7zclient.h
@@ -33,10 +33,10 @@
 #define S_ISLNK(m) (((m) & 0170000) == 0120000) /* symbolic link */
 #endif
 
-// three states for errors.
-// there are situations where TRUE/FALSE is not enough. we have an activity that can run into an error. sometimes we can
-// and want to continue the activity, other times we cannot. if we can continue we return OPER_CONTINUE,
-// if it cannot go on (out of memory, etc.) -> OPER_CANCEL. if everything is fine -> OPER_OK
+// three error states.
+// there are situations where TRUE/FALSE is not enough. we have an operation that can encounter an error. sometimes we can
+// and want to continue the operation, other times we cannot. if we can continue, we return OPER_CONTINUE,
+// if continuing is not possible (out of memory, etc.) -> OPER_CANCEL. if everything is OK -> OPER_OK
 #define OPER_OK 0
 #define OPER_CONTINUE 1
 #define OPER_CANCEL 2


### PR DESCRIPTION
## Summary

Refines the approved English comment translation in `src/plugins/7zip/7zclient.h`.

The change is limited to the `OPER_*` status comment and keeps the same behavior: `TRUE`/`FALSE` is insufficient, an operation may continue after some errors, `OPER_CONTINUE` means processing can proceed, `OPER_CANCEL` means continuing is impossible, and `OPER_OK` means no error occurred.

## Verification

- `git diff --check -- src/plugins/7zip/7zclient.h`
- Comment guard: strict and ignore-whitespace modes, 0 violations

## Model

OpenAI GPT-5.4 through Codex and GitHub Copilot.

## Provider Telemetry

- Total calls: 1
- Total tokens: 2,526
- Input tokens: 0
- Output tokens: 0
- Cache read input tokens: 0
- Copilot request units: 0
- Estimated cost: $0.00
