### PR TITLE
[translation] Fix src/common/lstrfix.h comments

### DIFF
--- a/src/common/lstrfix.h
+++ b/src/common/lstrfix.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/lstrfix.h
+++ b/src/common/lstrfix.h
@@ -3,11 +3,10 @@
 
 #pragma once
 
-// nasledujici funkce nepadaji pri praci s neplatnou pameti (ani pri praci s NULL):
-// lstrcpy, lstrcpyn, lstrlen a lstrcat (ty jsou definovane s priponou A nebo W, proto
-// je primo neredefinujeme), v zajmu snazsiho odladeni chyb potrebujeme, aby padaly,
-// protoze jinak se na chybu prijde pozdeji v miste, kde uz nemusi byt jasne, co ji
-// zpusobilo
+// The following functions do not crash when passed invalid pointers (including NULL):
+// lstrcpy, lstrcpyn, lstrlen, and lstrcat (these are defined with the A or W suffix, so
+// we do not redefine them directly). For easier debugging, we need them to crash,
+// because otherwise the bug is detected later, where its cause may no longer be clear
 #define lstrcpyA _sal_lstrcpyA
 #define lstrcpyW _sal_lstrcpyW
 #define lstrcpynA _sal_lstrcpynA


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/lstrfix.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 1/1 review unit(s).
- Validation passed with 1 rewrite(s), 0 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/lstrfix.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 2326 output token(s).
- Copilot CLI: 1 premium request(s).