### PR TITLE
[tanslation] Fix src/plugins/demoplug/fs1.cpp comments

### DIFF
--- a/src/plugins/demoplug/fs1.cpp
+++ b/src/plugins/demoplug/fs1.cpp
@@ -471,9 +471,9 @@ void CTopIndexMem::Push(const char* path, int topIndex)
         ok = s - path == l && SalamanderGeneral->StrNICmp(path, Path, l) == 0;
     }
 
-    if (ok) // it follows -> remember the next top index
+    if (ok) // path follows -> remember the next top index
     {
-        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // need to remove the first top index from memory
+        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // discard the first stored top index
         {
             int i;
             for (i = 0; i < TOP_INDEX_MEM_SIZE - 1; i++)
@@ -515,13 +515,13 @@ BOOL CTopIndexMem::FindAndPop(const char* path, int& topIndex)
             topIndex = TopIndexes[--TopIndexesCount];
             return TRUE;
         }
-        else // we no longer have this value (it was not stored or low memory discarded it)
+        else // we no longer have this value (it was not stored or was discarded due to low memory)
         {
             Clear();
             return FALSE;
         }
     }
-    else // request for another path -> clear the memory, a long jump occurred
+    else // request for a different path -> clear memory; a long jump occurred
     {
         Clear();
         return FALSE;


### PR DESCRIPTION
## Summary
- Update four comments in `src/plugins/demoplug/fs1.cpp`.
- Clarify `CTopIndexMem` path continuation, bounded buffer discard behavior, low-memory discard wording, and different-path reset handling.

## Verification
- Ran the upstream-main sequential comment review for this file.
- Re-ran Windows-side comment guard against the delivery checkout with zero violations.
- Manually inspected the final git diff to confirm only comment text changed.

Model: OpenAI GPT-5.4 through Codex and GitHub Copilot.
