### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h
@@ -5,8 +5,8 @@
 
 #include <xmmintrin.h>
 
-// precaution against runtime check failure in the debug version: the original macro casted RGB to WORD,
-// so it reported data loss (RED component)
+// precaution against a runtime check failure in the debug version: the original macro casts RGB to WORD,
+// so it reports data loss (RED component)
 #undef GetGValue
 #define GetGValue(rgb) ((BYTE)(((rgb) >> 8) & 0xFF))
 
@@ -126,7 +126,7 @@ public:
 
     BOOL Load(BYTE* dta, int size)
     {
-        if (size < 10) //10-byte header... 8 header + 2 version bytes
+        if (size < 10) //10-byte header... 8 header bytes + 2 version bytes
         {
             //_tcscpy(errbuff, TEXT("Internal error: Wrong data size"));
             //errlen = _tcslen(errbuff);
@@ -212,7 +212,7 @@ public:
         BYTE* aby = NULL;
         BOOL isAlpha = FALSE;
 
-        while (tbs + 4 <= end) // position + 4bytes chunk info
+        while (tbs + 4 <= end) // current position + 4-byte chunk info
         {
             mxc = *(unsigned short*)tbs;
             tbs += 2; //Chunk ID
@@ -242,7 +242,7 @@ public:
                 break;
             case 0x4645: //EF (end of file)
                 if (mxs != 0)
-                    return FALSE; //EF always empty!
+                    return FALSE; //EF must always be empty
                 EFfound = TRUE;
                 break;
             case 0x4642: //BF (fixed border info)
@@ -257,9 +257,9 @@ public:
                 fil = *(unsigned short*)tbs;
                 tbs += 2;
                 if (fit + fib > h)
-                    return FALSE; //fixed height is bigger then image height
+                    return FALSE; //fixed height exceeds image height
                 if (fir + fil > w)
-                    return FALSE; //fixed width is bigger then image width
+                    return FALSE; //fixed width exceeds image width
                 break;
             case 0x4144: //DA (Alpha channel)
                 tbd = aby;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens six technical notes around runtime-check wording, header byte counts, chunk parsing, the EF invariant, and fixed-border validation messages.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, Copilot SDK model `gpt-5.4`, and `--copilot-reasoning high`.
- 65 comment units, 65 review results, 65 resolved results, and 65 apply results.
- Branch-target comment guard passed for `src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/diskmap/DiskMap/TreeMap.Graphics.CCushionGraphics.h` completed without diff integrity failures.

## Telemetry
- Total: 5 provider calls, 128150 estimated tokens.
- Codex-family: 2 calls, 44637 estimated tokens.
- Copilot SDK: 3 calls, 83513 estimated tokens, 49059 input tokens, 4374 output tokens, 6 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
