### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs.h comments

### DIFF
--- a/src/plugins/filecomp/dialogs.h
+++ b/src/plugins/filecomp/dialogs.h
@@ -65,7 +65,7 @@ struct CColorsCfgButton
 {
     int TextID;         // button label identifier
     int ColorLineNumFG; // index of the FG color for the first button or -1 (FG cannot be configured)
-    int ColorLineNumBK; // index of the BG color for the first button or -1 (the button will not be visible)
+    int ColorLineNumBK; // index of the BK color for the first button or -1 (the button will not be visible)
     int ColorTextFG;    // index of the FG color for the second button or -1 (FG cannot be configured)
     int ColorTextBK;    // index of the BG color for the second button or -1 (the button will not be visible)
 };


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/dialogs.h.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/dialogs.h against current upstream main at 9a3f39d4df0a889fd8ca2949a6ea005bbabe8d5c with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 28 comment units / 28 grounding records / 28 comment-semantics records / 28 review results / 28 resolved results / 28 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,202 tokens; Copilot 0 requests, 0 tokens. Review reused 2 review-cache hits, 7 translation-memory hits (7 provider avoids), 14 deterministic resolutions, 1 request batch.
