### PR TITLE
[translation] Fix src/plugins/folders/dialogs.cpp comments

### DIFF
--- a/src/plugins/folders/dialogs.cpp
+++ b/src/plugins/folders/dialogs.cpp
@@ -26,7 +26,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontally and vertically center the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);


### PR DESCRIPTION
Refines translated comments in src/plugins/folders/dialogs.cpp.

Model: OpenAI GPT-5.4

Verification: Ran scan -> ground -> review -> resolve -> apply -> guard for src/plugins/folders/dialogs.cpp against current upstream main at 978bc5d9e48d941e63cfad4fa0319e975743e56d with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b. The run produced 4 comment units / 4 grounding records / 4 comment-semantics records / 4 review results / 4 resolved results / 4 apply results. Guard passed in strict and ignore-whitespace modes with 0 violations, and git diff --check is clean.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Review reused 2 translation-memory hits (2 provider avoids), 1 deterministic resolution, 0 request batches.
