### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDirectoryOverlay.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDirectoryOverlay.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDirectoryOverlay.h
@@ -420,7 +420,7 @@ protected:
                         else //text pixel
                         {
                             if (tx > titlewidth)
-                                titlewidth = tx; //extend the maximum text length
+                                titlewidth = tx; //extend the maximum text width
 
                             txt_data[cxp] = 0xff; //text pixel will be white
 
@@ -429,7 +429,7 @@ protected:
                                 for (int px = 0; px < 4; px++)
                                 {
                                     if ((px == 0) && (py == 0))
-                                        continue; //no need for the center
+                                        continue; //center pixel not needed
 
                                     int txa = CDirectoryOverlay_shadowdata[py * 4 + px];
                                     if (tx - px > 0)


### PR DESCRIPTION
Refines translated comments in src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDirectoryOverlay.h.

Model: OpenAI GPT-5.4

Verification: full OSTranslation sequential review with prompt-log-mode full, copilot-event-log full, clang AST grounding, review-provider auto, Copilot SDK gpt-5.4 reasoning high; 61 comment units, 61 review results, 61 resolved results, 61 apply results; branch-target guard passed strict and ignore-whitespace with 0 violations and 0 preprocessing failures; git diff --check passed.

Telemetry: 3 provider calls and 74418 estimated tokens total. Codex-family: 1 call and 19636 estimated tokens. Copilot SDK: 2 calls, 54782 estimated tokens, 31454 input tokens, 1824 output tokens, 4 Copilot request units. Copilot billing in this workflow is request-unit based, not token-priced.