### PR TITLE
[translation] Fix src/plugins/filecomp/mtxtout.h comments

### DIFF
--- a/src/plugins/filecomp/mtxtout.h
+++ b/src/plugins/filecomp/mtxtout.h
@@ -63,7 +63,7 @@ public:
             if (sizeof(CChar) > 1)
                 CalcMappingIfNeeded(hdc, lpString, cbCount);
             const CChar* s = lpString;
-            if (cbCount >= BufferSize) // realloc buffer if needed
+            if (cbCount >= BufferSize) // Reallocate the buffer if needed
             {
                 size_t newSize = __max(cbCount + 1, BufferSize * 2);
                 CChar* buf = (CChar*)realloc(Buffer, newSize * sizeof(CChar));


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/mtxtout.h.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/mtxtout.h against current upstream main at cfee3733a87403214e56b739a844b220b0b3ccc9 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 12 comment units / 12 grounding records / 12 comment-semantics records / 12 review results / 12 resolved results / 12 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Review reused 5 review-cache hits, 6 translation-memory hits (6 provider avoids), 1 deterministic resolution, 0 request batches.
