### PR TITLE
[translation] Fix src/common/heap.cpp comments

### DIFF
--- a/src/common/heap.cpp
+++ b/src/common/heap.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -111,7 +112,7 @@ public:
                 FreeLibrary(hUsedModules[i]);
 
             // Show the warning message box
-            MSG msg;             // Clear any buffered ESC key so the message box does not close immediately
+            MSG msg; // Clear any buffered ESC key so the message box does not close immediately
             while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                 ;
             MessageBoxA(NULL, "Detected memory leaks!", "Heap Message",

--- a/src/common/heap.cpp
+++ b/src/common/heap.cpp
@@ -28,15 +28,15 @@
 // boundaries so we can find the real functions
 // that we need to call for initialization.
 
-#pragma warning(disable : 4075) // chceme definovat poradi inicializace modulu
+#pragma warning(disable : 4075) // Define the module initialization order
 
 typedef void(__cdecl* _PVFV)(void);
 
 #pragma section(".i_hea$a", read)
-__declspec(allocate(".i_hea$a")) const _PVFV i_heap = (_PVFV)1; // na zacatek sekce .i_hea si dame promennou i_heap
+__declspec(allocate(".i_hea$a")) const _PVFV i_heap = (_PVFV)1; // Place i_heap at the start of the .i_hea section
 
 #pragma section(".i_hea$z", read)
-__declspec(allocate(".i_hea$z")) const _PVFV i_heap_end = (_PVFV)1; // a na konec sekce .i_hea si dame promennou i_heap_end
+__declspec(allocate(".i_hea$z")) const _PVFV i_heap_end = (_PVFV)1; // Place i_heap_end at the end of the .i_hea section
 
 void Initialize__Heap()
 {
@@ -69,8 +69,7 @@ int OurReportingFunction(int reportType, char* userMessage, int* retVal)
     // retVal to one.
     *retVal = 0;
 
-    // we'll report some information, but we also
-    // want _CrtDbgReport to get called - so we'll return FALSE
+    // Return FALSE after reporting some information so _CrtDbgReport still gets called
     return FALSE;
 }
 
@@ -79,7 +78,7 @@ class C__GCHeapInit
 public:
     C__GCHeapInit()
     {
-        // uloz stav pameti na zacatku
+        // Save the initial memory state
         _CrtMemCheckpoint(&start_state);
         prev_reporting_hook = _CrtSetReportHook(OurReportingFunction);
         InitializeCriticalSection(&CriticalSection);
@@ -87,32 +86,32 @@ public:
     }
     ~C__GCHeapInit()
     {
-        // zjisti aktualni stav pameti
+        // Capture the current memory state
         _CrtMemState end_state;
         _CrtMemCheckpoint(&end_state);
 
-        // zkontroluj, jestli jsou nejake leaky
+        // Check for memory leaks
         _CrtMemState diff;
         if (_CrtMemDifference(&diff, &start_state, &end_state))
         {
             HMODULE hUsedModules[GCHEAP_MAX_USED_MODULES];
-            // namapuju do pameti vsechny moduly, ve kterych se muzou hlasit memory leaky,
-            // tim se v reportu zobrazi jmena .cpp souboru (jinak by tam bylo jen "#File Error#")
+            // Map into memory all modules that may report memory leaks,
+            // so the report shows the .cpp file names (otherwise it would show only "#File Error#")
             for (int i = 0; i < UsedModulesCount; i++)
                 hUsedModules[i] = LoadLibraryEx(UsedModules[i], NULL, DONT_RESOLVE_DLL_REFERENCES);
 
-            // vypise vsechny neuvolnene bloky
+            // Dump all unfreed blocks
             _CrtMemDumpAllObjectsSince(&start_state);
 
-            // kdyz uz mame diff, tak ho taky vypisem
+            // Dump the diff too, since we already have it
             _CrtMemDumpStatistics(&diff);
 
-            // zase uvolnime namapovane moduly
+            // Release the mapped modules again
             for (int i = 0; i < UsedModulesCount; i++)
                 FreeLibrary(hUsedModules[i]);
 
-            // vyhod warning messagebox
-            MSG msg; // remove possibly buffered ESC key (not to close msgbox immediately)
+            // Show the warning message box
+            MSG msg;             // Clear any buffered ESC key so the message box does not close immediately
             while (PeekMessage(&msg, NULL, WM_KEYFIRST, WM_KEYLAST, PM_REMOVE))
                 ;
             MessageBoxA(NULL, "Detected memory leaks!", "Heap Message",


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/heap.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 13 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 19/19 review unit(s).
- Validation passed with 13 rewrite(s), 6 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/heap.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 9027 output token(s).
- Copilot CLI: 1 premium request(s).