### PR TITLE
[translation] Fix src/plugins/filecomp/cwbase.cpp comments

### DIFF
--- a/src/plugins/filecomp/cwbase.cpp
+++ b/src/plugins/filecomp/cwbase.cpp
@@ -145,9 +145,9 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
                         while (++iterator < end && IsSpaceX(*iterator))
                             if (*iterator == '\n')
                                 line++, linebreaks++;
-                        // Whitespace containing one linebreak matches whitespace without
-                        // linebreaks. It is represented by ' ' in compare data.
-                        // Blank line matches any sequence of one or more blanklines. Blank
+                        // Whitespace containing one line break matches whitespace without
+                        // line breaks. It is represented by ' ' in compare data.
+                        // A blank line matches any sequence of one or more blank lines. A blank
                         // line can contain any whitespace. It is represented by '\n' in
                         // compare data.
                         Strict.CompareData[i].push_back(
@@ -203,13 +203,13 @@ void CFilecompCoWorkerBase<CChar>::ScrictCompare(
     if (d == -1)
         CFilecompWorker::CException::Raise(IDS_INTERNALERROR, 0);
 
-    // TODO once I implement strict mode this should be handled
+    // TODO once strict mode is implemented, this should be handled
     // if (d == 0)
 
     // shift-boundaries is called before RemoveSingleCharMatches
     ShiftBoundaries(Strict.EditScript, Strict.CompareData);
 
-    // remove sigle char matches
+    // remove single-char matches
     RemoveSingleCharMatches();
 
     // build line scripts
@@ -403,7 +403,7 @@ void CFilecompCoWorkerBase<CChar>::ShiftBoundaries(CEditScript& editScript, CCom
         for (CEditScript::iterator change = editScript.begin();
              change < editScript.end(); ++change)
         {
-            // ignore changes occured only in other file
+            // ignore changes that occurred only in the other file
             if (change->Length[f] == 0)
                 continue;
 


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/cwbase.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/cwbase.cpp against current upstream main at bb00bdb0207c764673769c0e0e39ff674454fbfa with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 50 comment units / 50 grounding records / 50 comment-semantics records / 50 review results / 50 resolved results / 50 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Source screening requests touching src/plugins/filecomp/cwbase.cpp: Codex 11 requests, 208,889 tokens; Copilot 0 requests, 0 tokens. Review reused 32 review-cache hits, 17 translation-memory hits (17 provider avoids), 1 deterministic resolution, 0 request batches.
