### PR TITLE
[translation] Fix src/plugins/folders/fs1.cpp comments

### DIFF
--- a/src/plugins/folders/fs1.cpp
+++ b/src/plugins/folders/fs1.cpp
@@ -121,7 +121,7 @@ CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* plugin
         IShellFolder* newFolder;
         LPITEMIDLIST newPIDL;
 
-        if (isDir == 2) // up-dir
+        if (isDir == 2) // parent directory
         {
             if (CutLastItemFromIL(fs->CurrentPIDL, &newFolder, &newPIDL))
             {
@@ -311,9 +311,9 @@ CPluginDataInterface::CompareFilesFromFS(const CFileData* file1, const CFileData
     if (pidl1 == pidl2)
         return 0;
     if (pidl1 == NULL)
-        return -1; // the ".." directory arrives here and has pidl==NULL
+        return -1; // the ".." directory ends up here with pidl==NULL
     if (pidl2 == NULL)
-        return 1; // the ".." directory arrives here and has pidl==NULL
+        return 1; // the ".." directory ends up here with pidl==NULL
 
     while (1)
     {
@@ -330,7 +330,7 @@ CPluginDataInterface::CompareFilesFromFS(const CFileData* file1, const CFileData
             if (end2->mkid.cb == 0)
                 return 0; // PIDLs are identical
             else
-                return -1; // the first PIDL is shorter, thus "lesser"
+                return -1; // the first PIDL is shorter, so it is "less"
         }
         else
         {


### PR DESCRIPTION
Refines translated comments in src/plugins/folders/fs1.cpp.

Model: OpenAI GPT-5.4

Verification: Ran the sequential single-file pipeline against OpenSalamander/salamander main at 55bf6a124ab5bcccc4785439534a766081a7cd1e with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b: scan 40, ground 40, comment-semantics 40, review 40, resolve 40, apply 40. Comment guard passed for src/plugins/folders/fs1.cpp in strict and ignore-whitespace modes with no non-comment changes detected. Reviewed patch and git diff confirm the delivery only refines comment text.

Telemetry: Artifact-local provider usage was 0 requests total and 0 billing units. Codex 0 requests, 0 tokens; Copilot 0 requests, 0 tokens. Review reused 9 review-cache hits, 1 synthetic manual, 6 deterministic resolutions, 0 request batches.
