### PR TITLE
[tanslation] Fix src/plugins/demoview/dialogs.cpp comments

### DIFF
--- a/src/plugins/demoview/dialogs.cpp
+++ b/src/plugins/demoview/dialogs.cpp
@@ -36,7 +36,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontally and vertically center the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // want focus from DefDlgProc
+        break; // let DefDlgProc handle focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -98,7 +98,7 @@ protected:
             break;
         }
 
-        case WM_APP + 1000: // we should detach from the dialog (already centered)
+        case WM_APP + 1000: // detach from the dialog (it is already centered)
         {
             DetachWindow();
             delete this; // a bit of a hack, but nobody will touch 'this' anymore, so it's fine


### PR DESCRIPTION
Refines reviewed English comments in `src/plugins/demoview/dialogs.cpp`.

The patch updates comments only. It clarifies the DefDlgProc focus handoff and simplifies the delayed detach message comment.

Verification:

- Ran the branch-target sequential review for `src/plugins/demoview/dialogs.cpp`.
- Manually materialized the accepted draft changes into the target checkout.
- Re-ran the Windows-side comment guard.
- Guard result: 1 file checked, 0 violations.
