### PR TITLE
[translation] Fix src/plugins/shared/spl_arc.h comments

### DIFF
--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_arc) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_arc) // to make the structures independent of the current alignment setting
 #pragma pack(4)
 #endif // _MSC_VER
 #ifdef __BORLANDC__
@@ -31,7 +31,7 @@ class CPluginDataInterfaceAbstract;
 class CPluginInterfaceForArchiverAbstract
 {
 #ifdef INSIDE_SALAMANDER
-private: // ochrana proti nespravnemu primemu volani metod (viz CPluginInterfaceForArchiverEncapsulation)
+private: // guards against incorrect direct method calls (see CPluginInterfaceForArchiverEncapsulation)
     friend class CPluginInterfaceForArchiverEncapsulation;
 #else  // INSIDE_SALAMANDER
 public:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_arc.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 21/21 review unit(s).
- Validation passed with 2 rewrite(s), 9 keep(s), and 10 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_arc.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 8721 output token(s).
- Copilot CLI: 1 premium request(s).