### PR TITLE
[tanslation] Fix src/plugins/demoview/thumbldr.cpp comments

### DIFF
--- a/src/plugins/demoview/thumbldr.cpp
+++ b/src/plugins/demoview/thumbldr.cpp
@@ -12,7 +12,7 @@
 #include "precomp.h"
 
 // opens the specified file and converts it into a sequence of DWORDs
-// that is, 24 bits for color (R, G, B) and 8 bits of padding
+// i.e. 24 bits for color (R, G, B) and 8 unused bits
 // the size of a single row in bytes is: image_width * sizeof(DWORD)
 
 DWORD GetClrUsed(const BITMAPINFOHEADER* bih, BOOL max)
@@ -29,7 +29,7 @@ DWORD GetClrUsed(const BITMAPINFOHEADER* bih, BOOL max)
     case 8:
         return 256;
     default:
-        return 0; // A 24 or 32 bitcount DIB has no color table
+        return 0; // A 24-bit or 32-bit DIB has no color table
     }
 }
 
@@ -147,7 +147,7 @@ CPluginInterfaceForThumbLoader::LoadThumbnail(const char* filename,
                                               BOOL fastThumbnail)
 {
     BOOL stopFurtherLoaders = TRUE; // don't try next parsers
-    // we must call thumbMaker->SetError() when error occures and stopFurtherLoaders is TRUE
+    // we must call thumbMaker->SetError() when an error occurs and stopFurtherLoaders is TRUE
 
     // open the file
     HANDLE hFile = HANDLES_Q(CreateFile(filename, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
@@ -194,7 +194,7 @@ CPluginInterfaceForThumbLoader::LoadThumbnail(const char* filename,
                                 processTopDown = TRUE;
                                 height *= -1;
                             }
-                            // pass picture format to Open Salamander
+                            // pass image parameters to Open Salamander
                             if (thumbMaker->SetParameters(width, height, processTopDown ? 0 : SSTHUMB_MIRROR_VERT))
                             {
                                 LOGPALETTE* palette = NULL;


### PR DESCRIPTION
Refines reviewed English comments in `src/plugins/demoview/thumbldr.cpp`.

The patch updates comments only. It clarifies the DWORD pixel layout, uses standard 24/32-bit DIB terminology, fixes a small grammar typo, and describes the thumbnail parameter handoff more accurately.

Verification:

- Ran the branch-target sequential review for `src/plugins/demoview/thumbldr.cpp`.
- Manually materialized the accepted draft changes into the target checkout.
- Re-ran the Windows-side comment guard.
- Guard result: 1 file checked, 0 violations.
