### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp comments

### DIFF
--- a/src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp
+++ b/src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp
@@ -87,7 +87,7 @@ public:
         char focusPath[MAX_PATH];
         lstrcpyn(focusPath, FocusPathBuf, MAX_PATH);
         FocusPathBuf[0] = 0;
-        if (focusPath[0] != 0) // only if we were not unlucky (we did not hit the beginning of Salamander's BUSY mode)
+        if (focusPath[0] != 0) // only if we were not unlucky (that is, we did not hit the start of Salamander's BUSY mode)
         {
             LPTSTR name;
             if (SalamanderGeneral->CutDirectory(focusPath, &name))
@@ -104,7 +104,7 @@ public:
         char focusPath[MAX_PATH];
         lstrcpyn(focusPath, FocusPathBuf, MAX_PATH);
         FocusPathBuf[0] = 0;
-        if (focusPath[0] != 0) // only if we were not unlucky (we did not hit the beginning of Salamander's BUSY mode)
+        if (focusPath[0] != 0) // only if we did not enter at the start of Salamander's BUSY mode
         {
             SalamanderGeneral->SkipOneActivateRefresh(); // the main window will not refresh when switching from the viewer
             //SalamanderGeneral->ChangePanelPath(PANEL_SOURCE, focusPath);
@@ -212,8 +212,8 @@ RELOAD:
         if ((5000 - (act - buffer) == size + 1) && (act > buffer))
         {
             // if the string was exactly at the end of the buffer, it could
-            // be a truncated string -- if we can move the window
-            // to the beginning of the buffer, load the string once again
+            // have been truncated; if we can move the window
+            // to the beginning of the buffer, load the string again
             act = buffer;
             goto RELOAD;
         }
@@ -714,7 +714,7 @@ BOOL WINAPI CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperations
 
         //TODO: there should be a prompt asking the user for the path and confirming it...
 
-        if (curPathIsDisk) // 'path' is the path to a file/directory, perform the requested action with it
+        if (curPathIsDisk) // 'path' is the path to a file or directory; perform the requested action on it
         {
             //TRACE_I("Opening(" << curPath << ")." /*"): " << GetErrorText(error)*/);
             OpenDiskMapWindow(parent, curPath);
@@ -724,7 +724,7 @@ BOOL WINAPI CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperations
             //TRACE_I("Not disk.");
         }
 
-        return FALSE; // do not unselect items in the panel
+        return FALSE; // do not deselect items in the panel
     }
     default:
         SalamanderGeneral->ShowMessageBox("Unknown command.", "DEMOPLUG", MSGBOX_ERROR);


### PR DESCRIPTION
## Summary
- refine five translated comments in `src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp`
- improve the BUSY-mode wording, truncated-string reload explanation, path-action wording, and UI terminology
- keep the disabled trace lines unchanged after resolving them as explicit keep-target units in the apply artifact

## Model
- `gpt-5.4` via the branch-target review workflow (`cheap-first`, `--include-audit-only`)
- fallback run used reduced batching for this file: `--batch-size 8 --copilot-deep-batch-size 4`, `codex-reasoning medium`, `copilot-reasoning medium`

## Verification
- `CLANG_BIN=/usr/bin/clang-22 node --experimental-strip-types src/sequential-review.ts --target-root /mnt/d/Source/OpenSal/salamander_upstream --translation-source /mnt/d/Source/OpenSal/salamander_upstream --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir /mnt/d/source/ostranslation/artifacts/src-plugins-diskmap-diskmapplugin-diskmapplugin-cpp-review-20260411-batch8 --file src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp --review-provider auto --codex-model gpt-5.4 --codex-reasoning medium --copilot-model gpt-5.4 --copilot-reasoning medium --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --batch-size 8 --copilot-deep-batch-size 4 --include-audit-only`
- `node --experimental-strip-types src/cli.ts apply --target-root /mnt/d/Source/OpenSal/salamander_upstream --translation-source /mnt/d/Source/OpenSal/salamander_upstream --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir /mnt/d/source/ostranslation/artifacts/src-plugins-diskmap-diskmapplugin-diskmapplugin-cpp-review-20260411-batch8 --file src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp --review-provider auto --codex-model gpt-5.4 --codex-reasoning medium --copilot-model gpt-5.4 --copilot-reasoning medium --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --batch-size 8 --copilot-deep-batch-size 4 --include-audit-only`
- `cmd.exe /c "cd /d D:\source\ostranslation && set CLANG_BIN=C:\Program Files\LLVM\bin\clang.exe&& node --experimental-strip-types src\cli.ts guard --target-root D:\Source\OpenSal\salamander_janrysavy_delivery --translation-source D:\Source\OpenSal\salamander_janrysavy_delivery --baseline-source gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b --artifacts-dir D:\source\ostranslation\artifacts\src-plugins-diskmap-diskmapplugin-diskmapplugin-cpp-review-20260411-batch8 --file src/plugins/diskmap/DiskMapPlugin/DiskMapPlugin.cpp --review-provider auto --codex-model gpt-5.4 --codex-reasoning medium --copilot-model gpt-5.4 --copilot-reasoning medium --copilot-event-log full --prompt-log-mode full --cost-profile cheap-first --batch-size 8 --copilot-deep-batch-size 4 --include-audit-only"`
- fixed two disabled trace units in `resolved-results.jsonl` from `apply_rewrite` to `keep_target` before rerunning `apply` and `guard`
- inspected the delivery checkout diff to confirm comment-only changes in five locations

## Telemetry
- provider calls: 4
- cumulative tokens: 91,898
- billing units: 6 Copilot request units
- files reviewed: 1
- comment units: 114
