### PR TITLE
[tanslation] Fix src/plugins/7zip/dialogs.cpp comments

### DIFF
--- a/src/plugins/7zip/dialogs.cpp
+++ b/src/plugins/7zip/dialogs.cpp
@@ -389,7 +389,7 @@ CCompressParamsDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SetComboCurSelData(GetDlgItem(HWindow, IDCfgDictSize), CompressParams->DictSize);
         SetComboCurSelData(GetDlgItem(HWindow, IDCfgWordSize), CompressParams->WordSize);
 
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc handle focus
     }
 
     case WM_COMMAND:
@@ -434,7 +434,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontally and vertically center the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc handle focus
 
     case WM_COMMAND:
         break;
@@ -483,7 +483,7 @@ CConfigurationDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         EnableWindow(GetDlgItem(HWindow, IDC_CFG_LISTINFOMETHOD), Cfg.ExtendedListInfo);
 
         CompressParamsDlg.HWindow = HWindow;
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc handle focus
     }
 
     case WM_COMMAND:
@@ -580,7 +580,7 @@ CExtOptionsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         CompressParamsDlg.HWindow = HWindow;
 
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc handle focus
     }
 
     case WM_COMMAND:
@@ -666,7 +666,7 @@ CEnterPasswordDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_COMMAND:
     {
         /*
-      // preparation for skip and skip_all
+      // support for skip and skip_all
       switch (LOWORD(wParam))
       {
         case IDC_SKIP: return EndDialog(HWindow, DIALOG_SKIP);


### PR DESCRIPTION
## Summary

Refines approved English comment translations in `src/plugins/7zip/dialogs.cpp`.

The change replaces repeated `DefDlgProc` focus comments with clearer wording and changes the inactive `skip` / `skip_all` preparation note to support wording. Final review preserved the original indentation of the commented-out skip block to avoid unrelated formatting churn.

## Verification

- `git diff --check -- src/plugins/7zip/dialogs.cpp`
- Comment guard: strict and ignore-whitespace modes, 0 violations

## Model

OpenAI GPT-5.4 through Codex and GitHub Copilot.

## Provider Telemetry

- Total calls: 4
- Total tokens: 39,762
- Input tokens: 14,807
- Output tokens: 2,287
- Cache read input tokens: 9,344
- Copilot request units: 2
- Estimated cost: $0.00
