### PR TITLE
[translation] Fix src/plugins/mmviewer/wav/wavparser.cpp comments

### DIFF
--- a/src/plugins/mmviewer/wav/wavparser.cpp
+++ b/src/plugins/mmviewer/wav/wavparser.cpp
@@ -152,8 +152,8 @@ HRESULT CMMIO::ReadMMIO()
                      sizeof(pcmWaveFormat)) != sizeof(pcmWaveFormat))
             return E_FAIL;
 
-        // Allocate the waveformatex, but if its not pcm format, read the next
-        // word, and thats how many extra bytes to allocate.
+        // Allocate the WAVEFORMATEX structure. If the format is not PCM, read the next
+        // word to determine how many extra bytes to allocate.
         if (pcmWaveFormat.wf.wFormatTag == WAVE_FORMAT_PCM)
         {
             m_pwfx = (WAVEFORMATEX*)malloc(sizeof(WAVEFORMATEX));
@@ -166,7 +166,7 @@ HRESULT CMMIO::ReadMMIO()
         }
         else
         {
-            // Read in length of extra bytes.
+            // Read the length of the extra bytes.
             WORD cbExtraBytes = 0L;
             if (mmioRead(m_hmmio, (CHAR*)&cbExtraBytes, sizeof(WORD)) != sizeof(WORD))
                 return E_FAIL;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/wav/wavparser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, `--review-provider codex`, model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/mmviewer/wav/wavparser.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/mmviewer/wav/wavparser.cpp` completed without diff integrity failures.

## Telemetry
- Total: 6 provider calls, 112490 estimated tokens.
- Codex-family: 6 calls, 112490 estimated tokens.
- Copilot SDK: 0 calls, 0 Copilot request units.
