### PR TITLE
[translation] Fix src/common/lstrfix.inc comments

### DIFF
--- a/src/common/lstrfix.inc
+++ b/src/common/lstrfix.inc
@@ -3,8 +3,8 @@
 
 #include "lstrfix.h"
 
-// potlaceni warningu C4996: This function or variable may be unsafe. Consider using strcat_s instead.
-// duvod: lstrcat a dalsi Windows rutiny prost nejsou safe, takze to nema smysl resit tady
+// Suppress warning C4996: This function or variable may be unsafe. Consider using strcat_s instead.
+// Reason: lstrcat and other Windows routines simply are not safe, so it makes no sense to address it here.
 #pragma warning(push)
 #pragma warning(disable:4996)
 
@@ -75,8 +75,8 @@ LPWSTR _sal_lstrcatW(LPWSTR lpString1, LPCWSTR lpString2)
 // allows us to define these names.
 #pragma function(strlen, wcslen, strcpy, wcscpy, strcat, wcscat)
 
-// musel jsem si od MS pujcit implementace strlen, wcslen, strcpy, wcscpy, strcat a wcscat
-// protoze se zde ignoruji default-liby, kde jsou tyto funkce umistene
+// Borrowed the MS implementations of strlen, wcslen, strcpy, wcscpy, strcat, and wcscat
+// because the default libraries that contain these functions are ignored here.
 size_t __cdecl strlen (
         const char * str
         )


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/lstrfix.inc`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 12/12 review unit(s).
- Validation passed with 2 rewrite(s), 9 keep(s), and 1 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/lstrfix.inc` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4054 output token(s).
- Copilot CLI: 1 premium request(s).