### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/System.Lock.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/System.Lock.h
+++ b/src/plugins/diskmap/DiskMap/System.Lock.h
@@ -15,7 +15,7 @@ public:
     }
     BOOL TryEnter()
     {
-        return InterlockedExchange(&this->_lock, 1) == 0; // before writing, 0 means acquire the lock; otherwise it was already locked (1)
+        return InterlockedExchange(&this->_lock, 1) == 0; // before the write, 0 means the lock was acquired; otherwise it was already locked (1)
     }
     void Enter()
     {


### PR DESCRIPTION
Updates one lock-state comment in src/plugins/diskmap/DiskMap/System.Lock.h.

Reviewed against baseline OpenSalamander/salamander@a28afcb958578dd219311a7b500320b162de812b. The branch-target guard was rerun for one file and reported zero violations.
