### PR TITLE
[translation] Fix src/plugins/shared/spl_zlib.h comments

### DIFF
--- a/src/plugins/shared/spl_zlib.h
+++ b/src/plugins/shared/spl_zlib.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_zlib.h
+++ b/src/plugins/shared/spl_zlib.h
@@ -52,7 +52,7 @@ struct CSalZLIB
     UINT avail_in;  /* number of bytes available at next_in */
     ULONG total_in; /* total number of input bytes read so far */
 
-    BYTE* next_out;  /* next output byte should be put there */
+    BYTE* next_out;  /* where to write the next output byte */
     UINT avail_out;  /* remaining free space at next_out */
     ULONG total_out; /* total number of bytes output so far */
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_zlib.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 21/21 review unit(s).
- Validation passed with 1 rewrite(s), 20 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_zlib.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3139 output token(s).
- Copilot CLI: 1 premium request(s).