### PR TITLE
[translation] Fix src/plugins/mmviewer/vqf/vqfparser.cpp comments

### DIFF
--- a/src/plugins/mmviewer/vqf/vqfparser.cpp
+++ b/src/plugins/mmviewer/vqf/vqfparser.cpp
@@ -84,7 +84,7 @@ CParserVQF::GetFileInfo(COutputInterface* output)
                 {'(', 'c', ')', ' ', IDS_VQF_COPYRIGHT, NULL},
                 {'F', 'I', 'L', 'E', IDS_VQF_ORIGFILENAME, NULL},
 
-                //TODO I do not know exactly what these tags mean, you will have to find out
+                // TODO: The exact meaning of these tags is unknown and must be determined.
                 {'L', 'Y', 'R', 'C', IDS_VQF_LYRC, NULL},
                 {'W', 'O', 'R', 'D', IDS_VQF_WORD, NULL},
                 {'M', 'U', 'S', 'C', IDS_VQF_MUSC, NULL},


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/vqf/vqfparser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/vqf/vqfparser.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/vqf/vqfparser.cpp` completed without diff integrity failures.

## Telemetry
- Total: 2 provider calls, 36630 estimated tokens.
- Codex-family: 2 calls, 36630 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
