### PR TITLE
[translation] Fix src/common/handles.cpp comments

### DIFF
--- a/src/common/handles.cpp
+++ b/src/common/handles.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -524,7 +525,7 @@ C__Handles::C__Handles()
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::InitializeCriticalSection(&CriticalSection);
 #else  // MULTITHREADED_HANDLES_ENABLE
-    __HandlesMainThreadID = ::GetCurrentThreadId();     // The only allowed thread.
+    __HandlesMainThreadID = ::GetCurrentThreadId(); // The only allowed thread.
 #endif // MULTITHREADED_HANDLES_ENABLE
 }
 
@@ -604,7 +605,7 @@ C__Handles::SetInfo(const char* file, int line, C__HandlesOutputType outputType)
     ::EnterCriticalSection(&CriticalSection);
     if (CriticalSection.RecursionCount > 1)
     {
-        DebugBreak();         // Recursive handles call: another hidden message loop, see the call stack.
+        DebugBreak(); // Recursive handles call: another hidden message loop, see the call stack.
     }
 #endif // MULTITHREADED_HANDLES_ENABLE
     OutputType = outputType;
@@ -706,7 +707,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             {
                 C__HandlesOrigin org = Handles[i].Handle.Origin;
                 if (org != __hoLoadAccelerators && org != __hoLoadIcon &&
-                    org != __hoGetStockObject)                     // This is not a handle exempt from release (we prioritize handles that must be released).
+                    org != __hoGetStockObject) // This is not a handle exempt from release (we prioritize handles that must be released).
                 {
                     if (origin != NULL)
                         *origin = org;
@@ -721,7 +722,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             }
         }
     }
-    if (foundTypeOK != -1)     // Found only a handle exempt from release.
+    if (foundTypeOK != -1) // Found only a handle exempt from release.
     {
         type = Handles[foundTypeOK].Handle.Type;
         if (origin != NULL)
@@ -729,7 +730,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
         Handles.Delete(foundTypeOK);
         return TRUE;
     }
