### PR TITLE
[tanslation] Fix src/plugins/7zip/7za/c/7zDec.c comments

### DIFF
--- a/src/plugins/7zip/7za/c/7zDec.c
+++ b/src/plugins/7zip/7za/c/7zDec.c
@@ -412,7 +412,7 @@ static SRes SzFolder_Decode2(const CSzFolder *folder,
         }
         else if (ci == 2)
         {
-          if (unpackSize > outSize) /* check it */
+          if (unpackSize > outSize) /* check size */
             return SZ_ERROR_PARAM;
           tempBuf3 = outBufCur = outBuffer + (outSize - (size_t)unpackSize);
           tempSize3 = outSizeCur = (SizeT)unpackSize;


### PR DESCRIPTION
## Summary

- Refines one English comment in `src/plugins/7zip/7za/c/7zDec.c`.
- Changes a vague size-check note from `check it` to `check size`.
- Leaves the surrounding decompression logic unchanged.

## Verification

- `git diff --check -- src/plugins/7zip/7za/c/7zDec.c`
- Windows-side comment guard: `guard complete: 1 files, 0 violations`

## Review Artifacts

- Artifacts: `artifacts/src-plugins-7zip-7za-c-7zdec-c-review-20260410-run1`
- Provider calls: 2
- Provider tokens: 4721
