### PR TITLE
[translation] Fix src/plugins/shared/lukas/lcutils.h comments

### DIFF
--- a/src/plugins/shared/lukas/lcutils.h
+++ b/src/plugins/shared/lukas/lcutils.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/lcutils.h
+++ b/src/plugins/shared/lukas/lcutils.h
@@ -35,13 +35,13 @@ private: \
 // utilbase.cpp
 //
 
-extern HINSTANCE DLLInstance;     // handle k SPL-ku - jazykove nezavisle resourcy
-extern HINSTANCE HLanguage;       // handle k SLG-cku - jazykove zavisle resourcy
-extern BOOL WindowsVistaAndLater; // Windows Vista nebo pozdejsi z rady NT (6.0+)
+extern HINSTANCE DLLInstance;     // SPL handle - language-independent resources
+extern HINSTANCE HLanguage;       // SLG handle - language-dependent resources
+extern BOOL WindowsVistaAndLater; // Windows Vista or later in the NT family (6.0+)
 extern BOOL WindowsXP64AndLater;  // Windows XP 64, Vista or later (5.2+)
 
-// rozhrani Open Salamandera - platna od volani InitUtils() az do
-// ukonceni pluginu
+// Open Salamander interface - valid from the InitUtils() call until
+// plugin shutdown
 extern CSalamanderGeneralAbstract* SG;
 extern CSalamanderGUIAbstract* SalGUI;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/lcutils.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 4 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 18/18 review unit(s).
- Validation passed with 4 rewrite(s), 14 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/lukas/lcutils.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3434 output token(s).
- Copilot CLI: 1 premium request(s).