### PR TITLE
[tanslation] Fix src/plugins/demoplug/menu.cpp comments

### DIFF
--- a/src/plugins/demoplug/menu.cpp
+++ b/src/plugins/demoplug/menu.cpp
@@ -111,7 +111,7 @@ void WINAPI DEMOPLUGOperationFromDisk(const char* sourcePath, SalEnumSelection2 
     while ((name = next(data->Parent, 3, &dosName, &isDir, &size, &attr, &lastWrite,
                         nextParam, &errorOccured)) != NULL)
     {
-        if (errorOccured == SALENUM_ERROR) // SALENUM_CANCEL cannot arrive here
+        if (errorOccured == SALENUM_ERROR) // SALENUM_CANCEL cannot occur here
             data->Success = FALSE;
         if (!isDir)
             totalSize += size;
@@ -493,7 +493,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
           {
             break;
           }
-          else UpdateWindow(waitWndParent);  // avoid staring at leftover message box contents
+          else UpdateWindow(waitWndParent);  // redraw the parent window to remove message box remnants
           SalamanderGeneral->ShowSafeWaitWindow(TRUE);
         }
       }
@@ -501,7 +501,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
 */
 
         /*
-      // password mananger
+      // password manager
       CSalamanderPasswordManagerAbstract *passwordManager = NULL;
       passwordManager = SalamanderGeneral->GetSalamanderPasswordManager();
       if (passwordManager != NULL)
@@ -530,11 +530,11 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
           if (passwordManager->DecryptPassword(encryptedPassword, encryptedPasswordSize, &decryptedPassword))
           {
             TRACE_I("Decrypted password: " << decryptedPassword);
-            memset(decryptedPassword, 0, lstrlen(decryptedPassword));  // clear memory with plain password
+            memset(decryptedPassword, 0, lstrlen(decryptedPassword));  // clear the memory containing the plain text password
             SalamanderGeneral->Free(decryptedPassword);
           }
 
-          if (!encrypt) memset(encryptedPassword, 0, encryptedPasswordSize);  // clear memory with scrambled password
+          if (!encrypt) memset(encryptedPassword, 0, encryptedPasswordSize);  // clear the memory containing the scrambled password
           SalamanderGeneral->Free(encryptedPassword);
         }
       }
@@ -759,7 +759,7 @@ CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstract* sa
                         {
                             if (!filePath)
                             {
-                                // error - expected a file path, not a directory
+                                // error - expected a directory path, but found a file
                                 SalamanderGeneral->SalMessageBox(parent, "Unable to create the path specified, name has already been used for a file.",
                                                                  "Path Error", MB_OK | MB_ICONEXCLAMATION);
                                 continue; // ask again


### PR DESCRIPTION
Refines reviewed English comments in `src/plugins/demoplug/menu.cpp`.

This PR keeps the file's code and disabled sample formatting intact. It only updates selected comment text where the review found a clear wording or meaning issue:

- replaces a literal `SALENUM_CANCEL` calque with idiomatic technical wording;
- describes the wait-window `UpdateWindow` call in neutral redraw terms;
- fixes the `password manager` typo and clarifies password-buffer wiping comments;
- corrects the path error note so it says a directory path was expected but a file was found.

Verification:

- Ran the Windows-side comment guard for `src/plugins/demoplug/menu.cpp`.
- Guard result: 1 file checked, 0 violations.
