### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/System.WorkerThread.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/System.WorkerThread.h
+++ b/src/plugins/diskmap/DiskMap/System.WorkerThread.h
@@ -18,7 +18,7 @@ class CMyThreadQueue : public CThreadQueue
 public:
     CMyThreadQueue(const char* queueName /* e.g., "DemoPlug Viewers" */) : CThreadQueue(queueName) {}
 
-    void Add(HANDLE hThread, DWORD tid) // adds an item to the queue, returns success
+    void Add(HANDLE hThread, DWORD tid) // adds an item to the queue
     {
         CS.Enter();
         CThreadQueue::Add(new CThreadQueueItem(hThread, tid)); // cannot fail
@@ -108,22 +108,22 @@ public:
         this->_lock = new CLock();
         this->_rwlock = new CRWLock();
 
-        this->_doDelete = FALSE; // the thread may finish before CreateThread() returns, so postpone deletion
+        this->_doDelete = FALSE; // the thread may finish before CreateThread() returns, so postpone deleting the object
 
         this->_hThread = CreateThread(
             NULL,                               // default security attributes
             0,                                  // use default stack size
             CWorkerThread::s_ThreadProc,        // thread function
             this,                               // argument to thread function
-            (suspended) ? CREATE_SUSPENDED : 0, // use default creation flags
-            &this->_threadId);                  // returns the thread identifier
+            (suspended) ? CREATE_SUSPENDED : 0, // creation flags
+            &this->_threadId);                  // receives the thread identifier
 
         if (this->_hThread != NULL)
             ThreadQueue.Add(this->_hThread, this->_threadId);
         else
             this->_finished = TRUE; // the thread failed to start = act as if it has already finished
         if (selfDelete)
-            this->SetSelfDelete(selfDelete); // deletion of the object is now possible
+            this->SetSelfDelete(selfDelete); // the object can now be deleted
     }
     ~CWorkerThread()
     {
@@ -144,7 +144,7 @@ public:
     CLock* GetLock() { return this->_lock; }
     CRWLock* GetRWLock() { return this->_rwlock; }
 
-    void SetSelfDelete(BOOL selfDelete) //after calling with TRUE, references to the object are unsafe and it may be destroyed at any time
+    void SetSelfDelete(BOOL selfDelete) // after calling with TRUE, the object may be destroyed at any time, so references to it are unsafe
     {
         this->_innerlock->Enter();
         if (this->_doDelete != selfDelete)
@@ -155,11 +155,11 @@ public:
             }
             else //if the thread has already finished
             {
-                if (selfDelete) //wants to delete me, so delete...
+                if (selfDelete) // wants to delete this object, so delete it...
                 {
                     this->_innerlock->Leave(); //first release the lock
                     delete this;               //destroy ourselves
-                    return;                    //and exit quickly
+                    return;                    // return immediately
                 }
             }
         }


### PR DESCRIPTION
Refines translated comments in src/plugins/diskmap/DiskMap/System.WorkerThread.h.

Model: OpenAI GPT-5.4

Verification: full OSTranslation sequential review with prompt-log-mode full, copilot-event-log full, clang AST grounding, review-provider auto, Copilot SDK gpt-5.4 reasoning high; 36 comment units, 36 review results, 36 resolved results, 36 apply results; branch-target guard passed strict and ignore-whitespace with 0 violations and 0 preprocessing failures; git diff --check passed.

Telemetry: 9 provider calls and 131298 estimated tokens total. Codex-family: 8 calls and 98893 estimated tokens. Copilot SDK: 1 call, 32405 estimated tokens, 17225 input tokens, 2764 output tokens, 2 Copilot request units. Copilot billing in this workflow is request-unit based, not token-priced.