### PR TITLE
[translation] Fix src/plugins/checksum/wrappers.h comments

### DIFF
--- a/src/plugins/checksum/wrappers.h
+++ b/src/plugins/checksum/wrappers.h
@@ -13,7 +13,7 @@ public:
     virtual bool Init() = 0; // Init for a new file. true on success
     virtual bool Update(const char* buf, DWORD size) = 0;
     virtual bool Finalize() = 0;
-    virtual int GetDigest(char* buf, DWORD bufsize) = 0; // Returns # of copied binary bytes
+    virtual int GetDigest(char* buf, DWORD bufsize) = 0; // Returns the number of copied binary bytes.
     virtual bool ParseDigest(char* buf, char* fileName, int fileNameLen, char* digest) = 0;
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/checksum/wrappers.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 4 comment units, 4 review results, 4 resolved results, and 4 apply results.
- Branch-target comment guard passed for `src/plugins/checksum/wrappers.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/checksum/wrappers.h` completed without diff integrity failures.

## Telemetry
- Total: 3 provider calls, 51360 estimated tokens.
- Codex-family: 3 calls, 51360 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
