### PR TITLE
[translation] Fix src/plugins/shared/lukas/messages.h comments

### DIFF
--- a/src/plugins/shared/lukas/messages.h
+++ b/src/plugins/shared/lukas/messages.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-// aby byly struktury nezavisle na nastavenem zarovnavani
+// to make the structures independent of the current packing alignment
 #pragma pack(push, 4)
 
 struct CMessage
@@ -69,7 +69,7 @@ private:
     HANDLE HaveMessage;
     HANDLE FileMapping;
     CBuffer* Buffer;
-    HANDLE Reciever;   // jen pro odesilatele, handle ciloveho procesu
-    DWORD RecieverPid; // jen pro odesilatele, id ciloveho procesu
-    int SenderID;      // unikatni identifikator odesilatele
+    HANDLE Reciever;       // sender only: target process handle
+    DWORD RecieverPid;     // sender only: target process ID
+    int SenderID;          // unique sender ID
 };

--- a/src/plugins/shared/lukas/messages.h
+++ b/src/plugins/shared/lukas/messages.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -69,7 +70,7 @@ private:
     HANDLE HaveMessage;
     HANDLE FileMapping;
     CBuffer* Buffer;
-    HANDLE Reciever;       // sender only: target process handle
-    DWORD RecieverPid;     // sender only: target process ID
-    int SenderID;          // unique sender ID
+    HANDLE Reciever;   // sender only: target process handle
+    DWORD RecieverPid; // sender only: target process ID
+    int SenderID;      // unique sender ID
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/messages.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 4 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 6/6 review unit(s).
- Validation passed with 4 rewrite(s), 2 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/shared/lukas/messages.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3526 output token(s).
- Copilot CLI: 1 premium request(s).