### PR TITLE
[tanslation] Fix src/plugins/7zip/7za/c/7z.h comments

### DIFF
--- a/src/plugins/7zip/7za/c/7z.h
+++ b/src/plugins/7zip/7za/c/7z.h
@@ -173,11 +173,11 @@ UInt16 *SzArEx_GetFullNameUtf16_Back(const CSzArEx *p, size_t fileIndex, UInt16 
 SRes SzArEx_Extract(
     const CSzArEx *db,
     ILookInStream *inStream,
-    UInt32 fileIndex,         /* index of file */
-    UInt32 *blockIndex,       /* index of solid block */
+    UInt32 fileIndex,         /* file index */
+    UInt32 *blockIndex,       /* solid block index */
     Byte **outBuffer,         /* pointer to pointer to output buffer (allocated with allocMain) */
-    size_t *outBufferSize,    /* buffer size for output buffer */
-    size_t *offset,           /* offset of stream for required file in *outBuffer */
+    size_t *outBufferSize,    /* size of the output buffer */
+    size_t *offset,           /* offset of the required file stream in *outBuffer */
     size_t *outSizeProcessed, /* size of file in *outBuffer */
     ISzAlloc *allocMain,
     ISzAlloc *allocTemp);


### PR DESCRIPTION
## Summary

Refines approved English comment translations in `src/plugins/7zip/7za/c/7z.h`.

The change tightens `SzArEx_Extract` parameter comments by using direct file and solid-block index wording, describing the output-buffer size naturally, and clarifying that `offset` points to the required file stream inside `*outBuffer`.

## Verification

- `git diff --check -- src/plugins/7zip/7za/c/7z.h`
- Comment guard: strict and ignore-whitespace modes, 0 violations

## Model

OpenAI GPT-5.4 through Codex and GitHub Copilot.

## Provider Telemetry

- Total calls: 3
- Total tokens: 61,762
- Input tokens: 30,885
- Output tokens: 4,227
- Cache read input tokens: 22,400
- Copilot request units: 4
- Estimated cost: $0.00
