### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs4.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -218,7 +218,7 @@ protected:
             break;
         }
 
-        case WM_APP + 1000: // we should detach from the dialog (centering is done)
+        case WM_APP + 1000: // detach from the dialog after centering
         {
             DetachWindow();
             delete this; // a bit of a hack, but nothing will touch 'this' anymore so it's fine


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/dialogs4.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/dialogs4.cpp against current upstream main at b05058caf95db8e87f633154ff968bcdce0f3d0b with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 19 comment units / 19 grounding records / 19 comment-semantics records / 19 review results / 19 resolved results / 19 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,080 tokens; Copilot 0 requests, 0 tokens. Review reused 6 review-cache hits, 10 translation-memory hits (10 provider avoids), 2 deterministic resolutions, 1 request batch.
