### PR TITLE
[translation] Fix src/common/heap.h comments

### DIFF
--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -3,18 +3,13 @@
 
 #pragma once
 
-// Pridat do DEBUG verze projektu makro _CRTDBG_MAP_ALLOC, jinak se neukazuje zdroj leaku.
+// Define _CRTDBG_MAP_ALLOC in the DEBUG build; otherwise the leak source is not shown.
 
 #if defined(_DEBUG) && !defined(HEAP_DISABLE)
 
-#define GCHEAP_MAX_USED_MODULES 100 // kolik nejvic modulu se ma pamatovat pro load pred vypisem leaku
+#define GCHEAP_MAX_USED_MODULES 100 // maximum number of modules to remember so they can be loaded before reporting memory leaks
 
-// vola se pro moduly, ve kterych se muzou hlasit memory leaky, pokud se memory leaky detekuji,
-// dojde k loadu "as image" (bez initu modulu) vsech takto registrovanych modulu (pri kontrole
-// memory leaku uz jsou tyto moduly unloadle), a pak teprve k vypisu memory leaku = jsou videt
-// jmena .cpp modulu misto "#File Error#" hlasek, zaroven MSVC neotravuje s hromadou generovanych
-// exceptionu (jmena modulu jsou dostupna)
-// mozne volat z libovolneho threadu
+// Call this for modules that may report memory leaks. If leaks are detected, all modules registered this way are loaded "as image" (without module initialization; the modules are already unloaded when leaks are checked) before the leak report is printed. This shows .cpp module names instead of "#File Error#" messages, and MSVC does not flood the output with generated exceptions because the module names are available. Can be called from any thread.
 void AddModuleWithPossibleMemoryLeaks(const TCHAR* fileName);
 
 #endif // defined(_DEBUG) && !defined(HEAP_DISABLE)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/heap.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 3 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 4/4 review unit(s).
- Validation passed with 3 rewrite(s), 1 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/heap.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3753 output token(s).
- Copilot CLI: 1 premium request(s).