### PR TITLE
[translation] Fix src/plugins/filecomp/mainwnd.cpp comments

### DIFF
--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -705,7 +705,7 @@ BOOL CMainWindow::RebuildFileViewScripts(BOOL& cancel)
         SetForegroundWindow(HWindow);
         UpdateWindow(HWindow);
 
-        return TRUE; // ok
+        return TRUE; // success
     }
 
     // something went wrong
@@ -880,7 +880,7 @@ void CMainWindow::SpawnWorker(const char* path1, const char* path2,
         if (!worker->Create(ThreadQueue))
         {
             delete worker;
-            SetEvent(WorkerEvent); // so we do not wait for it in vain
+            SetEvent(WorkerEvent); // so we do not wait for it unnecessarily
             TRACE_I("Nepovedlo se spustit diff worker thread.");
         }
         else
@@ -962,8 +962,8 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     TTextFileViewWindow<CChar>* leftFileView = (TTextFileViewWindow<CChar>*)FileView[fviLeft];
     TTextFileViewWindow<CChar>* rightFileView = (TTextFileViewWindow<CChar>*)FileView[fviRight];
 
-    // taking ownership of the data; from now on I must release it
-    // passed in CTextCompareResults
+    // take ownership of the data; from now on it must be deallocated here
+    // when passed in CTextCompareResults
     leftFileView->SetData(res->Files[0].Text, res->Files[0].Lines, res->Files[0].LineScript);
     rightFileView->SetData(res->Files[1].Text, res->Files[1].Lines, res->Files[1].LineScript);
 
@@ -1076,7 +1076,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_TIMER:
     {
-        if (wParam == 666) // we should post CM_EXIT; the modal dialog should be gone by now
+        if (wParam == 666) // post CM_EXIT; the modal dialog should be gone by now
         {
             KillTimer(HWindow, 666);
             PostMessage(HWindow, WM_COMMAND, CM_EXIT, 0);
@@ -1167,7 +1167,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT state = GetMenuState(GetMenu(HWindow), CM_PREVDIFF, MF_BYCOMMAND);
             if (state & (MF_DISABLED | MF_GRAYED))
             {
-                if (DifferencesCount > 0) // Petr: when I scroll the view somewhere else I want Alt+Arrow to focus the difference (hunting it manually is a pain); with just one diff it did not work at all, otherwise only by jumping to next/previous
+                if (DifferencesCount > 0) // Petr: if the view is scrolled elsewhere, Alt+Arrow should focus the difference; with only one difference this did not work at all, otherwise it worked only by switching to next/previous
                     SelectDifference(SelectedDifference, CM_PREVDIFF);
                 return 0;
             }
@@ -1198,7 +1198,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT state = GetMenuState(GetMenu(HWindow), CM_NEXTDIFF, MF_BYCOMMAND);
             if (state & (MF_DISABLED | MF_GRAYED))
             {
-                if (DifferencesCount > 0) // Petr: when I scroll the view somewhere else I want Alt+Arrow to focus the difference (hunting it manually is a pain); with just one diff it did not work at all, otherwise only by jumping previous/next
+                if (DifferencesCount > 0) // Petr: when the view is scrolled away, Alt+Arrow should focus the difference (finding it manually is a pain); with only one difference, it did not work at all, otherwise it only worked by switching to previous/next
                     SelectDifference(SelectedDifference, CM_NEXTDIFF);
                 return 0;
             }
@@ -2228,10 +2228,11 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_ACTIVATEWINDOW:
     {
-        // if the window is disabled, a message box is likely sitting on top of it;
-        // bringing this window to the front would activate it (an issue in an older SS version
-        // where comparing identical files showed this window, then a message box about the match,
-        // and finally this message arrived, stealing focus from the box and activating the window underneath)
+        // if the window is disabled, a message box is likely displayed above it;
+        // bringing this window to the front would activate it (this happened in an older SS version
+        // when the user compared two identical files: this window appeared first,
+        // then a message box reporting the match popped up, and finally this message arrived,
+        // stealing focus from the message box and activating the window underneath)
         if (IsWindowEnabled(HWindow))
         {
             ShowWindow(HWindow, ShowCmd /*SW_SHOW*/);


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/mainwnd.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/mainwnd.cpp against current upstream main at b1c9725adcfcd0e76fc8299f0ee5c0107d07b692 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 130 comment units / 130 grounding records / 130 comment-semantics records / 130 review results / 130 resolved results / 130 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 4 requests total and 0 billing units. Codex 4 requests, 55,496 tokens; Copilot 0 requests, 0 tokens. Review reused 39 review-cache hits, 60 translation-memory hits (60 provider avoids), 6 deterministic resolutions, 4 request batches.
