### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/GUI.DirectoryLine.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/GUI.DirectoryLine.h
+++ b/src/plugins/diskmap/DiskMap/GUI.DirectoryLine.h
@@ -278,7 +278,7 @@ protected:
                     int rp = p;
                     int miswidth = pathwidth - width + this->_dotsWidth + dx[p - 1];
 
-                    dx[strlen] = miswidth; //stopper
+                    dx[strlen] = miswidth; //sentinel
                     while (miswidth > dx[rp])
                         rp++;
 


### PR DESCRIPTION
Updates one English comment translation in src/plugins/diskmap/DiskMap/GUI.DirectoryLine.h.

Reviewed against Czech baseline OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b. The branch-target guard was rerun for one file and reported zero violations.