-    if (found != -1)     // Found only a handle with the same numeric value.
+    if (found != -1) // Found only a handle with the same numeric value.
     {
 #if defined(_DEBUG) || defined(__HANDLES_DEBUG)
         C__HandlesData* data = &(Handles[found]);
@@ -944,13 +945,13 @@ C__Handles::CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess,
     HANDLE ret = ::CreateFileW(lpFileName, dwDesiredAccess, dwShareMode,
                                lpSecurityAttributes, dwCreationDisposition,
                                dwFlagsAndAttributes, hTemplateFile);
-    WCHAR paramsBuf[800 + 200];     // Limit file names to 800 characters; anything longer would not be printed anyway because of the MESSAGES limit.
+    WCHAR paramsBuf[800 + 200]; // Limit file names to 800 characters; anything longer would not be printed anyway because of the MESSAGES limit.
     const WCHAR* params = NULL;
     if (ret == INVALID_HANDLE_VALUE) // parameters to buffer only when error occurs (can be displayed)
     {
         DWORD err = GetLastError();
         _snwprintf_s(paramsBuf, _TRUNCATE,
-                     L"dwDesiredAccess=0x%X,\ndwShareMode=0x%X,\ndwCreationDisposition=0x%X,\ndwFlagsAndAttributes=0x%X,\nlpFileName=%s",                      // lpFileName is intentionally last; it can be up to 32K long and will be truncated.
+                     L"dwDesiredAccess=0x%X,\ndwShareMode=0x%X,\ndwCreationDisposition=0x%X,\ndwFlagsAndAttributes=0x%X,\nlpFileName=%s", // lpFileName is intentionally last; it can be up to 32K long and will be truncated.
                      dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, lpFileName);
         params = paramsBuf;
         SetLastError(err);
@@ -1039,7 +1040,7 @@ HDC C__Handles::BeginPaint(HWND hwnd, LPPAINTSTRUCT lpPaint)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    HDC ret = ::BeginPaint(hwnd, lpPaint);     // Contains a message loop.
+    HDC ret = ::BeginPaint(hwnd, lpPaint); // Contains a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2113,7 +2114,7 @@ BOOL C__Handles::FreeLibrary(HMODULE hLibModule)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::FreeLibrary(hLibModule);     // Calls DLL global destructors; may contain a message loop.
+    BOOL ret = ::FreeLibrary(hLibModule); // Calls DLL global destructors; may contain a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2133,7 +2134,7 @@ VOID C__Handles::FreeLibraryAndExitThread(HMODULE hLibModule, DWORD dwExitCode)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    ::FreeLibraryAndExitThread(hLibModule, dwExitCode);     // Calls DLL global destructors; may contain a message loop.
+    ::FreeLibraryAndExitThread(hLibModule, dwExitCode); // Calls DLL global destructors; may contain a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2219,7 +2220,7 @@ BOOL C__Handles::FindCloseChangeNotification(HANDLE hChangeHandle)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::FindCloseChangeNotification(hChangeHandle);     // Can hang for quite a long time.
+    BOOL ret = ::FindCloseChangeNotification(hChangeHandle); // Can hang for quite a long time.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2346,7 +2347,7 @@ HFILE
 C__Handles::OpenFile(LPCSTR lpFileName, LPOFSTRUCT lpReOpenBuff, UINT uStyle)
 {
     HFILE ret = ::OpenFile(lpFileName, lpReOpenBuff, uStyle);
-    CheckCreate(ret != HFILE_ERROR, __htFile, __hoOpenFile, (HANDLE)(UINT_PTR)ret, GetLastError(), TRUE);     // lpFileName is only char even in the Unicode version, so this function is unusable (obsolete); I left it out of the parameter dump.
+    CheckCreate(ret != HFILE_ERROR, __htFile, __hoOpenFile, (HANDLE)(UINT_PTR)ret, GetLastError(), TRUE); // lpFileName is only char even in the Unicode version, so this function is unusable (obsolete); I left it out of the parameter dump.
     return ret;
 }
 
@@ -2378,7 +2379,7 @@ HDWP C__Handles::DeferWindowPos(HDWP hWinPosInfo, HWND hWnd, HWND hWndInsertAfte
 {
     HDWP ret = ::DeferWindowPos(hWinPosInfo, hWnd, hWndInsertAfter, x, y, cx, cy, uFlags);
 
-    if (ret != hWinPosInfo)     // The structure was reallocated, so we must update the tracked handle value.
+    if (ret != hWinPosInfo) // The structure was reallocated, so we must update the tracked handle value.
     {
         CheckClose(TRUE, (HANDLE)hWinPosInfo, __htDeferWindowPos, __GetHandlesOrigin(__hoDeferWindowPos), ERROR_SUCCESS, FALSE);
         CheckCreate(ret != NULL, __htDeferWindowPos, __hoDeferWindowPos, (HANDLE)ret, GetLastError());
@@ -2400,7 +2401,7 @@ BOOL C__Handles::EndDeferWindowPos(HDWP hWinPosInfo)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::EndDeferWindowPos(hWinPosInfo);     // Contains a message loop.
+    BOOL ret = ::EndDeferWindowPos(hWinPosInfo); // Contains a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);

--- a/src/common/handles.cpp
+++ b/src/common/handles.cpp
@@ -7,7 +7,7 @@
 #include <tchar.h>
 #include <crtdbg.h>
 #include <ostream>
-#include <commctrl.h> // potrebuju LPCOLORMAP
+#include <commctrl.h> // Need LPCOLORMAP.
 
 #if defined(_DEBUG) && defined(_MSC_VER) // without passing file+line to 'new' operator, list of memory leaks shows only 'crtdbg.h(552)'
 #define new new (_NORMAL_BLOCK, __FILE__, __LINE__)
@@ -25,15 +25,15 @@
 // boundaries so we can find the real functions
 // that we need to call for initialization.
 
-#pragma warning(disable : 4075) // chceme definovat poradi inicializace modulu
+#pragma warning(disable : 4075) // We want to define the module initialization order.
 
 typedef void(__cdecl* _PVFV)(void);
 
 #pragma section(".i_hnd$a", read)
-__declspec(allocate(".i_hnd$a")) const _PVFV i_handles = (_PVFV)1; // na zacatek sekce .i_hnd si dame promennou i_handles
+__declspec(allocate(".i_hnd$a")) const _PVFV i_handles = (_PVFV)1; // Put the i_handles variable at the start of the .i_hnd section.
 
 #pragma section(".i_hnd$z", read)
-__declspec(allocate(".i_hnd$z")) const _PVFV i_handles_end = (_PVFV)1; // a na konec sekce .i_hnd si dame promennou i_handles_end
+__declspec(allocate(".i_hnd$z")) const _PVFV i_handles_end = (_PVFV)1; // Put the i_handles_end variable at the end of the .i_hnd section.
 
 void Initialize__Handles()
 {
@@ -524,13 +524,13 @@ C__Handles::C__Handles()
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::InitializeCriticalSection(&CriticalSection);
 #else  // MULTITHREADED_HANDLES_ENABLE
-    __HandlesMainThreadID = ::GetCurrentThreadId(); // jediny povoleny thread
+    __HandlesMainThreadID = ::GetCurrentThreadId();     // The only allowed thread.
 #endif // MULTITHREADED_HANDLES_ENABLE
 }
 
 C__Handles::~C__Handles()
 {
-    // vyrazeni handlu, ktere se uvolnuji automaticky
+    // Filter out handles that are released automatically.
     for (int i = Handles.Count - 1; i >= 0; i--)
     {
         if (Handles[i].Handle.Origin == __hoLoadAccelerators)
@@ -540,15 +540,15 @@ C__Handles::~C__Handles()
         else if (Handles[i].Handle.Origin == __hoGetStockObject)
             Handles.Delete(i);
     }
-    // kontrola + vypis zbylych
+    // Check and list the remaining handles.
     if (Handles.Count != 0)
     {
-        // musel jsem nahradit nize polozeny kod vyuzivajici MESSAGE_E, protoze pri volani
-        // tohoto destruktoru jsou v ALTAPDB jiz zdestruovane facets streamu a pri poslani intu
-        // nebo handlu do streamu to proste spadne (dela jen VC2010 a VC2012, ve VC2008
-        // to jeste slape); v Salamanderovi to nezlobi, asi kvuli RTL v DLLku (v ALTAPDB je
-        // static), ci co, po tom jsem uz dal nepatral, lepsi reseni by bylo zaridit
-        // destrukci facets az po tomto modulu, ale to bohuzel neumim (jen tez na "lib" urovni)
+        // I had to replace the code below that uses MESSAGE_E, because when this
+        // destructor is called the stream facets in ALTAPDB have already been destroyed, and sending an int
+        // or handle to the stream simply crashes (this happens only in VC2010 and VC2012; in VC2008
+        // it still works). It does not happen in Salamander, probably because the RTL is in the DLL
+        // (ALTAPDB uses a static one); I did not investigate further. A better solution would be to destroy the
+        // facets only after this module, but unfortunately I cannot do that (only at the "lib" level).
         char msgBuf[1000];
         sprintf_s(msgBuf,
 #ifdef MESSAGES_DEBUG
@@ -576,7 +576,7 @@ C__Handles::~C__Handles()
             TRACE_I("List of opened handles:");
             for (int i = 0; i < Handles.Count; i++)
             {
-                // saskarna pres msgBuf kvuli padackam v ALTAPDB, podrobnosti viz komentar vyse
+                // msgBuf workaround because of crashes in ALTAPDB; see the comment above for details.
                 sprintf_s(msgBuf, "%p", Handles[i].Handle.Handle);
                 TRACE_MI(Handles[i].File, Handles[i].Line,
                          __GetHandlesTypeName(Handles[i].Handle.Type) << " - " << __GetHandlesOrigin(Handles[i].Handle.Origin) << " - " << msgBuf);
@@ -585,7 +585,7 @@ C__Handles::~C__Handles()
         else
         {
             ConnectToTraceServer();
-            // saskarna pres msgBuf kvuli padackam v ALTAPDB, podrobnosti viz komentar vyse
+            // msgBuf workaround because of crashes in ALTAPDB; see the comment above for details.
             sprintf_s(msgBuf, "%d", Handles.Count);
             TRACE_I(__HandlesMessageNumberOpened << msgBuf);
         }
@@ -604,7 +604,7 @@ C__Handles::SetInfo(const char* file, int line, C__HandlesOutputType outputType)
     ::EnterCriticalSection(&CriticalSection);
     if (CriticalSection.RecursionCount > 1)
     {
-        DebugBreak(); // rekurzivni volani handles !!! zase nejaka maskovana message-loopa - viz call-stack
+        DebugBreak();         // Recursive handles call: another hidden message loop, see the call stack.
     }
 #endif // MULTITHREADED_HANDLES_ENABLE
     OutputType = outputType;
@@ -706,7 +706,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             {
                 C__HandlesOrigin org = Handles[i].Handle.Origin;
                 if (org != __hoLoadAccelerators && org != __hoLoadIcon &&
-                    org != __hoGetStockObject) // nejde o handle, ktery nemusi byt uvolneny (prioritne uvolnujeme handly, ktere se musi uvolnit)
+                    org != __hoGetStockObject)                     // This is not a handle exempt from release (we prioritize handles that must be released).
                 {
                     if (origin != NULL)
                         *origin = org;
@@ -721,7 +721,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             }
         }
     }
-    if (foundTypeOK != -1) // nalezen jen handle, ktery nemusi byt uvolneny
+    if (foundTypeOK != -1)     // Found only a handle exempt from release.
     {
         type = Handles[foundTypeOK].Handle.Type;
         if (origin != NULL)
@@ -729,7 +729,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
         Handles.Delete(foundTypeOK);
         return TRUE;
     }
-    if (found != -1) // nalezen jen handle se shodnym cislem
+    if (found != -1)     // Found only a handle with the same numeric value.
     {
 #if defined(_DEBUG) || defined(__HANDLES_DEBUG)
         C__HandlesData* data = &(Handles[found]);
@@ -944,13 +944,13 @@ C__Handles::CreateFileW(LPCWSTR lpFileName, DWORD dwDesiredAccess,
     HANDLE ret = ::CreateFileW(lpFileName, dwDesiredAccess, dwShareMode,
                                lpSecurityAttributes, dwCreationDisposition,
                                dwFlagsAndAttributes, hTemplateFile);
-    WCHAR paramsBuf[800 + 200]; // na jmena souboru omezime na 800 znaku, stejne delsi nevytiskneme diky omezeni MESSAGES
+    WCHAR paramsBuf[800 + 200];     // Limit file names to 800 characters; anything longer would not be printed anyway because of the MESSAGES limit.
     const WCHAR* params = NULL;
     if (ret == INVALID_HANDLE_VALUE) // parameters to buffer only when error occurs (can be displayed)
     {
         DWORD err = GetLastError();
         _snwprintf_s(paramsBuf, _TRUNCATE,
-                     L"dwDesiredAccess=0x%X,\ndwShareMode=0x%X,\ndwCreationDisposition=0x%X,\ndwFlagsAndAttributes=0x%X,\nlpFileName=%s", // lpFileName mame schvalne az na konci, muze byt az 32k dlouhe, orizne se
+                     L"dwDesiredAccess=0x%X,\ndwShareMode=0x%X,\ndwCreationDisposition=0x%X,\ndwFlagsAndAttributes=0x%X,\nlpFileName=%s",                      // lpFileName is intentionally last; it can be up to 32K long and will be truncated.
                      dwDesiredAccess, dwShareMode, dwCreationDisposition, dwFlagsAndAttributes, lpFileName);
         params = paramsBuf;
         SetLastError(err);
@@ -1039,7 +1039,7 @@ HDC C__Handles::BeginPaint(HWND hwnd, LPPAINTSTRUCT lpPaint)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    HDC ret = ::BeginPaint(hwnd, lpPaint); // obsahuje message-loopu
+    HDC ret = ::BeginPaint(hwnd, lpPaint);     // Contains a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2113,7 +2113,7 @@ BOOL C__Handles::FreeLibrary(HMODULE hLibModule)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::FreeLibrary(hLibModule); // obsahuje volani destruktoru globalek DLLka, muze obsahovat message-loopu
+    BOOL ret = ::FreeLibrary(hLibModule);     // Calls DLL global destructors; may contain a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2133,7 +2133,7 @@ VOID C__Handles::FreeLibraryAndExitThread(HMODULE hLibModule, DWORD dwExitCode)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    ::FreeLibraryAndExitThread(hLibModule, dwExitCode); // obsahuje volani destruktoru globalek DLLka, muze obsahovat message-loopu
+    ::FreeLibraryAndExitThread(hLibModule, dwExitCode);     // Calls DLL global destructors; may contain a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2219,7 +2219,7 @@ BOOL C__Handles::FindCloseChangeNotification(HANDLE hChangeHandle)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::FindCloseChangeNotification(hChangeHandle); // muze se kousnout i na dost dlouho
+    BOOL ret = ::FindCloseChangeNotification(hChangeHandle);     // Can hang for quite a long time.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);
@@ -2346,7 +2346,7 @@ HFILE
 C__Handles::OpenFile(LPCSTR lpFileName, LPOFSTRUCT lpReOpenBuff, UINT uStyle)
 {
     HFILE ret = ::OpenFile(lpFileName, lpReOpenBuff, uStyle);
-    CheckCreate(ret != HFILE_ERROR, __htFile, __hoOpenFile, (HANDLE)(UINT_PTR)ret, GetLastError(), TRUE); // lpFileName je jen char i v Unicode verzi = nepouzitelna funkce (zastarala), vyradil jsem ji z vypisu parametru
+    CheckCreate(ret != HFILE_ERROR, __htFile, __hoOpenFile, (HANDLE)(UINT_PTR)ret, GetLastError(), TRUE);     // lpFileName is only char even in the Unicode version, so this function is unusable (obsolete); I left it out of the parameter dump.
     return ret;
 }
 
@@ -2378,7 +2378,7 @@ HDWP C__Handles::DeferWindowPos(HDWP hWinPosInfo, HWND hWnd, HWND hWndInsertAfte
 {
     HDWP ret = ::DeferWindowPos(hWinPosInfo, hWnd, hWndInsertAfter, x, y, cx, cy, uFlags);
 
-    if (ret != hWinPosInfo) // doslo k realokaci struktury - musime zmenit hodnotu hlidaneho handlu
+    if (ret != hWinPosInfo)     // The structure was reallocated, so we must update the tracked handle value.
     {
         CheckClose(TRUE, (HANDLE)hWinPosInfo, __htDeferWindowPos, __GetHandlesOrigin(__hoDeferWindowPos), ERROR_SUCCESS, FALSE);
         CheckCreate(ret != NULL, __htDeferWindowPos, __hoDeferWindowPos, (HANDLE)ret, GetLastError());
@@ -2400,7 +2400,7 @@ BOOL C__Handles::EndDeferWindowPos(HDWP hWinPosInfo)
     ::LeaveCriticalSection(&CriticalSection);
 #endif // MULTITHREADED_HANDLES_ENABLE
 
-    BOOL ret = ::EndDeferWindowPos(hWinPosInfo); // obsahuje message-loopu
+    BOOL ret = ::EndDeferWindowPos(hWinPosInfo);     // Contains a message loop.
 
 #ifdef MULTITHREADED_HANDLES_ENABLE
     ::EnterCriticalSection(&CriticalSection);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/handles.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 23 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 86/86 review unit(s).
- Validation passed with 23 rewrite(s), 62 keep(s), and 1 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/handles.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 12193 output token(s).
- Copilot CLI: 1 premium request(s).