### PR TITLE
[translation] Fix src/common/dib.cpp comments

### DIFF
--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -7,7 +7,7 @@
 #include <crtdbg.h>
 #include <ostream>
 #include <limits.h>
-#include <commctrl.h> // potrebuju LPCOLORMAP
+#include <commctrl.h> // Needed for LPCOLORMAP.
 
 #if defined(_DEBUG) && defined(_MSC_VER) // without passing file+line to 'new' operator, list of memory leaks shows only 'crtdbg.h(552)'
 #define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -21,8 +21,8 @@
 
 #include "dib.h"
 
-// opatreni proti runtime check failure v debug verzi: puvodni verze makra pretypovava rgb na WORD,
-// takze hlasi ztratu dat (RED slozky)
+// Workaround for a runtime check failure in the debug build: the original version of the macro casts rgb to WORD,
+//  so it reports data loss in the RED component.
 #undef GetGValue
 #define GetGValue(rgb) ((BYTE)(((rgb) >> 8) & 0xFF))
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 19/19 review unit(s).
- Validation passed with 2 rewrite(s), 17 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/dib.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 6060 output token(s).
- Copilot CLI: 1 premium request(s).