### PR TITLE
[translation] Fix src/plugins/checkver/internet.cpp comments

### DIFF
--- a/src/plugins/checkver/internet.cpp
+++ b/src/plugins/checkver/internet.cpp
@@ -124,7 +124,7 @@ DWORD WINAPI ThreadDownload(void* param)
     CTDData* data = (CTDData*)param;
     DWORD dialogID = data->MainDialogID;
     BOOL firstLoadAfterInstall = data->FirstLoadAfterInstall;
-    SetEvent(data->Continue); // let the main thread continue; from this point on the data are invalid (=NULL)
+    SetEvent(data->Continue); // let the main thread continue; from this point on, the data are no longer valid (=NULL)
     data = NULL;
 
     // lock the DLL to prevent it from being unloaded while this function runs
@@ -204,8 +204,8 @@ DWORD WINAPI ThreadDownload(void* param)
 
         default:
         {
-            // p.s. adjusted to allow version checking behind a firewall (tested at SPS)
-            // HTTP (experimentally much faster than FTP-passive at SPS, probably due to HTTP caching,
+            // adjusted to allow version checking behind a firewall (tested at SPS)
+            // HTTP (experimentally much faster than FTP passive at SPS, probably due to HTTP caching;
             //       usually passes through firewalls)
             char scriptURL[200];
             _snprintf_s(scriptURL, _TRUNCATE, "%s?version=%s&lang=%s",
@@ -270,7 +270,7 @@ DWORD WINAPI ThreadDownload(void* param)
         PostMessage(HMainDialog, WM_USER_DOWNLOADTHREAD_EXIT, !exit, 0); // thread ends; data are loaded
         FreeLibrary(hLock);                                              // release the lock
         LeaveCriticalSection(&MainDialogIDSection);
-        return 0; // let the thread die naturally
+        return 0; // let the thread exit normally
     }
     else
     {
@@ -301,7 +301,7 @@ StartDownloadThread(BOOL firstLoadAfterInstall)
     HANDLE hThread = CreateThread(NULL, 0, ThreadDownload, &data, 0, &threadID);
     if (hThread == NULL)
         TRACE_E("Unable to create Check Version Download thread.");
-    else // wait until the thread takes the data
+    else // wait until the thread picks up the data
         WaitForSingleObject(data.Continue, INFINITE);
 
     CloseHandle(data.Continue);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/checkver/internet.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/checkver/internet.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/checkver/internet.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call, 17291 estimated tokens.
- Codex-family: 1 call, 17291 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
