### PR TITLE
[translation] Fix src/common/dib.h comments

### DIFF
--- a/src/common/dib.h
+++ b/src/common/dib.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/dib.h
+++ b/src/common/dib.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-// nacte z resourcu bitmapu hRsrc (ziskan z FindResource(...)),
-// premapuje mapCount barev: mapColor[i] -> toColor[i]
-// a vytvori bitmapu kompatibilni s desktopem
+// loads the bitmap resource hRsrc (obtained with FindResource(...)),
+// remaps mapCount colors: mapColor[i] -> toColor[i],
+// and creates a bitmap compatible with the desktop
 
 HBITMAP LoadBitmapAndMapColors(HINSTANCE hInst, HRSRC hRsrc, int mapCount,
                                COLORREF* mapColor, COLORREF* toColor);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dib.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 2/2 review unit(s).
- Validation passed with 1 rewrite(s), 1 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/dib.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 1036 output token(s).
- Copilot CLI: 1 premium request(s).