### PR TITLE
[translation] Fix src/plugins/mmviewer/dialogs.cpp comments

### DIFF
--- a/src/plugins/mmviewer/dialogs.cpp
+++ b/src/plugins/mmviewer/dialogs.cpp
@@ -32,7 +32,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontal and vertical centering of the dialog to the parent
         if (Parent != NULL)
             SalGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // want focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/dialogs.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/dialogs.cpp` completed without diff integrity failures.

## Telemetry
- Total: 0 provider calls, 0 estimated tokens.
- Codex-family: 0 calls, 0 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
