### PR TITLE
[translation] Fix src/plugins/filecomp/mtxtout.cpp comments

### DIFF
--- a/src/plugins/filecomp/mtxtout.cpp
+++ b/src/plugins/filecomp/mtxtout.cpp
@@ -49,7 +49,7 @@ bool FontHasChangedX(CChar* ViewerFontMapping, HDC memDC, int fontWidth, int fon
             rect.bottom = fontHeight;
             // NOTE: GetCharWidth32 still returns the same width for all characters,
             // although DrawTextEx does not!
-            if (DrawTextExX(memDC, ch, 1, &rect, DT_LEFT | DT_TOP | DT_CALCRECT | DT_NOPREFIX | DT_SINGLELINE | DT_NOCLIP, NULL)) // with DT_NOCLIP can be 2 x faster
+            if (DrawTextExX(memDC, ch, 1, &rect, DT_LEFT | DT_TOP | DT_CALCRECT | DT_NOPREFIX | DT_SINGLELINE | DT_NOCLIP, NULL)) // DT_NOCLIP can be up to 2x faster
             {
                 if (rect.right - rect.left != fontWidth)
                 {


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/mtxtout.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/mtxtout.cpp against current upstream main at d6fe74f10f742d00ec2b2b2206be8b790b43dab2 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 19 comment units / 19 grounding records / 19 comment-semantics records / 19 review results / 19 resolved results / 19 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,383 tokens; Copilot 0 requests, 0 tokens. Review reused 8 review-cache hits, 10 translation-memory hits (10 provider avoids), 1 request batch.
