### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs2.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs2.cpp
+++ b/src/plugins/filecomp/dialogs2.cpp
@@ -522,7 +522,7 @@ void CPreviewWindow::RePaint()
 void CPreviewWindow::SetFont(LOGFONT* font)
 {
     CALL_STACK_MESSAGE1("CPreviewWindow::SetFont()");
-    // load the font
+    // create the font
     if (HFont)
         DeleteObject(HFont);
     HDC hdc = GetDC(NULL);


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/dialogs2.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/dialogs2.cpp against current upstream main at d908b50f238cc4839dee157aabc326a17c18996c with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 80 comment units / 80 grounding records / 80 comment-semantics records / 80 review results / 80 resolved results / 80 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 2 requests total and 0 billing units. Codex 2 requests, 35,125 tokens; Copilot 0 requests, 0 tokens. Review reused 13 review-cache hits, 45 translation-memory hits (45 provider avoids), 5 deterministic resolutions, 2 request batches.
