### PR TITLE
[translation] Fix src/plugins/mmviewer/mod/modparser.cpp comments

### DIFF
--- a/src/plugins/mmviewer/mod/modparser.cpp
+++ b/src/plugins/mmviewer/mod/modparser.cpp
@@ -62,7 +62,7 @@ BOOL CParserMOD::ReadScreamTrackerModule()
         if (fread(&type, 1, 1, f) != 1)
             return FALSE;
 
-        if (type == 16) // this indicates an S3M module
+        if (type == 16) // S3M module
         {
             if (fseek(f, 0x2C, SEEK_SET) != 0)
                 return FALSE;
@@ -217,10 +217,10 @@ BOOL CParserMOD::ReadMultiTrackerModule()
 
 BOOL CParserMOD::ReadProTrackerModule()
 {
-    // with this stupid format it is hard to tell whether it really
-    // is a MOD file, so I'll try to catch at least the null terminator
-    // after the song name. If it is there, I assume it is a MOD.
-    // I also check that those 19 characters are normal characters
+    // With this format, it is difficult to determine reliably whether this is really
+    // a MOD file, so at least check for the null terminator after the song name.
+    // If it is present, treat it as a MOD.
+    // Also check that those 19 characters are normal characters.
 
     memset(modulename, '\0', sizeof(modulename));
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/mod/modparser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/mod/modparser.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/mod/modparser.cpp` completed without diff integrity failures.

## Telemetry
- Total: 0 provider calls, 0 estimated tokens.
- Codex-family: 0 calls, 0 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
