### PR TITLE
[translation] Fix src/plugins/shared/spl_com.h comments

### DIFF
--- a/src/plugins/shared/spl_com.h
+++ b/src/plugins/shared/spl_com.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_com.h
+++ b/src/plugins/shared/spl_com.h
@@ -12,7 +12,7 @@
 #pragma once
 
 #ifdef _MSC_VER
-#pragma pack(push, enter_include_spl_com) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_spl_com) // so that the structures are independent of the current packing
 #pragma pack(4)
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 #endif                    // _MSC_VER
@@ -20,11 +20,10 @@
 #pragma option -a4
 #endif // __BORLANDC__
 
-// v pluginu je treba definovat promennou SalamanderVersion (int) a v SalamanderPluginEntry tuto
-// promennou inicializovat:
+// the plugin must define the SalamanderVersion variable (int) and initialize it in SalamanderPluginEntry:
 // SalamanderVersion = salamander->GetVersion();
 
-// globalni promenna s verzi Salamandera, ve kterem je tento plugin nacteny
+// global variable with the Salamander version in which this plugin is loaded
 extern int SalamanderVersion;
 
 //
@@ -185,11 +184,11 @@ struct CQuadWord
     BOOL operator<=(const CQuadWord& qw) const { return Value <= qw.Value; }
     BOOL operator>=(const CQuadWord& qw) const { return Value >= qw.Value; }
 
-    // prevod na double (pozor na ztratu presnosti u velkych cisel - double ma jen 15 platnych cislic)
+    // conversion to double (beware of precision loss for large numbers - double has only 15 significant digits)
     double GetDouble() const
