### PR TITLE
[translation] Fix src/plugins/mmviewer/mmviewer.h comments

### DIFF
--- a/src/plugins/mmviewer/mmviewer.h
+++ b/src/plugins/mmviewer/mmviewer.h
@@ -142,7 +142,7 @@ enum CViewerWindowEnablerEnum
 class CViewerWindow : public CWindow
 {
 public:
-    HANDLE Lock; // 'lock' object or NULL (signaled only after we close the file)
+    HANDLE Lock; // 'lock' object or NULL (becomes signaled only after the file is closed)
     CRendererWindow Renderer;
 
     HWND HRebar; // holds the MenuBar and ToolBar


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/mmviewer.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 19 comment units, 19 review results, 19 resolved results, and 19 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/mmviewer.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/mmviewer.h` completed without diff integrity failures.

## Telemetry
- Total: 2 provider calls, 36232 estimated tokens.
- Codex-family: 2 calls, 36232 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
