### PR TITLE
[translation] Fix src/plugins/filecomp/dlg_com.cpp comments

### DIFF
--- a/src/plugins/filecomp/dlg_com.cpp
+++ b/src/plugins/filecomp/dlg_com.cpp
@@ -88,7 +88,7 @@ CCommonDialog::CCommonDialog(int resID, HWND hParent, CObjectOrigin origin)
     {
         // horizontal and vertical centering of the dialog over the parent
         CenterWindow(HWindow);
-        break; // I want focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/dlg_com.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/dlg_com.cpp against current upstream main at de3f1eca8db5d4d60299b3ba1b66a90dfc0cd777 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 61 comment units / 61 grounding records / 61 comment-semantics records / 61 review results / 61 resolved results / 61 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,107 tokens; Copilot 0 requests, 0 tokens. Review reused 20 review-cache hits, 36 translation-memory hits (36 provider avoids), 4 deterministic resolutions, 1 request batch.
