### PR TITLE
[translation] Fix src/plugins/mmviewer/mp3/id3tagv1.cpp comments

### DIFF
--- a/src/plugins/mmviewer/mp3/id3tagv1.cpp
+++ b/src/plugins/mmviewer/mp3/id3tagv1.cpp
@@ -9,7 +9,7 @@
 
 void chkstrcpy(char* out, const char* in, size_t maxoutsize);
 
-//max ID3TAGV1::genre size allowed
+// Maximum allowed size for ID3TAGV1::genre
 const char* ID3TAGV1_GetGenreStr(BYTE genre)
 {
     switch (genre)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/mp3/id3tagv1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/mp3/id3tagv1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/mp3/id3tagv1.cpp` completed without diff integrity failures.

## Telemetry
- Total: 0 provider calls, 0 estimated tokens.
- Codex-family: 0 calls, 0 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
