### PR TITLE
[translation] Fix src/plugins/filecomp/worker2.cpp comments

### DIFF
--- a/src/plugins/filecomp/worker2.cpp
+++ b/src/plugins/filecomp/worker2.cpp
@@ -331,7 +331,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
                 }
             }
 
-            // compare data in chunks of the requested size
+            // compare data in blocks of the requested size
             DWORD size = (DWORD)__min(blokSize, remain);
 
             ptr0 = cf[0].ReadBuffer(offset, size, CancelFlag);
@@ -371,5 +371,5 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
         }
     }
 
-    return 0; // succes
+    return 0; // success
 }


### PR DESCRIPTION
Refines translated comments in src/plugins/filecomp/worker2.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/filecomp/worker2.cpp against current upstream main at 1c80be798863e36bf4c1409a34016ed1ba67029a with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 17 comment units / 17 grounding records / 17 comment-semantics records / 17 review results / 17 resolved results / 17 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Review reused 6 review-cache hits, 11 translation-memory hits (11 provider avoids), 0 deterministic resolutions, 0 request batches.
