### PR TITLE
[translation] Fix src/plugins/filecomp/viewwnd.cpp comments

### DIFF
--- a/src/plugins/filecomp/viewwnd.cpp
+++ b/src/plugins/filecomp/viewwnd.cpp
@@ -454,7 +454,7 @@ CFileViewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     SendMessage(HWindow, WM_HSCROLL, charsToScroll < 0 ? SB_LINEUP : SB_LINEDOWN, 0);
             }
         }
-        return TRUE; // the event is handled; do not emulate scrollbar clicking (happens when FALSE is returned)
+        return TRUE; // the event is handled; do not emulate scrollbar clicks (that happens when FALSE is returned)
     }
 
     case WM_RBUTTONUP:
@@ -617,7 +617,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
                 line = Script[0][*change].GetLine();
 
             size_t context = Context;
-            if (line < size_t(Context)) // sometimes there is not enough lines
+            if (line < size_t(Context)) // sometimes there are not enough lines
             {
                 size_t sline;
                 if (((CTextFileViewWindowBase*)Siblink)->Script[0][*change].IsBlank())
@@ -999,7 +999,7 @@ void CTextFileViewWindowBase::UpdateSelection(int x, int y)
 {
     CALL_STACK_MESSAGE3("CTextFileViewWindowBase::UpdateSelection(%d, %d)", x, y);
     if (!DataValid || !Tracking)
-        return; // just to be safe
+        return; // defensive check
     if (x < LineNumWidth)
         x = LineNumWidth;
     if (y < 0)


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/viewwnd.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/viewwnd.cpp against current upstream main at a01213e0a0705f9a07a68170a864057beb0e1dc7 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 77 comment units / 77 grounding records / 77 comment-semantics records / 77 review results / 77 resolved results / 77 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,973 tokens; Copilot 0 requests, 0 tokens. Review reused 28 review-cache hits, 43 translation-memory hits (43 provider avoids), 2 deterministic resolutions, 1 request batch.
