### PR TITLE
[translation] Fix src/plugins/folders/fs2.cpp comments

### DIFF
--- a/src/plugins/folders/fs2.cpp
+++ b/src/plugins/folders/fs2.cpp
@@ -19,7 +19,7 @@ CPluginFSInterface::CPluginFSInterface()
     // Desktop -> CurrentPIDL
     if (FAILED(SHGetSpecialFolderLocation(NULL, CSIDL_DESKTOP, &CurrentPIDL)))
     {
-        // the Desktop PIDL is empty, but we obtain it cleanly
+        // The Desktop PIDL is an empty PIDL, but we still obtain it explicitly
         CurrentPIDL = NULL;
         TRACE_E("SHGetSpecialFolderLocation failed on CSIDL_DESKTOP");
     }
@@ -90,7 +90,7 @@ BOOL WINAPI
 CPluginFSInterface::GetFullName(CFileData& file, int isDir, char* buf, int bufSize)
 {
     buf[0] = 0;
-    //  lstrcpyn(buf, Path, bufSize);  // if the path does not fit, the name definitely will not either (an error will be reported)
+    //  lstrcpyn(buf, Path, bufSize);  // if the path does not fit, the name definitely will not fit either (an error will be reported)
     if (isDir == 2)
         return SalamanderGeneral->CutDirectory(buf, NULL); // up-dir
     else
@@ -132,7 +132,7 @@ CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fsNameI
     if (ErrorState == fesFatal)
     {
         ErrorState = fesOK;
-        return FALSE; // ListCurrentPath failed due to memory, fatal error
+        return FALSE; // ListCurrentPath failed due to insufficient memory, fatal error
     }
 
     return TRUE;


### PR DESCRIPTION
Refines translated comments in src/plugins/folders/fs2.cpp.

Model: OpenAI GPT-5.4

Verification: Ran the sequential single-file pipeline against OpenSalamander/salamander main at 06f2c7227a7cb70302c6a804a75f4a17e940ee50 with baseline gh:OpenSalamander/salamander/a28afcb958578dd219311a7b500320b162de812b: scan 30, ground 30, comment-semantics 30, review 30, resolve 30, apply 30. Comment guard passed for src/plugins/folders/fs2.cpp in strict and ignore-whitespace modes with no non-comment changes detected. Reviewed patch and git diff confirm the delivery only refines comment text.

Telemetry: Artifact-local provider usage was 2 requests total and 0 billing units. Codex 2 requests, 34,559 tokens; Copilot 0 requests, 0 tokens. Review reused 10 review-cache hits, 1 synthetic manual, 2 deterministic resolutions, 2 request batches.
