### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs.cpp
+++ b/src/plugins/filecomp/dialogs.cpp
@@ -133,7 +133,7 @@ LRESULT CCompareFilesDialog::DragDropEditProc(HWND hWnd, UINT uMsg, WPARAM wPara
     CCompareFilesDialog* pParent = (CCompareFilesDialog*)WindowsManager.GetWindowPtr(GetParent(hWnd));
 
     if (!pParent)
-        return NULL; // What's wrong?
+        return NULL; // Parent dialog not found
 
     if (WM_DROPFILES == uMsg)
     {
@@ -170,7 +170,7 @@ CCompareFilesDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         SG->InstallWordBreakProc(hWnd1); // install WordBreakProc into the combo box
         SG->InstallWordBreakProc(hWnd2); // install WordBreakProc into the combo box
 
-        // I believe OldEditProc1 and OldEditProc2 are equal. But I am rather paranoic...
+        // OldEditProc1 and OldEditProc2 should be equal, but keep both separately to be safe.
         OldEditProc1 = (WNDPROC)GetWindowLongPtr(hWnd1, GWLP_WNDPROC);
         OldEditProc2 = (WNDPROC)GetWindowLongPtr(hWnd2, GWLP_WNDPROC);
         SetWindowLongPtr(hWnd1, GWLP_WNDPROC, (LONG_PTR)DragDropEditProc);


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/dialogs.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/dialogs.cpp against current upstream main at 65d119e068a2d6d27da642c6a304ace78e257b00 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 17 comment units / 17 grounding records / 17 comment-semantics records / 17 review results / 17 resolved results / 17 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Source screening requests touching src/plugins/filecomp/dialogs.cpp: Codex 3 requests, 69,220 tokens; Copilot 0 requests, 0 tokens. Review reused 6 review-cache hits, 9 translation-memory hits (9 provider avoids), 2 deterministic resolutions, 0 request batches.