### PR TITLE
[translation] Fix src/plugins/checkver/checkver.cpp comments

### DIFF
--- a/src/plugins/checkver/checkver.cpp
+++ b/src/plugins/checkver/checkver.cpp
@@ -72,9 +72,9 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     }
     if (fdwReason == DLL_PROCESS_DETACH)
     {
-        // if Altap Salamander is blocked from accessing the internet by the firewall and Salamander is closed while checkver is running,
-        // TRACE is destroyed before this function is called, which leads to a crash in TRACE_I,
-        // therefore TRACE must not be called here
+        // if Altap Salamander is blocked from accessing the internet by a firewall and Salamander is closed while checkver is running,
+        // TRACE is destroyed before this function is called, causing a crash in TRACE_I,
+        // so TRACE must not be called here
         //TRACE_I("CheckVer DLL_PROCESS_DETACH");
         DeleteCriticalSection(&MainDialogIDSection);
         if (HModulesEnumDone != NULL)
@@ -151,8 +151,8 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     DWORD loadInfo = salamander->GetLoadInformation();
 
-    // immediately after Salamander is installed, perform the version check with an open window so that
-    // it is visible what is happening and the user understands why internet access must be allowed
+    // immediately after Salamander is installed, perform the version check with the window open so that
+    // the user can see what is happening and understand why Internet access must be allowed
     // in the personal firewall
     if (loadInfo & LOADINFO_NEWSALAMANDERVER)
         LoadedOnSalInstall = TRUE;
@@ -369,7 +369,7 @@ unsigned WINAPI ThreadMessageLoopBody(void* param)
     }
 
     data->Success = HMainDialog != NULL;
-    SetEvent(data->Continue); // let the main thread continue; from this point on the data are invalid (=NULL)
+    SetEvent(data->Continue); // let the main thread continue; from this point on, the data are no longer valid (=NULL)
     data = NULL;
 
     MSG msg;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/checkver/checkver.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 64 comment units, 64 review results, 64 resolved results, and 64 apply results.
- Branch-target comment guard passed for `src/plugins/checkver/checkver.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/checkver/checkver.cpp` completed without diff integrity failures.

## Telemetry
- Total: 0 provider calls, 0 estimated tokens.
- Codex-family: 0 calls, 0 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
