### PR TITLE
[translation] Fix src/plugins/folders/folders.cpp comments

### DIFF
--- a/src/plugins/folders/folders.cpp
+++ b/src/plugins/folders/folders.cpp
@@ -76,12 +76,12 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     { // reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
-                   "Folders" /* neprekladat! */, MB_OK | MB_ICONERROR);
+                   "Folders" /* do not translate */, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
     // load the language module (.slg)
-    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "Folders" /* neprekladat! */);
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "Folders" /* do not translate */);
     if (HLanguage == NULL)
         return NULL;
 
@@ -91,7 +91,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     // obtain the interface providing customized Windows controls used in Salamander
     SalamanderGUI = salamander->GetSalamanderGUI();
 
-    if (!InitializeWinLib("Folders" /* neprekladat! */, DLLInstance))
+    if (!InitializeWinLib("Folders" /* do not translate */, DLLInstance))
         return NULL;
     SetWinLibStrings("Invalid number!", LoadStr(IDS_PLUGINNAME));
 
@@ -101,7 +101,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
                                    VERSINFO_VERSION_NO_PLATFORM,
                                    VERSINFO_COPYRIGHT,
                                    LoadStr(IDS_PLUGIN_DESCRIPTION),
-                                   "FOLDERS" /* neprekladat! */, NULL, "fld");
+                                   "FOLDERS" /* do not translate */, NULL, "fld");
 
     salamander->SetPluginHomePageURL("www.altap.cz");
 


### PR DESCRIPTION
Refines translated comments in src/plugins/folders/folders.cpp.

Model: OpenAI GPT-5.4

Verification: Ran the sequential single-file pipeline against OpenSalamander/salamander main at d86e52e40bbf08d94e0f304b9796afa2f398f6cd with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b: scan 26, ground 26, comment-semantics 26, review 26, resolve 26, apply 26. Comment guard passed for src/plugins/folders/folders.cpp in strict and ignore-whitespace modes with no non-comment changes detected. Reviewed patch and git diff confirm the delivery only refines comment text.

Telemetry: Artifact-local provider usage was 1 request total and 0 billing units. Codex 1 request, 17,244 tokens; Copilot 0 requests, 0 tokens. Review reused 13 review-cache hits, 7 translation-memory hits (7 provider avoids), 2 deterministic resolutions, 1 request batch.
