### PR TITLE
[tanslation] Fix src/plugins/7zip/extract.h comments

### DIFF
--- a/src/plugins/7zip/extract.h
+++ b/src/plugins/7zip/extract.h
@@ -99,7 +99,7 @@ private:
         Cancel
     };
     // behavior of the callback when a data error occurs
-    BOOL DataErrorSilent; // whether to ask about Keep or Delete
+    BOOL DataErrorSilent; // whether to prompt for Keep or Delete
     EOperationMode DataErrorMode;
     BOOL DataErrorDeleteSilent; // report an error when deleting
     BOOL SilentDelete;


### PR DESCRIPTION
## Summary

Refines an approved English comment translation in `src/plugins/7zip/extract.h`.

The change updates the `DataErrorSilent` field comment from asking about Keep/Delete to prompting for Keep/Delete, which better describes the user-facing callback behavior.

## Verification

- `git diff --check -- src/plugins/7zip/extract.h`
- Comment guard: strict and ignore-whitespace modes, 0 violations

## Model

OpenAI GPT-5.4 through Codex and GitHub Copilot.

## Provider Telemetry

- Total calls: 2
- Total tokens: 38,255
- Input tokens: 12,057
- Output tokens: 624
- Cache read input tokens: 8,704
- Copilot request units: 2
- Estimated cost: $0.00
