### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/Utils.Array.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/Utils.Array.h
+++ b/src/plugins/diskmap/DiskMap/Utils.Array.h
@@ -92,7 +92,7 @@ public:
         {
             free(Blocks[_count / BlockSize]);
         }
-        if (!_count) //used them all
+        if (!_count) // all elements used up
         {
             free(Blocks);
             Blocks = NULL;
@@ -104,7 +104,7 @@ public:
         CDynamicArray * const &operator[](float index); // function is never called, but if it is missing
         // MSVC does terrible things
 	*/
-    DATA_TYPE& operator[](int index) //returns the element at the position
+    DATA_TYPE& operator[](int index) // returns the element at the given position
     {
         return Blocks[index / BlockSize][index % BlockSize];
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/Utils.Array.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the empty-state cleanup note and the indexing operator description.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode full`, `--copilot-event-log full`, AST grounding through clang, `--review-provider auto`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/diskmap/DiskMap/Utils.Array.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/diskmap/DiskMap/Utils.Array.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call, 20870 estimated tokens.
- Codex-family: 1 call, 20870 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
