### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.CDiskMap.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.CDiskMap.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.CDiskMap.h
@@ -551,7 +551,7 @@ public:
     BOOL ZoomOut()
     {
         if (this->_viewdir == NULL)
-            return FALSE; //if it is not null, the root should not be null either
+            return FALSE; //if _viewdir is not NULL, _rootdir should not be NULL either
         if (this->_viewdir != this->_rootdir)
         {
             this->_viewdir = this->_viewdir->GetParent();
@@ -585,7 +585,7 @@ public:
         this->_rootdir = NULL;
         this->_populateworker = NULL;
         wrk->SetSelfDelete(TRUE);
-        wrk->Abort(TRUE); //TODO: do I really want to wait?
+        wrk->Abort(TRUE); //TODO: should this really wait?
         return TRUE;
     }
 


### PR DESCRIPTION
Refines translated comments in src/plugins/diskmap/DiskMap/TreeMap.CDiskMap.h.

Model: OpenAI GPT-5.4

Verification: full OSTranslation sequential review with prompt-log-mode full, copilot-event-log full, clang AST grounding, review-provider auto, Copilot SDK gpt-5.4 reasoning high; 49 comment units, 49 review results, 49 resolved results, 49 apply results; branch-target guard passed strict and ignore-whitespace with 0 violations and 0 preprocessing failures; git diff --check passed.

Telemetry: 3 provider calls and 73308 estimated tokens total. Codex-family: 1 call and 21146 estimated tokens. Copilot SDK: 2 calls, 52162 estimated tokens, 30903 input tokens, 2315 output tokens, 4 Copilot request units. Copilot billing in this workflow is request-unit based, not token-priced.