### PR TITLE
[translation] Fix src/plugins/mmviewer/mp4/mp4head.cpp comments

### DIFF
--- a/src/plugins/mmviewer/mp4/mp4head.cpp
+++ b/src/plugins/mmviewer/mp4/mp4head.cpp
@@ -91,14 +91,14 @@ static int ReadADTSHeader(FILE* file, AACHEAD_DECODED* info)
             break;
         }
 
-        /* check syncword */
+        /* Check the syncword. */
         if (!((buffer[0] == 0xFF) && ((buffer[1] & 0xF6) == 0xF0)))
             break;
 
         if (!frames)
         {
-            /* fixed ADTS header is the same for every frame, so we read it only once */
-            /* Syncword found, proceed to read in the fixed ADTS header */
+            /* The fixed ADTS header is the same for every frame, so we read it only once. */
+            /* Syncword found; proceed to read the fixed ADTS header. */
             ID = buffer[1] & 0x08;
             info->object_type = (buffer[2] & 0xC0) >> 6;
             sr_idx = (buffer[2] & 0x3C) >> 2;
@@ -178,7 +178,7 @@ bool DecodeAACHeader(FILE* file, AACHEAD_DECODED* info)
     adxx_id[5 - 1] = 0;
     info->length = 0;
 
-    /* Determine the header type of the file, check the first two bytes */
+    /* Determine the file header type by checking the first two bytes. */
     if (StringComp((const char*)adxx_id, "AD", 2) == 0)
     {
         /* We think its an ADIF header, but check the rest just to make sure */


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/mp4/mp4head.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 25 comment units, 25 review results, 25 resolved results, and 25 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/mp4/mp4head.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/mp4/mp4head.cpp` completed without diff integrity failures.

## Telemetry
- Total: 3 provider calls, 59440 estimated tokens.
- Codex-family: 3 calls, 59440 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
