### PR TITLE
[translation] Fix src/plugins/mmviewer/ogg/ogg.h comments

### DIFF
--- a/src/plugins/mmviewer/ogg/ogg.h
+++ b/src/plugins/mmviewer/ogg/ogg.h
@@ -68,10 +68,8 @@ extern "C"
         unsigned char header[282]; /* working space for header encode */
         int header_fill;
 
-        int e_o_s; /* set when we have buffered the last packet in the
-                             logical bitstream */
-        int b_o_s; /* set after we've written the initial page
-                             of a logical bitstream */
+        int e_o_s; /* set when the last packet in the logical bitstream has been buffered */
+        int b_o_s; /* set after the initial page of a logical bitstream has been written */
         long serialno;
         long pageno;
         ogg_int64_t packetno; /* sequence number for decode; the framing


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/ogg/ogg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 20 comment units, 20 review results, 20 resolved results, and 20 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/ogg/ogg.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/ogg/ogg.h` completed without diff integrity failures.

## Telemetry
- Total: 2 provider calls, 36332 estimated tokens.
- Codex-family: 2 calls, 36332 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
