### PR TITLE
[translation] Fix src/plugins/filecomp/filecomp.cpp comments

### DIFF
--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -317,7 +317,7 @@ void CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     }
 
     UpdateDefaultColors(Colors, Palette);
-    // Do not allow normalization if Normaliz.dll not present
+    // Do not allow normalization if Normaliz.dll is not present
     if (!PNormalizeString)
         DefCompareOptions.NormalizationForm = FALSE;
 }
@@ -689,7 +689,7 @@ CFilecompThread::Body()
         }
 
         if (!dialogBox || !succes)
-            break; // leave the message loop
+            break; // exit the message loop
 
     LLAUNCHFC:
 


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/filecomp.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/filecomp.cpp against current upstream main at 3a0cdb5c46c443055e544dfa6ce3421c075702e2 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 73 comment units / 73 grounding records / 73 comment-semantics records / 73 review results / 73 resolved results / 73 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 2 requests total and 0 billing units. Codex 2 requests, 34,413 tokens; Copilot 0 requests, 0 tokens. Review reused 27 review-cache hits, 20 translation-memory hits (20 provider avoids), 7 deterministic resolutions, 2 request batches.
