### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDiskMapOverlay.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDiskMapOverlay.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDiskMapOverlay.h
@@ -40,7 +40,7 @@ public:
     BOOL Paint(CZBitmap* pix, HDC refDC)
     {
         if (this->_selected == FALSE)
-            return TRUE; //ok, but nothing to draw
+            return TRUE; //nothing is drawn
 
         int width = pix->GetWidth();
         int height = pix->GetHeight();


### PR DESCRIPTION
Refines translated comments in src/plugins/diskmap/DiskMap/TreeMap.DiskMap.CDiskMapOverlay.h.

Model: OpenAI GPT-5.4

Verification: full OSTranslation sequential review with prompt-log-mode full, copilot-event-log full, clang AST grounding, review-provider auto, Copilot SDK gpt-5.4 reasoning high; 3 comment units, 3 review results, 3 resolved results, 3 apply results; branch-target guard passed strict and ignore-whitespace with 0 violations and 0 preprocessing failures; git diff --check passed.

Telemetry: 1 provider call and 19843 estimated tokens total. Copilot SDK: 1 call, 19843 estimated tokens, 12576 input tokens, 739 output tokens, 2 Copilot request units. Copilot billing in this workflow is request-unit based, not token-priced.