### PR TITLE
[tanslation] Fix src/plugins/demoview/demoview.h comments

### DIFF
--- a/src/plugins/demoview/demoview.h
+++ b/src/plugins/demoview/demoview.h
@@ -140,7 +140,7 @@ protected:
 class CViewerWindow : public CWindow
 {
 public:
-    HANDLE Lock;                      // 'lock' object or NULL (set to the signaled state once we close the file)
+    HANDLE Lock;                      // 'lock' object or NULL (set to the signaled state after the file is closed)
     char Name[MAX_PATH];              // file name or ""
     CRendererWindow Renderer;         // viewer inner window
     HIMAGELIST HGrayToolBarImageList; // toolbar and menu in the gray variant (computed from the colored one)
@@ -154,7 +154,7 @@ public:
     CGUIToolBarAbstract* ToolBar;
 
     int EnumFilesSourceUID;    // source UID for enumerating files in the viewer
-    int EnumFilesCurrentIndex; // index of the current viewer file within the source
+    int EnumFilesCurrentIndex; // index of the current file in the viewer within the source
 
 public:
     CViewerWindow(int enumFilesSourceUID, int enumFilesCurrentIndex);


### PR DESCRIPTION
Refines reviewed English comments in `src/plugins/demoview/demoview.h`.

The patch updates comments only. It clarifies when the viewer lock is signaled and makes the current-file index description less ambiguous.

Verification:

- Ran the branch-target sequential review for `src/plugins/demoview/demoview.h`.
- Manually materialized the accepted draft changes into the target checkout.
- Re-ran the Windows-side comment guard.
- Guard result: 1 file checked, 0 violations.
