### PR TITLE
[translation] Fix src/plugins/filecomp/cwoptim.cpp comments

### DIFF
--- a/src/plugins/filecomp/cwoptim.cpp
+++ b/src/plugins/filecomp/cwoptim.cpp
@@ -232,11 +232,11 @@ void CFilecompCoWorkerOptimized<CChar>::Compare(CTextFileReader (&reader)[2])
             this->CancelFlag);
         if (d == -1)
             CFilecompWorker::CException::Raise(IDS_INTERNALERROR, 0);
-        /*  if (d == 0) We now let the file display
-    {
-      throw CFilecompWorker::CFilesDontDifferException();
-      }
-    }*/
+        /*  if (d == 0) We now let the file be displayed
+            {
+              throw CFilecompWorker::CFilesDontDifferException();
+              }
+            }*/
 
         // shift-boundaries, call before RemoveSingleCharMatches
         this->ShiftBoundaries(editScript, compareData);


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/cwoptim.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/cwoptim.cpp against current upstream main at e2be0b490afeeacd50968c93a6444779c65f17fd with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 36 comment units / 36 grounding records / 36 comment-semantics records / 36 review results / 36 resolved results / 36 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 2 requests total and 0 billing units. Codex 2 requests, 34,967 tokens; Copilot 0 requests, 0 tokens. Review reused 8 review-cache hits, 19 translation-memory hits (19 provider avoids), 2 deterministic resolutions, 2 request batches.
