### PR TITLE
[translation] Fix src/plugins/mmviewer/renpaint.cpp comments

### DIFF
--- a/src/plugins/mmviewer/renpaint.cpp
+++ b/src/plugins/mmviewer/renpaint.cpp
@@ -117,7 +117,7 @@ void CRendererWindow::Paint(HDC hDC, BOOL moveEditBoxes, DWORD deferFlg)
     SCROLLINFO si;
     si.cbSize = sizeof(si);
     si.fMask = SIF_POS;
-    if (!GetScrollInfo(HWindow, SB_VERT, &si)) //0 = no scrollbar
+    if (!GetScrollInfo(HWindow, SB_VERT, &si)) // 0 = no scroll position
         si.nPos = 0;
 
     int yPos = si.nPos;
@@ -158,7 +158,7 @@ void CRendererWindow::Paint(HDC hDC, BOOL moveEditBoxes, DWORD deferFlg)
                     {
                         LRESULT lines = SendMessage(item->hwnd, (UINT)EM_GETLINECOUNT, 0, 0);
 
-                        if (lines > 1) // add a tiny scrollbar ;-)
+                        if (lines > 1) // add a vertical scrollbar
                         {
                             LONG style = GetWindowLong(item->hwnd, GWL_STYLE);
                             SetWindowLong(item->hwnd, GWL_STYLE, style | WS_VSCROLL);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/renpaint.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 15 comment units, 15 review results, 15 resolved results, and 15 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/renpaint.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/renpaint.cpp` completed without diff integrity failures.

## Telemetry
- Total: 3 provider calls, 55997 estimated tokens.
- Codex-family: 3 calls, 55997 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