-    { // MSVC neumi konverzi unsigned __int64 na double, takze si musime pomoct sami
+    { // MSVC cannot convert unsigned __int64 to double, so we have to help it
         if (Value < CQuadWord(0, 0x80000000).Value)
-            return (double)(__int64)Value; // kladne cislo
+            return (double)(__int64)Value; // positive number
         else
             return 9223372036854775808.0 + (double)(__int64)(Value - CQuadWord(0, 0x80000000).Value);
     }
@@ -199,80 +198,80 @@ struct CQuadWord
 
 #define ICONOVERLAYINDEX_NOTUSED 15 // hodnota pro CFileData::IconOverlayIndex v pripade, ze ikona nema overlay
 
-// zaznam kazdeho souboru a adresare v Salamanderovi (zakladni data o souboru/adresari)
-struct CFileData // nesmi sem prijit destruktor !
+// record of each file and directory in Salamander (basic file/directory data)
+struct CFileData // no destructor may be added here!
 {
-    char* Name;                    // naalokovane jmeno souboru (bez cesty), nutne alokovat na heapu
-                                   // Salamandera (viz CSalamanderGeneralAbstract::Alloc/Realloc/Free)
+    char* Name;                    // allocated file name (without the path), must be allocated on
+                                   // Salamander's heap (see CSalamanderGeneralAbstract::Alloc/Realloc/Free)
     char* Ext;                     // ukazatel do Name za prvni tecku zprava (vcetne tecky na zacatku jmena,
                                    // na Windows se chape jako pripona, narozdil od UNIXu) nebo na konec
                                    // Name, pokud pripona neexistuje; je-li v konfiguraci nastaveno FALSE
                                    // pro SALCFG_SORTBYEXTDIRSASFILES, je v Ext pro adresare ukazatel na konec
                                    // Name (adresare nemaji pripony)
-    CQuadWord Size;                // velikost souboru v bytech
-    DWORD Attr;                    // atributy souboru - ORovane konstanty FILE_ATTRIBUTE_XXX
-    FILETIME LastWrite;            // cas posledniho zapisu do souboru (UTC-based time)
-    char* DosName;                 // naalokovane DOS 8.3 jmeno souboru, neni-li treba je NULL, nutne
-                                   // alokovat na heapu Salamandera (viz CSalamanderGeneralAbstract::Alloc/Realloc/Free)
-    DWORD_PTR PluginData;          // pouziva plugin skrze CPluginDataInterfaceAbstract, Salamander ignoruje
+    CQuadWord Size;                // file size in bytes
+    DWORD Attr;                    // file attributes - ORed FILE_ATTRIBUTE_XXX constants
+    FILETIME LastWrite;            // last-write time of the file (UTC-based time)
+    char* DosName;                 // allocated DOS 8.3 file name; if not needed it is NULL, must be
+                                   // allocated on Salamander's heap (see CSalamanderGeneralAbstract::Alloc/Realloc/Free)
+    DWORD_PTR PluginData;          // used by the plugin through CPluginDataInterfaceAbstract; Salamander ignores it
     unsigned NameLen : 9;          // delka retezce Name (strlen(Name)) - POZOR: maximalni delka jmena je (MAX_PATH - 5)
     unsigned Hidden : 1;           // je hidden? (je-li 1, ikonka je pruhlednejsi o 50% - ghosted)
     unsigned IsLink : 1;           // je link? (je-li 1, ikonka ma overlay linku) - standardni plneni viz CSalamanderGeneralAbstract::IsFileLink(CFileData::Ext), pri zobrazeni ma prednost pred IsOffline, ale IconOverlayIndex ma prednost
     unsigned IsOffline : 1;        // je offline? (je-li 1, ikonka ma overlay offline - cerne hodiny), pri zobrazeni ma IsLink i IconOverlayIndex prednost
-    unsigned IconOverlayIndex : 4; // index icon-overlaye (pokud ikona nema zadny overlay, je zde hodnota ICONOVERLAYINDEX_NOTUSED), pri zobrazeni ma prednost pred IsLink a IsOffline
+    unsigned IconOverlayIndex : 4; // icon overlay index (if the icon has no overlay, this is ICONOVERLAYINDEX_NOTUSED); when displayed, it takes precedence over IsLink and IsOffline
 
-    // flagy pro interni pouziti v Salamanderovi: nuluji se pri pridani do CSalamanderDirectoryAbstract
-    unsigned Association : 1;     // vyznam jen pro zobrazeni 'simple icons' - ikona asociovaneho souboru, jinak 0
-    unsigned Selected : 1;        // read-only flag oznaceni (0 - polozka neoznacena, 1 - polozka oznacena)
-    unsigned Shared : 1;          // je adresar sdileny? u souboru se nepouziva
-    unsigned Archive : 1;         // jedna se o archiv? pouziva se pro zobrazovani ikony archivu v panelu
-    unsigned SizeValid : 1;       // je u adresare napocitana jeho velikost?
-    unsigned Dirty : 1;           // je potreba tuto polozku prekreslit? (pouze docasna platnost; mezi nastavenim bitu a prekreslenim panelu nesmi byt pumpovana message queue, jinak muze dojit k prekresleni ikonky (icon reader) a tim resetu bitu! v dusledku se neprekresli polozka)
+    // flags for Salamander internal use: they are cleared when added to CSalamanderDirectoryAbstract
+    unsigned Association : 1;     // meaningful only for displaying 'simple icons' - icon of the associated file, otherwise 0
+    unsigned Selected : 1;        // read-only selection flag (0 - item not selected, 1 - item selected)
+    unsigned Shared : 1;          // is the directory shared? not used for files
+    unsigned Archive : 1;         // is this an archive? used to display the archive icon in the panel
+    unsigned SizeValid : 1;       // has the directory size already been computed?
+    unsigned Dirty : 1;           // does this item need to be redrawn? (temporary only; the message queue must not be pumped between setting the bit and redrawing the panel, otherwise the icon may be redrawn by the icon reader and the bit reset; as a result the item will not be redrawn)
     unsigned CutToClip : 1;       // je CUT-nutej na clipboardu? (je-li 1, ikonka je pruhlednejsi o 50% - ghosted)
-    unsigned IconOverlayDone : 1; // jen pro potreby icon-reader-threadu: ziskavame nebo uz jsme ziskavali icon-overlay? (0 - ne, 1 - ano)
+    unsigned IconOverlayDone : 1; // for icon-reader-thread use only: are we retrieving or have we already retrieved the icon overlay? (0 - no, 1 - yes)
 };
 
-// konstanty urcujici platnost dat, ktera jsou primo ulozena v CFileData (velikost, pripona, atd.)
-// nebo se generuji z primo ulozenych dat automaticky (file-type se generuje z pripony);
-// Name + NameLen jsou povinne (musi byt platne vzdy); platnost PluginData si ridi plugin sam
-// (Salamander tento atribut ignoruje)
-#define VALID_DATA_EXTENSION 0x0001   // pripona je ulozena v Ext (bez: vsechny Ext = konec Name)
-#define VALID_DATA_DOSNAME 0x0002     // DOS name je ulozeno v DosName (bez: vsechny DosName = NULL)
-#define VALID_DATA_SIZE 0x0004        // velikost v bytech je ulozena v Size (bez: vsechny Size = 0)
-#define VALID_DATA_TYPE 0x0008        // file-type muze byt generovan z Ext (bez: negeneruje se)
-#define VALID_DATA_DATE 0x0010        // datum modifikace (UTC-based) je ulozen v LastWrite (bez: vsechny datumy v LastWrite jsou 1.1.1602 v local time)
-#define VALID_DATA_TIME 0x0020        // cas modifikace (UTC-based) je ulozen v LastWrite (bez: vsechny casy v LastWrite jsou 0:00:00 v local time)
-#define VALID_DATA_ATTRIBUTES 0x0040  // atributy jsou ulozeny v Attr (ORovane Win32 API konstanty FILE_ATTRIBUTE_XXX) (bez: vsechny Attr = 0)
-#define VALID_DATA_HIDDEN 0x0080      // "ghosted" priznak ikony je ulozen v Hidden (bez: vsechny Hidden = 0)
+// constants that specify the validity of data stored directly in CFileData (size, extension, etc.)
+// or generated automatically from directly stored data (file type is generated from the extension);
+// Name + NameLen are mandatory (must always be valid); PluginData validity is managed by the plugin itself
+// (Salamander ignores this field)
+#define VALID_DATA_EXTENSION 0x0001   // extension is stored in Ext (without it: all Ext values point to the end of Name)
+#define VALID_DATA_DOSNAME 0x0002     // DOS name is stored in DosName (without it: all DosName values = NULL)
+#define VALID_DATA_SIZE 0x0004        // the size in bytes is stored in Size (without it: all Size values are 0)
+#define VALID_DATA_TYPE 0x0008        // file type can be generated from Ext (without it: it is not generated)
+#define VALID_DATA_DATE 0x0010        // modification date (UTC-based) is stored in LastWrite (without it: all dates in LastWrite are 1.1.1602 in local time)
+#define VALID_DATA_TIME 0x0020        // modification time (UTC-based) is stored in LastWrite (without it: all times in LastWrite are 0:00:00 in local time)
+#define VALID_DATA_ATTRIBUTES 0x0040  // attributes are stored in Attr (ORed Win32 API FILE_ATTRIBUTE_XXX constants) (without it: all Attr values are 0)
+#define VALID_DATA_HIDDEN 0x0080      // 'ghosted' icon flag is stored in Hidden (without it: all Hidden values are 0)
 #define VALID_DATA_ISLINK 0x0100      // IsLink obsahuje 1 pokud jde o link, ikonka ma overlay linku (bez: vsechny IsLink = 0)
-#define VALID_DATA_ISOFFLINE 0x0200   // IsOffline obsahuje 1 pokud jde o offline soubor/adresar, ikonka ma offline overlay (bez: vsechny IsOffline = 0)
-#define VALID_DATA_PL_SIZE 0x0400     // ma smysl jen bez pouziti VALID_DATA_SIZE: plugin ma aspon pro nektere soubory/adresare ulozenou velikost v bytech (nekde v PluginData), pro ziskani teto velikosti Salamander vola CPluginDataInterfaceAbstract::GetByteSize()
-#define VALID_DATA_PL_DATE 0x0800     // ma smysl jen bez pouziti VALID_DATA_DATE: plugin ma aspon pro nektere soubory/adresare ulozeny datum modifikace (nekde v PluginData), pro ziskani teto velikosti Salamander vola CPluginDataInterfaceAbstract::GetLastWriteDate()
-#define VALID_DATA_PL_TIME 0x1000     // ma smysl jen bez pouziti VALID_DATA_TIME: plugin ma aspon pro nektere soubory/adresare ulozeny cas modifikace (nekde v PluginData), pro ziskani teto velikosti Salamander vola CPluginDataInterfaceAbstract::GetLastWriteTime()
-#define VALID_DATA_ICONOVERLAY 0x2000 // IconOverlayIndex je index icon-overlaye (zadny overlay = hodnota ICONOVERLAYINDEX_NOTUSED) (bez: vsechny IconOverlayIndex = ICONOVERLAYINDEX_NOTUSED), zadani ikon viz CSalamanderGeneralAbstract::SetPluginIconOverlays
+#define VALID_DATA_ISOFFLINE 0x0200   // IsOffline is 1 for an offline file/directory; the icon gets the offline overlay (without it: all IsOffline values are 0)
+#define VALID_DATA_PL_SIZE 0x0400     // meaningful only when VALID_DATA_SIZE is not used: the plugin stores the size in bytes for at least some files/directories (somewhere in PluginData); Salamander calls CPluginDataInterfaceAbstract::GetByteSize() to retrieve it
+#define VALID_DATA_PL_DATE 0x0800     // meaningful only when VALID_DATA_DATE is not used: the plugin stores the modification date for at least some files/directories (somewhere in PluginData); Salamander calls CPluginDataInterfaceAbstract::GetLastWriteDate() to retrieve it
+#define VALID_DATA_PL_TIME 0x1000     // meaningful only when VALID_DATA_TIME is not used: the plugin stores the modification time for at least some files/directories (somewhere in PluginData); Salamander calls CPluginDataInterfaceAbstract::GetLastWriteTime() to retrieve it
+#define VALID_DATA_ICONOVERLAY 0x2000 // IconOverlayIndex is the icon overlay index (no overlay = ICONOVERLAYINDEX_NOTUSED) (without it: all IconOverlayIndex values are ICONOVERLAYINDEX_NOTUSED); for assigning overlays see CSalamanderGeneralAbstract::SetPluginIconOverlays
 
-#define VALID_DATA_NONE 0 // pomocna konstanta - platne je jen Name a NameLen
+#define VALID_DATA_NONE 0 // helper constant - only Name and NameLen are valid
 
 #ifdef INSIDE_SALAMANDER
-// VALID_DATA_ALL a VALID_DATA_ALL_FS_ARC jsou jen pro interni pouziti v Salamanderovi (jadre),
-// pluginy si naORuji jen konstanty odpovidajici pluginem dodavanym datum (zamezi se tak problemum
-// pri zavedeni dalsich konstant a jim odpovidajicim datum)
+// VALID_DATA_ALL and VALID_DATA_ALL_FS_ARC are for Salamander core internal use only;
+// plugins should OR only constants that correspond to data supplied by the plugin
+// (to avoid problems when new constants and corresponding data are added)
 #define VALID_DATA_ALL 0xFFFF
-#define VALID_DATA_ALL_FS_ARC (0xFFFF & ~VALID_DATA_ICONOVERLAY) // pro FS a archivy: vse krome icon-overlays
+#define VALID_DATA_ALL_FS_ARC (0xFFFF & ~VALID_DATA_ICONOVERLAY) // for FS and archives: everything except icon overlays
 #endif                                                           // INSIDE_SALAMANDER
 
-// Pokud je zapnuto skryvani hidden a system souboru a adresaru, nezobrazuji se v panelech polozky s
-// Hidden==1 a Attr obsahujicim FILE_ATTRIBUTE_HIDDEN a/nebo FILE_ATTRIBUTE_SYSTEM.
+// If hiding hidden and system files/directories is enabled, items with
+// Hidden==1 and Attr containing FILE_ATTRIBUTE_HIDDEN and/or FILE_ATTRIBUTE_SYSTEM are not shown in panels.
 
-// konstanty priznaku pro CSalamanderDirectoryAbstract:
-// jmena souboru a adresaru (i v cestach) se maji porovnavat case-sensitive (bez tohoto flagu je
-// porovnavani case-insensitive - standardni chovani ve Windows)
+// CSalamanderDirectoryAbstract flag constants:
+// file and directory names (including path components) are compared case-sensitively with this flag
+// (without it, comparison is case-insensitive - the standard Windows behavior)
 #define SALDIRFLAG_CASESENSITIVE 0x0001
-// jmena podadresaru v ramci kazdeho adresare se nebudou testovat na duplicitu (tento
-// test je casove narocny a je nutny jen v archivech, pokud se pridavaji polozky nejen
-// do rootu - aby fungovalo napr. pridani "file1" na "dir1" nasledovane pridanim
-// "dir1" - "dir1" se prida prvni operaci (automaticky se prida neexistujici cesta),
-// druha operace uz jen obnovi udaje o "dir1" (nesmi ho pridat znovu))
+// subdirectory names within each directory are not checked for duplicates (this
+// check is time-consuming and is needed only in archives when items are added not only
+// to the root - e.g. so that adding 'file1' to 'dir1' followed by adding
+// 'dir1' works correctly: the first operation adds 'dir1' automatically as a missing path,
+// and the second operation only refreshes the data for 'dir1' instead of adding it again)
 #define SALDIRFLAG_IGNOREDUPDIRS 0x0002
 
 class CPluginDataInterfaceAbstract;
@@ -286,17 +285,17 @@ public:
     // VALID_DATA_ICONOVERLAY) a priznaku objektu (viz metoda SetFlags)
     virtual void WINAPI Clear(CPluginDataInterfaceAbstract* pluginData) = 0;
 
-    // zadani masky platnych dat, podle ktere se urcuje, ktera data z CFileData jsou platna
-    // a ktera se maji pouze "nulovat" (viz komentar k VALID_DATA_XXX); maska 'validData'
-    // obsahuje ORovane hodnoty VALID_DATA_XXX; standardni hodnota masky je suma vsech
-    // VALID_DATA_XXX krome VALID_DATA_ICONOVERLAY; masku platnych dat je potreba nastavit
-    // pred volanim AddFile/AddDir
+    // sets the valid data mask that determines which CFileData fields are valid
+    // and which should only be zeroed (see the VALID_DATA_XXX comment); the 'validData' mask
+    // contains ORed VALID_DATA_XXX values; the default mask is the sum of all
+    // VALID_DATA_XXX values except VALID_DATA_ICONOVERLAY; the valid data mask must be set
+    // before calling AddFile/AddDir
     virtual void WINAPI SetValidData(DWORD validData) = 0;
 
-    // nastaveni priznaku pro tento objekt; 'flags' je kombinace ORovanych priznaku SALDIRFLAG_XXX,
-    // standardni hodnota priznaku objektu je nula pro archivatory (zadny priznak neni nastaven)
-    // a SALDIRFLAG_IGNOREDUPDIRS pro file-systemy (smi se pridavat jen do rootu, test na duplicitu
-    // adresaru je zbytecny)
+    // sets flags for this object; 'flags' is a combination of ORed SALDIRFLAG_XXX flags;
+    // the default object flag value is zero for archivers (no flags set)
+    // and SALDIRFLAG_IGNOREDUPDIRS for file systems (they may add only to the root, so duplicate
+    // directory checks are unnecessary)
     virtual void WINAPI SetFlags(DWORD flags) = 0;
 
     // prida soubor na zadanou cestou (relativni k tomuto "salamander-adresari"), vraci uspech
@@ -325,30 +324,30 @@ public:
     // zobrazuje se vzdy na zacatku listingu a ma specialni ikonu)
     virtual BOOL WINAPI AddDir(const char* path, CFileData& dir, CPluginDataInterfaceAbstract* pluginData) = 0;
 
-    // vraci pocet souboru v objektu
+    // returns the number of files in the object
     virtual int WINAPI GetFilesCount() const = 0;
 
-    // vraci pocet adresaru v objektu
+    // returns the number of directories in the object
     virtual int WINAPI GetDirsCount() const = 0;
 
-    // vraci soubor z indexu 'index', vracena data lze pouzit jen pro cteni
+    // returns the file at index 'index'; the returned data is read-only
     virtual CFileData const* WINAPI GetFile(int index) const = 0;
 
-    // vraci adresar z indexu 'index', vracena data lze pouzit jen pro cteni
+    // returns the directory at index 'index'; the returned data is read-only
     virtual CFileData const* WINAPI GetDir(int index) const = 0;
 
-    // vraci objekt CSalamanderDirectory pro adresar z indexu 'index', vraceny objekt lze
-    // pouzit jen pro cteni (objekty pro prazdne adresare nejsou alokovany, vraci se jeden
-    // globalni prazdny objekt - zmena tohoto objektu by se projevila globalne)
+    // returns the CSalamanderDirectory object for the directory at 'index'; the returned object is read-only
+    // (objects for empty directories are not allocated, so a single global empty object is returned
+    // - modifying that object would affect it globally)
     virtual CSalamanderDirectoryAbstract const* WINAPI GetSalDir(int index) const = 0;
 
-    // Pluginu umoznuje predem sdelit predpokladany pocet souboru a adresaru v tomto adresari.
-    // Salamander si upravi realokacni strategii tak, aby pridavani prvku prilis nebrzdilo.
-    // Ma smysl volat pro adresare obsahujici tisice souboru nebo adresaru. V pripade desitek
-    // tisic uz je zavolani teto metody temer nutnost, jinak realokace zaberou nekolik vterin.
-    // 'files' a 'dirs' tedy vyjadruji priblizny celkovy pocet souboru a adresaru.
-    // Pokud je nektera z hodnot -1, bude ji Salamander ignorovat.
-    // Metodu ma vyznam volat pouze pokud je adresar prazdny, tedy nebylo volano AddFile nebo AddDir.
+    // Lets the plugin tell Salamander the expected number of files and directories in this directory in advance.
+    // Salamander adjusts its reallocation strategy so adding items does not slow down too much.
+    // This is worth calling for directories containing thousands of files or directories. For tens of
+    // thousands, calling this method is almost necessary, otherwise reallocations can take several seconds.
+    // 'files' and 'dirs' therefore specify the approximate total number of files and directories.
+    // If either value is -1, Salamander ignores it.
+    // The method is useful only while the directory is empty, before AddFile or AddDir has been called.
     virtual void WINAPI SetApproximateCount(int files, int dirs) = 0;
 };
 
