### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.TreeData.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.TreeData.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.TreeData.h
@@ -157,7 +157,7 @@ public:
             return dirHorizontal;
             break;
         }
-        return dirNULL; //TODO: error!
+        return dirNULL; //TODO: bug
     }
     //virtual ERenderDecision Decide(CCushionRow *csr, double width, double length, int level, EDirection lastdir, INT64 datasize, INT64 remainingdata, int i, int remainingfiles)
     virtual ERenderDecision Decide(CCushionRow* csr, double width, double length, INT64 datasize, INT64 remainingdata) = 0;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/TreeMap.TreeData.h`.
- Keeps the change comment-only; no executable code was modified.
- Rewrites the fallback TODO note into a clearer defect label.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, Copilot SDK model `gpt-5.4`, and `--copilot-reasoning high`.
- 5 comment units, 5 review results, 5 resolved results, and 5 apply results.
- Branch-target comment guard passed for `src/plugins/diskmap/DiskMap/TreeMap.TreeData.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/diskmap/DiskMap/TreeMap.TreeData.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call, 24769 estimated tokens.
- Copilot SDK: 1 call, 24769 estimated tokens, 14194 input tokens, 1359 output tokens, 2 Copilot request units.
- Copilot billing in this workflow is request-unit based, not token-priced.
