### PR TITLE
[translation] Fix src/plugins/filecomp/worker.cpp comments

### DIFF
--- a/src/plugins/filecomp/worker.cpp
+++ b/src/plugins/filecomp/worker.cpp
@@ -217,7 +217,7 @@ void CFilecompWorker::GuardedBody()
     for (i = 0; i <= 1; i++)
     {
         // Patera 2008.12.28: FILE_SHARE_WRITE added to support files locked by others
-        // NOTE: IntViewer can open such files, users wants FC to support them as well
+        // NOTE: IntViewer can open such files; users want FC to support them as well
         // See https://forum.altap.cz/viewtopic.php?t=2675
         // See also CHexFileViewWindow::SetData()
         Files[i].File = CreateFile(Files[i].Name, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/worker.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/worker.cpp against current upstream main at b1bc2406f783652782e9da9422d3cf2371438c76 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 34 comment units / 34 grounding records / 34 comment-semantics records / 34 review results / 34 resolved results / 34 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,088 tokens; Copilot 0 requests, 0 tokens. Review reused 6 review-cache hits, 22 translation-memory hits (22 provider avoids), 5 deterministic resolutions, 1 request batch.
