### PR TITLE
[tanslation] Fix src/plugins/7zip/7zthreads.cpp comments

### DIFF
--- a/src/plugins/7zip/7zthreads.cpp
+++ b/src/plugins/7zip/7zthreads.cpp
@@ -126,7 +126,7 @@ HRESULT LaunchAndDo7ZipTask(LPTHREAD_START_ROUTINE threadProc, LPVOID args)
 
             GetExitCodeThread(hThread, &exitCode);
             CloseHandle(hThread);
-            return exitCode; // Our thread body func returns HRESULT
+            return exitCode; // Our thread body function returns HRESULT
         }
 
         MSG msg;
@@ -155,9 +155,9 @@ HRESULT DoDecompress(CSalamanderForOperationsAbstract* salamander, CDecompressPa
 
         if (FAILED(result) && ((FACILITY_WIN32 << 16) == (result & 0x7FFF0000)))
         {
-            // LastError error encoded into HRESULT
-            // There is something strange: E_OUTOFMEMORY as 0x8007000EL prints as "Not enough storage is available to complete this operation"
-            // even when not truncated to 16 bits while 0x80000002L prints as "Ran out of memory"
+            // LastError encoded as HRESULT
+            // Oddly, E_OUTOFMEMORY as 0x8007000EL prints as "Not enough storage is available to complete this operation"
+            // even without truncating to 16 bits, while 0x80000002L prints as "Ran out of memory"
             SysError(label, (result == E_OUTOFMEMORY) ? 0x80000002L : (result & 0xFFFF), FALSE);
         }
         else


### PR DESCRIPTION
## Summary

Refines approved English comment translations in `src/plugins/7zip/7zthreads.cpp`.

The change expands an abbreviated thread-body comment and rewrites the HRESULT/LastError explanation in natural technical English while preserving the E_OUTOFMEMORY distinction used by the code.

## Verification

- `git diff --check -- src/plugins/7zip/7zthreads.cpp`
- Comment guard: strict and ignore-whitespace modes, 0 violations

## Model

OpenAI GPT-5.4 through Codex and GitHub Copilot.

## Provider Telemetry

- Total calls: 2
- Total tokens: 27,580
- Input tokens: 13,605
- Output tokens: 944
- Cache read input tokens: 9,728
- Copilot request units: 2
- Estimated cost: $0.00
