### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h
+++ b/src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h
@@ -1,10 +1,10 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
 
-// The following ifdef block is the standard way of creating macros which make exporting
+// The following ifdef block is the standard way of creating macros that make exporting
 // from a DLL simpler. All files within this DLL are compiled with the ZAREVAKDISKMAPPLUGIN_EXPORTS
-// symbol defined on the command line. this symbol should not be defined on any project
-// that uses this DLL. This way any other project whose source files include this file see
+// symbol defined on the command line. This symbol should not be defined in any project
+// that uses this DLL. This way, any other project whose source files include this file sees
 // ZAREVAKDISKMAPPLUGIN_API functions as being imported from a DLL, whereas this DLL sees symbols
 // defined with this macro as being exported.
 


### PR DESCRIPTION
## Summary
- refine the standard DLL import/export explanation in `src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h`
- fix grammar, capitalization, and punctuation in the header comment block
- keep the change comment-only with no effect on exported symbols or runtime behavior

## Model
- `gpt-5.4` via the branch-target review workflow (`cheap-first`, `--include-audit-only`)

## Verification
- `CLANG_BIN=/usr/bin/clang-22 node --experimental-strip-types src/sequential-review.ts --target-root /mnt/d/Source/OpenSal/salamander_upstream --translation-source /mnt/d/Source/OpenSal/salamander_upstream --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir /mnt/d/source/ostranslation/artifacts/src-plugins-diskmap-diskmapplugin-diskmapplugin-h-review-20260411-batch7 --file src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h --review-provider auto --copilot-model gpt-5.4 --copilot-reasoning high --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --include-audit-only`
- `cmd.exe /c "cd /d D:\source\ostranslation && set CLANG_BIN=C:\Program Files\LLVM\bin\clang.exe&& node --experimental-strip-types src\cli.ts guard --target-root D:\Source\OpenSal\salamander_janrysavy_delivery --translation-source D:\Source\OpenSal\salamander_janrysavy_delivery --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir D:\source\ostranslation\artifacts\src-plugins-diskmap-diskmapplugin-diskmapplugin-h-review-20260411-batch7 --file src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.h --review-provider auto --copilot-model gpt-5.4 --copilot-reasoning high --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --include-audit-only"`
- inspected the delivery checkout diff to confirm a comment-only header change

## Telemetry
- provider calls: 1
- cumulative tokens: 24,215
- billing units: 2 Copilot request units
- files reviewed: 1
- comment units: 3
