### PR TITLE
[translation] Fix src/plugins/mmviewer/buffer.h comments

### DIFF
--- a/src/plugins/mmviewer/buffer.h
+++ b/src/plugins/mmviewer/buffer.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-//Persistent not supported!!!
+//Persistence not supported.
 
 class CBuffer
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/buffer.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 2 comment units, 2 review results, 2 resolved results, and 2 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/buffer.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/buffer.h` completed without diff integrity failures.

## Telemetry
- Total: 0 provider calls, 0 estimated tokens.
- Codex-family: 0 calls, 0 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
