### PR TITLE
[translation] Fix src/plugins/shared/lukas/gdi.h comments

### DIFF
--- a/src/plugins/shared/lukas/gdi.h
+++ b/src/plugins/shared/lukas/gdi.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/gdi.h
+++ b/src/plugins/shared/lukas/gdi.h
@@ -17,24 +17,24 @@ public:
     ~CBackbufferedDC();
     void Destroy();
 
-    // nastavi okno ke kteremu se DC vaze
+    // Sets the window the DC is bound to
     void SetWindow(HWND window);
 
-    // aktualizuje vnitrni data v zavislosti na zmene velikosti okna/rozliseni
-    // obrazovky apod; nevolat mezi BeginPaint a EndPaint
+    // Updates internal data after changes in window size, screen
+    // resolution, etc.; do not call between BeginPaint and EndPaint
     void Update();
 
-    // zahaji kresleni do okna, _musi_ parovat s EndPaint, nelze volat
-    // opakovane
+    // Starts drawing into the window; _must_ be paired with EndPaint;
+    // cannot be called repeatedly
     void BeginPaint();
 
-    // ukonci kresleni a zkopiruje obsah back-bufferu na obrazovku
+    // Ends drawing and copies the back buffer contents to the screen
     void EndPaint();
 
-    // DC pro kresleni do okna, platne jen mezi BeginPaint a EndPaint
+    // DC for drawing into the window, valid only between BeginPaint and EndPaint
     operator HDC();
 
-    // vrati rectangle o rozmerech bufferu
+    // Returns a RECT with the buffer dimensions
     const RECT& GetRect() { return ClientRect; }
 
 private:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/gdi.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 6 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 8/8 review unit(s).
- Validation passed with 6 rewrite(s), 2 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/lukas/gdi.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3642 output token(s).
- Copilot CLI: 1 premium request(s).