### PR TITLE
[translation] Fix src/plugins/mmviewer/parser.h comments

### DIFF
--- a/src/plugins/mmviewer/parser.h
+++ b/src/plugins/mmviewer/parser.h
@@ -11,7 +11,7 @@ enum CParserResultEnum
     preOpenError,      // error while opening the file
     preReadError,      // error while reading from the file
     preWriteError,     // error while writing to the file
-    preSeekError,      // error while setting the position in the file
+    preSeekError,      // error while seeking in the file
     preCorruptedFile,  // corruped file
     preExtensionError, // unable to initialize Windows extensions e.g. WMA
     preCount           // another error


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/parser.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 15 comment units, 15 review results, 15 resolved results, and 15 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/parser.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/parser.h` completed without diff integrity failures.

## Telemetry
- Total: 2 provider calls, 34019 estimated tokens.
- Codex-family: 2 calls, 34019 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
