### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h
+++ b/src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h
@@ -271,7 +271,7 @@ public:
         static const int maxexp = sizeof expch / sizeof TCHAR - 2;
         size_t len = 0;
         int exp = 0;
-        //C4244 ok: we only need the first few digits because we compute the short form "1.45TB"
+        //C4244 is OK: we only need the first few digits because we compute the short form "1,45TB"
         double rs = (double)(__int64)size;
         while (rs >= 1024 && exp < maxexp)
         {


### PR DESCRIPTION
## Summary
- update the translated C4244 explanatory comment in `src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h`
- align the short-size example with the localized comma decimal form already used in this branch
- keep the change comment-only with no runtime behavior impact

## Model
- `gpt-5.4` via the branch-target review workflow (`cheap-first`, `--include-audit-only`)

## Verification
- `CLANG_BIN=/usr/bin/clang-22 node --experimental-strip-types src/sequential-review.ts --target-root /mnt/d/Source/OpenSal/salamander_upstream --translation-source /mnt/d/Source/OpenSal/salamander_upstream --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir /mnt/d/source/ostranslation/artifacts/src-plugins-diskmap-diskmap-utils-cstringformatter-h-review-20260410-batch4 --file src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h --review-provider auto --copilot-model gpt-5.4 --copilot-reasoning high --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --include-audit-only`
- `cmd.exe /c "cd /d D:\source\ostranslation && set CLANG_BIN=C:\Program Files\LLVM\bin\clang.exe&& node --experimental-strip-types src\cli.ts guard --target-root D:\Source\OpenSal\salamander_janrysavy_delivery --translation-source D:\Source\OpenSal\salamander_janrysavy_delivery --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir D:\source\ostranslation\artifacts\src-plugins-diskmap-diskmap-utils-cstringformatter-h-review-20260410-batch4 --file src/plugins/diskmap/DiskMap/Utils.CStringFormatter.h --review-provider auto --copilot-model gpt-5.4 --copilot-reasoning high --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --include-audit-only"`
- inspected the delivery checkout diff to confirm a one-line comment-only change

## Telemetry
- provider calls: 2
- cumulative tokens: 42,361
- billing units: 2 Copilot request units
- files reviewed: 1
- comment units: 33
