### PR TITLE
[translation] Fix src/common/handles.h comments

### DIFF
--- a/src/common/handles.h
+++ b/src/common/handles.h
@@ -3,15 +3,15 @@
 
 #pragma once
 
-// makro HANDLES_ENABLE - zapina monitorovani handlu
-// makro _DEBUG nebo __HANDLES_DEBUG - vypis debug hlasek do TRACE
-// makro MULTITHREADED_HANDLES_ENABLE - pripravi handles pro multithreadove aplikace
+// HANDLES_ENABLE macro - enables handle monitoring
+// _DEBUG or __HANDLES_DEBUG macro - outputs debug messages to TRACE
+// MULTITHREADED_HANDLES_ENABLE macro - prepares handles for multithreaded applications
 
 #define NOHANDLES(function) function
 
 #ifndef HANDLES_ENABLE
 
-// aby nedochazelo k problemum se stredniky v nize nadefinovanych makrech
+// to avoid problems with semicolons in the macros defined below
 inline void __HandlesEmptyFunction() {}
 
 #define HANDLES(function) ::function
@@ -26,7 +26,7 @@ inline void __HandlesEmptyFunction() {}
 
 #ifndef MULTITHREADED_HANDLES_ENABLE
 
-// pro kontrolu pouziti nemulti-threadove verze modulu
+// for checking use of the non-multithreaded module version
 extern DWORD __HandlesMainThreadID;
 
 #endif // MULTITHREADED_HANDLES_ENABLE
@@ -47,8 +47,8 @@ enum C__HandlesOutputType
 
 enum C__HandlesType
 {
-    __htHandle_comp_with_CloseHandle,  // handle kompatibilni s CloseHandle() a DuplicateHandle()
-    __htHandle_comp_with_DeleteObject, // handle kompatibilni s DeleteObject() a GetStockObject()
+    __htHandle_comp_with_CloseHandle,      // handle compatible with CloseHandle() and DuplicateHandle()
+    __htHandle_comp_with_DeleteObject,     // handle compatible with DeleteObject() and GetStockObject()
     __htKey,
     __htIcon,
     __htGlobal,
@@ -213,7 +213,7 @@ struct C__HandlesHandle
 {
     C__HandlesType Type;
     C__HandlesOrigin Origin;
-    HANDLE Handle; // univerzalni, pro vsechny druhy handlu
+    HANDLE Handle;     // generic, for all handle types
 
     C__HandlesHandle() {}
 
@@ -257,11 +257,11 @@ protected:
 class C__Handles
 {
 protected:
-    C_HandlesDataArray Handles;      // vsechny kontrolovane handly
-    C__HandlesData TemporaryHandle;  // pri vkladani nastaven z SetInfo()
-    C__HandlesOutputType OutputType; // typ vystupu hlasek
+    C_HandlesDataArray Handles;          // all monitored handles
+    C__HandlesData TemporaryHandle;      // set from SetInfo() during insertion
+    C__HandlesOutputType OutputType;     // message output type
 #ifdef MULTITHREADED_HANDLES_ENABLE
-    CRITICAL_SECTION CriticalSection; // pro synchronizaci multi-threadu
+    CRITICAL_SECTION CriticalSection;     // for multithreaded synchronization
 #endif // MULTITHREADED_HANDLES_ENABLE
 
 public:
@@ -655,9 +655,9 @@ public:
     BOOL OpenProcessToken(HANDLE ProcessHandle, DWORD DesiredAccess, PHANDLE TokenHandle);
 
 protected:
-    void AddHandle(C__HandlesHandle handle); // prida TemporaryHandle
+    void AddHandle(C__HandlesHandle handle);     // adds TemporaryHandle
 
-    // vyjme handle, pri uspechu vraci TRUE
+    // removes the handle; returns TRUE on success
     BOOL DeleteHandle(C__HandlesType& type, HANDLE handle,
                       C__HandlesOrigin* origin,
                       C__HandlesType expType);

--- a/src/common/handles.h
+++ b/src/common/handles.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -47,8 +48,8 @@ enum C__HandlesOutputType
 
 enum C__HandlesType
 {
-    __htHandle_comp_with_CloseHandle,      // handle compatible with CloseHandle() and DuplicateHandle()
-    __htHandle_comp_with_DeleteObject,     // handle compatible with DeleteObject() and GetStockObject()
+    __htHandle_comp_with_CloseHandle,  // handle compatible with CloseHandle() and DuplicateHandle()
+    __htHandle_comp_with_DeleteObject, // handle compatible with DeleteObject() and GetStockObject()
     __htKey,
     __htIcon,
     __htGlobal,
@@ -213,7 +214,7 @@ struct C__HandlesHandle
 {
     C__HandlesType Type;
     C__HandlesOrigin Origin;
-    HANDLE Handle;     // generic, for all handle types
+    HANDLE Handle; // generic, for all handle types
 
     C__HandlesHandle() {}
 
@@ -257,11 +258,11 @@ protected:
 class C__Handles
 {
 protected:
-    C_HandlesDataArray Handles;          // all monitored handles
-    C__HandlesData TemporaryHandle;      // set from SetInfo() during insertion
-    C__HandlesOutputType OutputType;     // message output type
+    C_HandlesDataArray Handles;      // all monitored handles
+    C__HandlesData TemporaryHandle;  // set from SetInfo() during insertion
+    C__HandlesOutputType OutputType; // message output type
 #ifdef MULTITHREADED_HANDLES_ENABLE
-    CRITICAL_SECTION CriticalSection;     // for multithreaded synchronization
+    CRITICAL_SECTION CriticalSection; // for multithreaded synchronization
 #endif // MULTITHREADED_HANDLES_ENABLE
 
 public:
@@ -655,7 +656,7 @@ public:
     BOOL OpenProcessToken(HANDLE ProcessHandle, DWORD DesiredAccess, PHANDLE TokenHandle);
 
 protected:
-    void AddHandle(C__HandlesHandle handle);     // adds TemporaryHandle
+    void AddHandle(C__HandlesHandle handle); // adds TemporaryHandle
 
     // removes the handle; returns TRUE on success
     BOOL DeleteHandle(C__HandlesType& type, HANDLE handle,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/handles.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 12 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 22/22 review unit(s).
- Validation passed with 12 rewrite(s), 10 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/handles.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 7913 output token(s).
- Copilot CLI: 1 premium request(s).