@@ -357,10 +356,10 @@ public:
 // SalEnumSelection a SalEnumSelection2
 //
 
-// konstanty vracene z SalEnumSelection a SalEnumSelection2 v parametru 'errorOccured'
-#define SALENUM_SUCCESS 0 // chyba nenastala
-#define SALENUM_ERROR 1   // nastala chyba a uzivatel si preje pokracovat v operaci (vynechaly se jen chybne soubory/adresare)
-#define SALENUM_CANCEL 2  // nastala chyba a uzivatel si preje zrusit operaci
+// constants returned by SalEnumSelection and SalEnumSelection2 in the 'errorOccured' parameter
+#define SALENUM_SUCCESS 0 // no error occurred
+#define SALENUM_ERROR 1   // an error occurred and the user chose to continue the operation (only the faulty files/directories were skipped)
+#define SALENUM_CANCEL 2  // an error occurred and the user wants to cancel the operation
 
 // enumerator, vraci jmena souboru, konci vracenim NULL;
 // 'enumFiles' == -1 -> reset enumerace (po tomto volani zacina enumerace opet od zacatku), vsechny
@@ -418,7 +417,7 @@ typedef const char*(WINAPI* SalEnumSelection2)(HWND parent, int enumFiles, const
 //
 // sada metod Salamandera pro praci se sloupci v panelu (vypinani/zapinani/pridavani/nastavovani)
 
-// rezimy pohledu panelu
+// panel view modes
 #define VIEW_MODE_TREE 1
 #define VIEW_MODE_BRIEF 2
 #define VIEW_MODE_DETAILED 3
@@ -426,29 +425,29 @@ typedef const char*(WINAPI* SalEnumSelection2)(HWND parent, int enumFiles, const
 #define VIEW_MODE_THUMBNAILS 5
 #define VIEW_MODE_TILES 6
 
-#define TRANSFER_BUFFER_MAX 1024 // velikost bufferu pro prenos obsahu sloupcu z pluginu do Salamandera
+#define TRANSFER_BUFFER_MAX 1024 // buffer size for transferring column contents from the plugin to Salamander
 #define COLUMN_NAME_MAX 30
 #define COLUMN_DESCRIPTION_MAX 100
 
-// Identifikatory sloupcu. Sloupce vlozene pluginem maji nastaveno ID==COLUMN_ID_CUSTOM.
-// Standardni sloupce Salamandera maji ostatni ID.
-#define COLUMN_ID_CUSTOM 0 // sloupec je poskytovan pluginem - o ulozeni jeho dat se postara plugin
-#define COLUMN_ID_NAME 1   // zarovnano vlevo, podporuje FixedWidth
+// Column identifiers. Plugin-inserted columns have ID==COLUMN_ID_CUSTOM.
+// Salamander standard columns have the other IDs.
+#define COLUMN_ID_CUSTOM 0 // column provided by the plugin - the plugin is responsible for storing its data
+#define COLUMN_ID_NAME 1   // left-aligned, supports FixedWidth
 // zarovnano vlevo, podporuje FixedWidth; samostatny sloupec "Ext", muze byt jen na indexu==1;
 // pokud sloupec neexistuje a v datech panelu (viz CSalamanderDirectoryAbstract::SetValidData())
 // se nastavi VALID_DATA_EXTENSION, je sloupec "Ext" zobrazen ve sloupci "Name"
 #define COLUMN_ID_EXTENSION 2
-#define COLUMN_ID_DOSNAME 3     // zarovnano vlevo
-#define COLUMN_ID_SIZE 4        // zarovnano vpravo
-#define COLUMN_ID_TYPE 5        // zarovnano vlevo, podporuje FixedWidth
-#define COLUMN_ID_DATE 6        // zarovnano vpravo
-#define COLUMN_ID_TIME 7        // zarovnano vpravo
-#define COLUMN_ID_ATTRIBUTES 8  // zarovnano vpravo
-#define COLUMN_ID_DESCRIPTION 9 // zarovnano vlevo, podporuje FixedWidth
+#define COLUMN_ID_DOSNAME 3     // left-aligned
+#define COLUMN_ID_SIZE 4        // right-aligned
+#define COLUMN_ID_TYPE 5        // left-aligned, supports FixedWidth
+#define COLUMN_ID_DATE 6        // right-aligned
+#define COLUMN_ID_TIME 7        // right-aligned
+#define COLUMN_ID_ATTRIBUTES 8  // right-aligned
+#define COLUMN_ID_DESCRIPTION 9 // left-aligned, supports FixedWidth
 
-// Callback pro naplneni bufferu znakama, ktere se maji zobrazit v prislusnem sloupci.
-// Z duvodu optimalizace funkce nedostava/nevraci promenne prostrednictvim parametru,
-// ale prostrednictvim globalni promennych (CSalamanderViewAbstract::GetTransferVariables).
+// Callback that fills the buffer with characters to be shown in the corresponding column.
+// For optimization, the function does not receive/return variables through parameters,
+// but through global variables (CSalamanderViewAbstract::GetTransferVariables).
 typedef void(WINAPI* FColumnGetText)();
 
 // Callback pro ziskani indexu jednoduchych ikon pro FS s vlastnimi ikonami (pitFromPlugin).
@@ -457,14 +456,14 @@ typedef void(WINAPI* FColumnGetText)();
 // Z globalnich promennych callback vyuziva jen TransferFileData a TransferIsDir.
 typedef int(WINAPI* FGetPluginIconIndex)();
 
-// sloupec muze vzniknout dvema zpusoby:
-// 1) Sloupec vytvoril Salamander na zaklade sablony aktualniho pohledu.
-//    V tomto pripade ukazatel 'GetText' (na plnici funkci) ukazuje do Salamandera
-//    a ziskava texty standardne z CFileData.
-//    Hodnota promenne 'ID' je ruzna od COLUMN_ID_CUSTOM.
+// A column can be created in two ways:
+// 1) The column was created by Salamander from the current view template.
+//    In this case, 'GetText' (the fill function pointer) points into Salamander
+//    and retrieves text from CFileData in the standard way.
+//    The 'ID' field is different from COLUMN_ID_CUSTOM.
 //
-// 2) Sloupec pridal plugin na zaklade svych potreb.
-//    'GetText' ukazuje do pluginu a 'ID' je rovno COLUMN_ID_CUSTOM.
+// 2) The column was added by the plugin for its own needs.
+//    'GetText' points into the plugin and 'ID' equals COLUMN_ID_CUSTOM.
 
 struct CColumn
 {
@@ -487,62 +486,61 @@ struct CColumn
                                               // nastavi VALID_DATA_EXTENSION. Pro spojeni dvou
                                               // retezcu poslouzi CSalamanderGeneralAbstract::AddStrToStr().
 
-    FColumnGetText GetText; // callback pro ziskani textu (popis u deklatace typu FColumnGetText)
+    FColumnGetText GetText; // callback used to obtain text (see the FColumnGetText declaration)
 
-    // FIXME_X64 - male pro ukazatel, neni nekdy potreba?
-    DWORD CustomData; // Neni pouzivana Salamanderem;  plugin ji muze
-                      // vyuzit pro rozliseni svych pridanych sloupcu.
+    // FIXME_X64 - too small for a pointer, is it ever needed?
+    DWORD CustomData; // Not used by Salamander; the plugin can
+                      // use it to distinguish the columns added by the plugin.
 
-    unsigned SupportSorting : 1; // je sloupec mozne radit?
+    unsigned SupportSorting : 1; // can the column be sorted?
 
-    unsigned LeftAlignment : 1; // pro TRUE je sloupec zarovnavan vlevo; jinak vpravo
+    unsigned LeftAlignment : 1; // TRUE means the column is left-aligned; otherwise right-aligned
 
-    unsigned ID : 4; // identifikator sloupce
-                     // Pro standardni sloupce poskytovane Salamanderem
-                     // obsahuje hodnoty ruzne od COLUMN_ID_CUSTOM.
-                     // Pro sloupce pridane pluginem obsahuje vzdy
-                     // hodnotu COLUMN_ID_CUSTOM.
+    unsigned ID : 4; // column identifier
+                     // For standard columns provided by Salamander,
+                     // it contains values other than COLUMN_ID_CUSTOM.
+                     // For columns added by the plugin, it always contains
+                     // the value COLUMN_ID_CUSTOM.
 
-    // Promenne Width a FixedWidth muzou byt zmeneny uzivatelem behem prace s panelem.
-    // Standardni sloupce poskytovane Salamanderem maji zajisteno ukladani/nacitani
-    // techto hodnot.
-    // Hodnoty techto promennych pro sloupce poskytovane pluginem je treba ulozit/nacist
-    // v ramci pluginu.
-    // Sloupce, jejichz sirku pocita Salamander na zaklade obsahu a uzivatel ji nemuze
-    // menit, nazyvame 'elasticke'. Sloupce, pro ktere muze uzivatel nastavit sirku nazyvame
-    // 'pevne'/'fixed'.
+    // The Width and FixedWidth variables can be changed by the user while working with the panel.
+    // Salamander stores/loads these values for standard columns it provides.
+    // Values of these variables for plugin-provided columns must be stored/loaded
+    // by the plugin itself.
+    // Columns whose width Salamander calculates from their content and the user cannot
+    // change are called 'elastic'. Columns whose width the user can set are called
+    // 'fixed'.
     unsigned Width : 16;     // Sirka sloupce v pripade, ze je v rezimu pevne (nastavitelne) sirky.
-    unsigned FixedWidth : 1; // Je sloupec v rezimu pevne (nastavitelne) sirky?
+    unsigned FixedWidth : 1; // is the column in fixed (user-adjustable) width mode?
 
-    // pracovni promenne (nikam se neukladaji a neni treba je inicializovat)
-    // jsou urcene pro interni potreby Salamandera a pluginy je ignoruji,
-    // protoze jejich obsah neni pri volani pluginu zaruceny
-    unsigned MinWidth : 16; // Minimalni sirka, na kterou muze byt sloupce smrsten.
-                            // Je pocitana na zaklade nazvu sloupce a jeho raditelnosti
-                            // tak, aby byla hlavicka sloupce vzdy viditelna
+    // working variables (not stored anywhere and need not be initialized)
+    // are reserved for Salamander's internal use and are ignored by plugins,
+    // because their contents are not guaranteed when plugin code is called
+    unsigned MinWidth : 16; // minimum width to which the column can be shrunk.
+                            // It is computed from the column name and its sortability
+                            // so that the column header is always visible
 };
 
-// Plugin prostrednictvim tohoto rozhrani muze pri zmene cesty zmenit rezim
-// zobrazeni v panelu. Veskera prace se sloupci se tyka jen vsech detailed rezimu
-// (Detailed + Types + tri volitelne rezimy Alt+8/9/0). Pri zmene cesty dostane
-// plugin standardni sadu sloupcu nagenerovanou na zaklade sablony aktualniho
-// pohledu. Plugin muze tuto sadu modifikovat. Modifikace neni trvaleho razu
-// a pri pristi zmene cesty obdrzi plugin opet standardni sadu sloupcu. Muze tak
-// napriklad odstranit nektery ze std. sloupcu. Pred novym plnenim std. sloupci
-// dostane plugin prilezitost ulozeni informaci o svych sloupcich (COLUMN_ID_CUSTOM).
-// Muze tak ulozit jejich 'Width' a 'FixedWidth', ktere uzivatel mohl v panelu
-// nastavit (viz ColumnFixedWidthShouldChange() a ColumnWidthWasChanged() v interfacu
-// CPluginDataInterfaceAbstract). Pokud plugin zmeni rezim pohledu, zmena je trvala
-// (napr. prepnuti na rezim Thumbnails zustane i po opusteni pluginove cesty).
+// Through this interface, the plugin can change the panel display mode when the path changes.
+// All column operations apply only to the detailed modes
+// (Detailed + Types + the three custom modes Alt+8/9/0). When the path changes, the
+// plugin gets a standard set of columns generated from the current view template.
+// The plugin can modify this set. The modification is not permanent,
+// and on the next path change the plugin again receives the standard set of columns. It can,
+// for example, remove one of the standard columns. Before the standard columns are rebuilt,
+// the plugin gets a chance to store information about its own columns (COLUMN_ID_CUSTOM).
+// It can store their 'Width' and 'FixedWidth', which the user may have changed in the panel
+// (see ColumnFixedWidthShouldChange() and ColumnWidthWasChanged() in
+// CPluginDataInterfaceAbstract). If the plugin changes the display mode, the change is permanent
+// (e.g. switching to Thumbnails remains in effect even after leaving the plugin path).
 
 class CSalamanderViewAbstract
 {
 public:
     // -------------- panel ----------------
 
-    // vraci rezim, ve kterem je zobrazen panel (tree/brief/detailed/icons/thumbnails/tiles)
-    // vraci jednu z hodnot VIEW_MODE_xxxx (rezim Detailed, Types a tri volitelne rezimy jsou
-    // vsechny VIEW_MODE_DETAILED)
+    // returns the panel display mode (tree/brief/detailed/icons/thumbnails/tiles)
+    // returns one of the VIEW_MODE_xxxx values (Detailed, Types, and the three custom modes
+    // all use VIEW_MODE_DETAILED)
     virtual DWORD WINAPI GetViewMode() = 0;
 
     // Nastavi rezim panelu na 'viewMode'. Pokud jde o nektery z detailed rezimu, muze
@@ -601,23 +599,23 @@ public:
 
     // ------------- columns ---------------
 
-    // vraci pocet sloupcu v panelu (vzdy minimalne jeden, protoze nazev bude vzdy zobrazen)
+    // returns the number of columns in the panel (always at least one, because Name is always shown)
     virtual int WINAPI GetColumnsCount() = 0;
 
-    // vraci ukazatel na sloupec (pouze pro cteni)
-    // 'index' udava, ktery ze sloupcu bude vracen; pokud sloupec 'index' neexistuje, vraci NULL
+    // returns a pointer to the column (read-only)
+    // 'index' specifies which column is returned; returns NULL if the column at 'index' does not exist
     virtual const CColumn* WINAPI GetColumn(int index) = 0;
 
-    // Vlozi sloupec na pozici 'index'. Na pozici 0 je vzdy umisten sloupec Name,
-    // pokud je zobrazen sloupec Ext, bude na pozici 1. Jinak lze sloupec umistit
-    // libovolne. Struktura 'column' bude prekopirovana do vnitrnich struktur
-    // Salamandera. Vraci TRUE pokud byl sloupec vlozen.
+    // Inserts a column at position 'index'. The Name column is always at position 0,
+    // and if the Ext column is shown, it is at position 1. Otherwise the column may be inserted
+    // at any position. The 'column' structure is copied into Salamander's internal structures.
+    // Returns TRUE if the column was inserted.
     virtual BOOL WINAPI InsertColumn(int index, const CColumn* column) = 0;
 
-    // Vlozi standardni sloupec s ID 'id' na pozici 'index'. Na pozici 0 je vzdy
-    // umisten sloupec Name, pokud je vkladan sloupec Ext, musi to byt na pozici 1.
-    // Jinak lze sloupec umistit libovolne. 'id' je jedna z hodnot COLUMN_ID_xxxx,
-    // mimo COLUMN_ID_CUSTOM a COLUMN_ID_NAME.
+    // Inserts the standard column with ID 'id' at position 'index'. The Name column is always
+    // at position 0; if the Ext column is inserted, it must be at position 1.
+    // Otherwise the column may be inserted at any position. 'id' is one of the COLUMN_ID_xxxx values,
+    // except COLUMN_ID_CUSTOM and COLUMN_ID_NAME.
     virtual BOOL WINAPI InsertStandardColumn(int index, DWORD id) = 0;
 
     // Nastavi nazev a popis sloupce (nesmi byt prazdne retezce ani NULL). Delky
@@ -630,11 +628,11 @@ public:
     // null-terminatory) - viz CSalamanderGeneralAbstract::AddStrToStr().
     virtual BOOL WINAPI SetColumnName(int index, const char* name, const char* description) = 0;
 
-    // Odstrani sloupec na pozici 'index'. Lze odstranit jak sloupce pridane pluginem,
-    // tak standardni sloupce Salamandera. Nelze odstranit sloupec 'Name', ktery je vzdy
-    // na indexu 0. Pozor pri odstranovani sloupce 'Ext', pokud je v datech pluginu
-    // (viz CSalamanderDirectoryAbstract::SetValidData()) VALID_DATA_EXTENSION, musi
-    // se jmeno+popis sloupce 'Ext' objevit u sloupce 'Name'.
+    // Removes the column at position 'index'. Both plugin-added columns
+    // and Salamander's standard columns can be removed. The Name column, which is always
+    // at index 0, cannot be removed. Be careful when removing the Ext column: if plugin data
+    // (via CSalamanderDirectoryAbstract::SetValidData()) includes VALID_DATA_EXTENSION,
+    // the Ext column name+description must appear under the Name column.
     virtual BOOL WINAPI DeleteColumn(int index) = 0;
 };
 
@@ -670,15 +668,15 @@ public:
     // vrati TRUE, a pro vsechny adresare, pokud CallReleaseForDirs vrati TRUE
     virtual void WINAPI ReleasePluginData(CFileData& file, BOOL isDir) = 0;
 
-    // jen pro data archivu (pro FS se nedoplnuje up-dir symbol):
-    // pozmenuje navrhovany obsah up-dir symbolu (".." nahore v panelu); 'archivePath'
-    // je cesta v archivu, pro kterou je symbol urcen; v 'upDir' vstupuji navrzena
-    // data symbolu: jmeno ".." (nemenit), date&time archivu, zbytek nulovany;
-    // v 'upDir' vystupuji zmeny pluginu, predevsim by mel zmenit 'upDir.PluginData',
-    // ktery bude vyuzivan na up-dir symbolu pri ziskavani obsahu pridanych sloupcu;
-    // pro 'upDir' se nebude volat ReleasePluginData, jakekoliv potrebne uvolnovani
-    // je mozne provest vzdy pri dalsim volani GetFileDataForUpDir nebo pri uvolneni
-    // celeho interfacu (v jeho destruktoru - volan z
+    // archive data only (FS does not add an up-dir symbol):
+    // modifies the proposed contents of the up-dir symbol ('..' at the top of the panel); 'archivePath'
+    // is the archive path the symbol is for; 'upDir' receives the proposed symbol
+    // data: the name '..' (do not change it), the archive date&time, everything else zeroed;
+    // 'upDir' returns plugin changes, mainly 'upDir.PluginData',
+    // which is used by the up-dir symbol when obtaining the contents of added columns;
+    // ReleasePluginData will not be called for 'upDir'; any necessary cleanup
+    // can always be done on the next call to GetFileDataForUpDir or when the
+    // entire interface is released (in its destructor - called from
     // CPluginInterfaceAbstract::ReleasePluginDataInterface)
     virtual void WINAPI GetFileDataForUpDir(const char* archivePath, CFileData& upDir) = 0;
 
@@ -854,30 +852,30 @@ public:
     // a podle jeji navratove hodnoty akci pripadne predcasne ukoncit
     virtual void WINAPI OpenProgressDialog(const char* title, BOOL twoProgressBars,
                                            HWND parent, BOOL fileProgress) = 0;
-    // vypise text 'txt' (i nekolik radku - provadi se rozpad na radky) do progress-dialogu
+    // writes text 'txt' (even multiple lines - it is split into lines) to the progress dialog
     virtual void WINAPI ProgressDialogAddText(const char* txt, BOOL delayedPaint) = 0;
-    // neni-li 'totalSize1' CQuadWord(-1, -1), nastavi 'totalSize1' jako 100 procent prvniho progress-metru,
-    // neni-li 'totalSize2' CQuadWord(-1, -1), nastavi 'totalSize2' jako 100 procent druheho progress-metru
-    // (pro progress-dialog s jednim progress-metrem je povinne 'totalSize2' CQuadWord(-1, -1))
+    // if 'totalSize1' is not CQuadWord(-1, -1), sets 'totalSize1' as 100 percent of the first progress bar;
+    // if 'totalSize2' is not CQuadWord(-1, -1), sets 'totalSize2' as 100 percent of the second progress bar
+    // (for a progress dialog with a single progress bar, 'totalSize2' must be CQuadWord(-1, -1))
     virtual void WINAPI ProgressSetTotalSize(const CQuadWord& totalSize1, const CQuadWord& totalSize2) = 0;
-    // neni-li 'size1' CQuadWord(-1, -1), nastavi velikost 'size1' (size1/total1*100 procent) na prvnim progress-metru,
-    // neni-li 'size2' CQuadWord(-1, -1), nastavi velikost 'size2' (size2/total2*100 procent) na druhem progress-metru
-    // (pro progress-dialog s jednim progress-metrem je povinne 'size2' CQuadWord(-1, -1)), vraci informaci jestli ma
-    // akce pokracovat (FALSE = konec)
+    // if 'size1' is not CQuadWord(-1, -1), sets 'size1' on the first progress bar (size1/total1*100 percent);
+    // if 'size2' is not CQuadWord(-1, -1), sets 'size2' on the second progress bar (size2/total2*100 percent)
+    // (for a progress dialog with a single progress bar, 'size2' must be CQuadWord(-1, -1)); returns whether the
+    // action should continue (FALSE = stop)
     virtual BOOL WINAPI ProgressSetSize(const CQuadWord& size1, const CQuadWord& size2, BOOL delayedPaint) = 0;
-    // prida (pripadne k oboum progress-metrum) velikost 'size' (size/total*100 procent progressu),
-    // vraci informaci jestli ma akce pokracovat (FALSE = konec)
+    // adds 'size' to one or both progress bars (size/total*100 percent progress),
+    // returns whether the action should continue (FALSE = stop)
     virtual BOOL WINAPI ProgressAddSize(int size, BOOL delayedPaint) = 0;
-    // enabluje/disabluje tlacitko Cancel
+    // enables/disables the Cancel button
     virtual void WINAPI ProgressEnableCancel(BOOL enable) = 0;
-    // vraci HWND dialogu progressu (hodi se pri vypisu chyb a dotazu pri otevrenem progress-dialogu)
+    // returns the progress dialog HWND (useful for showing errors and prompts while the progress dialog is open)
     virtual HWND WINAPI ProgressGetHWND() = 0;
-    // zavre progress-dialog
+    // closes the progress dialog
     virtual void WINAPI CloseProgressDialog() = 0;
 
-    // presune vsechny soubory ze 'source' adresare do 'target' adresare,
-    // navic premapovava predpony zobrazovanych jmen ('remapNameFrom' -> 'remapNameTo')
-    // vraci uspech operace
+    // moves all files from the 'source' directory to the 'target' directory,
+    // and also remaps displayed name prefixes ('remapNameFrom' -> 'remapNameTo')
+    // returns whether the operation succeeded
     virtual BOOL WINAPI MoveFiles(const char* source, const char* target, const char* remapNameFrom,
                                   const char* remapNameTo) = 0;
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_com.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 100 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 164/164 review unit(s).
- Validation passed with 100 rewrite(s), 31 keep(s), and 33 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_com.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 30372 output token(s).
- Copilot CLI: 1 premium request(s).