### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp
+++ b/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp
@@ -204,7 +204,7 @@ INT64 CZDirectory::PopulateDir(CWorkerThread* mythread, TCHAR* path, int pos, si
                         realsize = 0;
                         disksize = 0;
                     }
-                    else if (datasize == 0) //everything ok, but empty
+                    else if (datasize == 0) //no error, but empty
                     {
                         this->_dircount++;
                         dircount++;
@@ -294,7 +294,7 @@ INT64 CZDirectory::PopulateDir(CWorkerThread* mythread, TCHAR* path, int pos, si
                 this->_files->At(fre) = f;
             }
             //if (((filecount + dircount) > MAXREPORTEDFILES) || (GetTickCount() - lastTime > 500)) //either many files or 0.5 sec elapsed
-            if ((GetTickCount() - lastTime > 250) && (filecount + dircount) > 0) //if 0.25 sec elapsed and at least something new was found
+            if ((GetTickCount() - lastTime > 250) && (filecount + dircount) > 0) //if 0.25 sec have elapsed and at least something new was found
             {
                 this->_root->IncStats(filecount, dircount, tsize);
                 lastTime = GetTickCount();


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens two short implementation notes around the empty-directory path and the periodic progress-report condition.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, Copilot SDK model `gpt-5.4`, and `--copilot-reasoning high`.
- 29 comment units, 29 review results, 29 resolved results, and 29 apply results.
- Branch-target comment guard passed for `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/diskmap/DiskMap/TreeMap.FileData.CZDirectory.cpp` completed without diff integrity failures.

## Telemetry
- Total: 4 provider calls, 98802 estimated tokens.
- Codex-family: 1 call, 23219 estimated tokens.
- Copilot SDK: 3 calls, 75583 estimated tokens, 45239 input tokens, 3720 output tokens, 6 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
