### PR TITLE
[translation] Fix src/plugins/filecomp/viewwnd3.cpp comments

### DIFF
--- a/src/plugins/filecomp/viewwnd3.cpp
+++ b/src/plugins/filecomp/viewwnd3.cpp
@@ -819,7 +819,7 @@ CHexFileViewWindow::CalculateOffset(int x, int y)
 
     if ((hOffs + FontWidth / 2) / FontWidth < BytesPerLine / 4 * 13)
     {
-        // Inside hexa block
+        // Inside the hex block
         //offset += (hOffs + FontWidth/2)/FontWidth/3;
         int i = ((hOffs + FontWidth / 2) / FontWidth + 2) / 13;
         int j = ((hOffs + FontWidth / 2 - i * 13 * FontWidth) / FontWidth + 1) / 3;


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/viewwnd3.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/viewwnd3.cpp against current upstream main at 8c91635fd9357956f190f7db948c8be3f5f2b1d8 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 56 comment units / 56 grounding records / 56 comment-semantics records / 56 review results / 56 resolved results / 56 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 19,148 tokens; Copilot 0 requests, 0 tokens. Review reused 10 review-cache hits, 33 translation-memory hits (33 provider avoids), 3 deterministic resolutions, 1 request batch.
