### PR TITLE
[tanslation] Fix src/plugins/demoplug/demoplug.h comments

### DIFF
--- a/src/plugins/demoplug/demoplug.h
+++ b/src/plugins/demoplug/demoplug.h
@@ -330,7 +330,7 @@ public:
 
     DWORD Enablers[vweCount];
 
-    HWND HRebar; // holds the menu bar and toolbar
+    HWND HRebar; // holds MenuBar and ToolBar
     CGUIMenuPopupAbstract* MainMenu;
     CGUIMenuBarAbstract* MenuBar;
     CGUIToolBarAbstract* ToolBar;
@@ -420,7 +420,7 @@ public:
 
     void Set(const char* fileName, DWORD progress, BOOL dalayedPaint);
 
-    // empties the message queue (call often enough) and allows repainting, handling Cancel, ...
+    // empties the message queue (call often enough), allows repainting, and handles Cancel presses
     // returns TRUE if the user wants to interrupt the operation
     BOOL GetWantCancel();
 


### PR DESCRIPTION
## Summary
- Update two comments in `src/plugins/demoplug/demoplug.h`.
- Preserve explicit `MenuBar` / `ToolBar` member naming and clarify Cancel handling in the delete progress dialog comment.

## Verification
- Ran the upstream-main sequential comment review for this file.
- Re-ran Windows-side comment guard against the delivery checkout with zero violations.
- Manually inspected the final git diff to confirm only comment text changed.

Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
