### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp
+++ b/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp
@@ -10,7 +10,7 @@ size_t CZFile::GetFullName(TCHAR* buff, size_t size)
     size_t pos = 0;
     if (this->_parent)
         pos = this->_parent->GetFullName(buff, size);
-    if ((pos + this->_namelen + 1) < size) //pos = path + null terminator; total = path + ( '\\' + name length ) + null < size
+    if ((pos + this->_namelen + 1) < size) //pos = path + null terminator; total = path + ( '\\' + name length ) + null terminator < size
     {
         if (pos && buff[pos - 1] != TEXT('\\'))
         {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Clarifies that both occurrences in the length-check comment refer to the null terminator.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, Copilot SDK model `gpt-5.4`, and `--copilot-reasoning high`.
- 2 comment units, 2 review results, 2 resolved results, and 2 apply results.
- Branch-target comment guard passed for `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/diskmap/DiskMap/TreeMap.FileData.CZFile.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call, 28145 estimated tokens.
- Copilot SDK: 1 call, 28145 estimated tokens, 14990 input tokens, 2147 output tokens, 2 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
