### PR TITLE
[translation] Fix src/plugins/mmviewer/renmain.cpp comments

### DIFF
--- a/src/plugins/mmviewer/renmain.cpp
+++ b/src/plugins/mmviewer/renmain.cpp
@@ -265,7 +265,7 @@ LRESULT CRendererWindow::OnCommand(WPARAM wParam, LPARAM lParam)
                     FileName[0] = 0;
                 }
 
-                // set the index even if it fails so the user can move to the next/previous image
+                // Set the index even if opening fails so the user can move to the next/previous image
                 EnumFilesCurrentIndex = enumFilesCurrentIndex;
             }
         }
@@ -482,7 +482,7 @@ CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (Output.GetCount())
             return 1;
-        // Let Windows erase the bground for us if we have nothing to show...
+        // Let Windows erase the background for us if we have nothing to show...
         break;
     }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/renmain.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 26 comment units, 26 review results, 26 resolved results, and 26 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/renmain.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/renmain.cpp` completed without diff integrity failures.

## Telemetry
- Total: 4 provider calls, 76878 estimated tokens.
- Codex-family: 4 calls, 76878 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
