### PR TITLE
[translation] Fix src/common/messages.cpp comments

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -178,14 +179,14 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     data.Type = uType;
     data.Return = 0;
 
-    MessagesStrStream.flush();     // flush into the buffer (lpText)
+    MessagesStrStream.flush(); // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     data.Text = MessagesStringBuf.c_str();
-    MessagesStringBuf.erase();     // prepare for the next message
+    MessagesStringBuf.erase(); // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     int len = (int)MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len);     // backup copy of the text
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // backup copy of the text
     if (message != NULL)
     {
         memcpy((char*)message, MessagesStringBuf.c_str(), len); // je to FIXED -> HANDLE==PTR
@@ -193,8 +194,8 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     }
     else
         data.Text = __MessagesLowMemory;
-    MessagesStringBuf.erase();     // prepare for the next message
-    LeaveMessagesModul();          // other threads and message loops may resume now
+    MessagesStringBuf.erase(); // prepare for the next message
+    LeaveMessagesModul();      // other threads and message loops may resume now
 #endif                         // MULTITHREADED_MESSAGES_ENABLE
 
     // run the MessageBox in a new thread so it does not dispatch this thread's messages
@@ -202,7 +203,7 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)__MessagesMessageBoxThreadF, &data, 0, &threadID);
     if (thread != NULL)
     {
-        WaitForSingleObject(thread, INFINITE);         // wait until the user dismisses it
+        WaitForSingleObject(thread, INFINITE); // wait until the user dismisses it
         CloseHandle(thread);
     }
     else
@@ -219,24 +220,24 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
 int C__Messages::MessageBox(HWND hWnd, const char* lpCaption, UINT uType)
 {
     int ret;
-    MessagesStrStream.flush();     // flush into the buffer (lpText)
+    MessagesStrStream.flush(); // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     if (!IsWindow(hWnd))
         hWnd = NULL;
     ret = ::MessageBoxA(hWnd, MessagesStringBuf.c_str(), lpCaption, uType);
-    MessagesStringBuf.erase();     // prepare for the next message
+    MessagesStringBuf.erase(); // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     size_t len = MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len);     // backup copy of the text
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // backup copy of the text
     char* txt;
     txt = (char*)message; // je to FIXED -> HANDLE==PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), len);
     else
         txt = (char*)__MessagesLowMemory;
-    MessagesStringBuf.erase();     // prepare for the next message
-    LeaveMessagesModul();          // other threads and message loops may resume now
+    MessagesStringBuf.erase(); // prepare for the next message
+    LeaveMessagesModul();      // other threads and message loops may resume now
 
     if (!IsWindow(hWnd))
         hWnd = NULL;
@@ -288,14 +289,14 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     data.Type = uType;
     data.Return = 0;
 
-    MessagesStrStream.flush();     // flush into the buffer (lpText)
+    MessagesStrStream.flush(); // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     data.Text = MessagesStringBuf.c_str();
-    MessagesStringBuf.erase();     // prepare for the next message
+    MessagesStringBuf.erase(); // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     int len = (int)MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len);     // backup copy of the text
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // backup copy of the text
     if (message != NULL)
     {
         memcpy((WCHAR*)message, MessagesStringBuf.c_str(), sizeof(WCHAR) * len); // je to FIXED -> HANDLE==PTR
@@ -303,8 +304,8 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     }
     else
         data.Text = __MessagesLowMemoryW;
-    MessagesStringBuf.erase();     // prepare for the next message
-    LeaveMessagesModul();          // other threads and message loops may resume now
+    MessagesStringBuf.erase(); // prepare for the next message
+    LeaveMessagesModul();      // other threads and message loops may resume now
 #endif                         // MULTITHREADED_MESSAGES_ENABLE
 
     // run the MessageBox in a new thread so it does not dispatch this thread's messages
@@ -312,7 +313,7 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)__MessagesWMessageBoxThreadF, &data, 0, &threadID);
     if (thread != NULL)
     {
-        WaitForSingleObject(thread, INFINITE);         // wait until the user dismisses it
+        WaitForSingleObject(thread, INFINITE); // wait until the user dismisses it
         CloseHandle(thread);
     }
     else
@@ -329,24 +330,24 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
 int C__MessagesW::MessageBox(HWND hWnd, const WCHAR* lpCaption, UINT uType)
 {
     int ret;
-    MessagesStrStream.flush();     // flush into the buffer (lpText)
+    MessagesStrStream.flush(); // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     if (!IsWindow(hWnd))
         hWnd = NULL;
     ret = ::MessageBoxW(hWnd, MessagesStringBuf.c_str(), lpCaption, uType);
-    MessagesStringBuf.erase();     // prepare for the next message
+    MessagesStringBuf.erase(); // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     size_t len = MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len);     // backup copy of the text
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // backup copy of the text
     WCHAR* txt;
     txt = (WCHAR*)message; // je to FIXED -> HANDLE==PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), sizeof(WCHAR) * len);
     else
         txt = (WCHAR*)__MessagesLowMemoryW;
-    MessagesStringBuf.erase();     // prepare for the next message
-    LeaveMessagesModul();          // other threads and message loops may resume now
+    MessagesStringBuf.erase(); // prepare for the next message
+    LeaveMessagesModul();      // other threads and message loops may resume now
 
     if (!IsWindow(hWnd))
         hWnd = NULL;

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -20,15 +20,15 @@
 // boundaries so we can find the real functions
 // that we need to call for initialization.
 
-#pragma warning(disable : 4075) // chceme definovat poradi inicializace modulu
+#pragma warning(disable : 4075) // we want to define the module initialization order
 
 typedef void(__cdecl* _PVFV)(void);
 
 #pragma section(".i_msg$a", read)
-__declspec(allocate(".i_msg$a")) const _PVFV i_messages = (_PVFV)1; // na zacatek sekce .i_msg si dame promennou i_messages
+__declspec(allocate(".i_msg$a")) const _PVFV i_messages = (_PVFV)1; // put i_messages at the start of the .i_msg section
 
 #pragma section(".i_msg$z", read)
-__declspec(allocate(".i_msg$z")) const _PVFV i_messages_end = (_PVFV)1; // a na konec sekce .i_msg si dame promennou i_messages_end
+__declspec(allocate(".i_msg$z")) const _PVFV i_messages_end = (_PVFV)1; // put i_messages_end at the end of the .i_msg section
 
 void Initialize__Messages()
 {
@@ -77,16 +77,16 @@ WCHAR __MessagesTitleBufW[200];
 
 #ifdef MULTITHREADED_MESSAGES_ENABLE
 
-// kriticka sekce pro cely modul - monitor
+// module-wide critical section - monitor
 CRITICAL_SECTION __MessagesCriticalSection;
-// handle aktualniho vlastniciho threadu
+// ID of the current owning thread
 DWORD __MessagesOwnerThreadID = 0;
-// pocet vnorenych volani EnterMessagesModul (v ramci aktualniho vlastniciho threadu)
+// number of nested EnterMessagesModul calls within the current owning thread
 int __MessagesModulBlockCount = 0;
 
 #ifdef MESSAGES_DEBUG
 
-// volani z threadu, ktery nema pristup k datum a funkcim modulu (nezalokoval)
+// call from a thread that has no access to the module data and functions (did not allocate them)
 const char* __MessagesBadCall = "Incorrect call to function from modul MESSAGES.";
 
 #endif // MESSAGES_DEBUG
@@ -139,20 +139,10 @@ void LeaveMessagesModul()
 C__Messages::C__Messages() : MessagesStrStream(&MessagesStringBuf)
 {
 #ifdef _DEBUG
-    // nove streamy pouzivaji interne locales, ktere maji implementovany
-    // jednotlive "facets" pomoci lazy creation - jsou alokovany na heapu
-    // kdyz jsou potreba, tedy kdyz nekdo posle do streamu neco, co ma
-    // formatovani zavisle na lokalich pravidlech, treba cislo, datum,
-    // nebo boolean. Tyto "facets" jsou pak dealokovany pri exitu
-    // programu s prioritou compiler, tzn. po nasi kontrole memory leaku.
-    // Takze pokud nekdo pouzije stream k vypisu cehokoli lokalizovatelneho,
-    // nas debug heap zacne hlasit memory leaky, i kdyz zadne nejsou. Abychom
-    // tomu predesli, donutime locales vytvorit vsechny "facets" ted, dokud
-    // jeste nehlidame heap.
-    // Zatim pouzivame pouze vystupni stream a pouze se stringy (bez konverze)
-    // a cisly. Takze poslat cislo do stringstreamu by melo stacit. Pokud
-    // v budoucnu zacneme pouzivat streamy vic a debug heap zacne hlasit
-    // leaky, budeme zde muset pridat vic vstupu/vystupu.
+    // New streams use internal locales whose individual "facets" are created lazily and allocated on the heap only when needed, for example when something with locale-dependent formatting such as a number, date, or boolean is sent to the stream.
+    // These "facets" are then deallocated at program exit with compiler priority, i.e. after our memory leak check.
+    // So if someone uses a stream to output anything locale-dependent, the debug heap starts reporting memory leaks even though there are none. To prevent that, force the locales to create all "facets" now, while we are not tracking the heap yet.
+    // For now we use only output streams, and only with strings (without conversion) and numbers. So sending a number to the stringstream should be enough. If we start using streams more in the future and the debug heap starts reporting leaks again, we will have to add more input/output here.
     std::stringstream s;
     s << 1;
 #endif // _DEBUG
@@ -175,8 +165,8 @@ struct C__MessageBoxData
 };
 
 int CALLBACK __MessagesMessageBoxThreadF(C__MessageBoxData* data)
-{ // nesmi cekat na odezvu volajiciho threadu, protoze ten nebude reagovat
-    // proto je parent==NULL -> zadne disablovani oken atd.
+{ // must not wait for the calling thread to respond, because it will not respond
+    // therefore parent == NULL -> no window disabling, etc.
     data->Return = MessageBoxA(NULL, data->Text, data->Caption, data->Type | MB_SETFOREGROUND);
     return 0;
 }
@@ -188,14 +178,14 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     data.Type = uType;
     data.Return = 0;
 
-    MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    MessagesStrStream.flush();     // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     data.Text = MessagesStringBuf.c_str();
-    MessagesStringBuf.erase(); // priprava pro dalsi message
+    MessagesStringBuf.erase();     // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     int len = (int)MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // zaloha textu
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len);     // backup copy of the text
     if (message != NULL)
     {
         memcpy((char*)message, MessagesStringBuf.c_str(), len); // je to FIXED -> HANDLE==PTR
@@ -203,16 +193,16 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     }
     else
         data.Text = __MessagesLowMemory;
-    MessagesStringBuf.erase(); // priprava pro dalsi message
-    LeaveMessagesModul();      // ted uz muzou zacit blbnout ostatni thready + message loopy
+    MessagesStringBuf.erase();     // prepare for the next message
+    LeaveMessagesModul();          // other threads and message loops may resume now
 #endif                         // MULTITHREADED_MESSAGES_ENABLE
 
-    // MessageBox nahodime v novem threadu, aby nerozeslal message tohoto threadu
+    // run the MessageBox in a new thread so it does not dispatch this thread's messages
     DWORD threadID;
     HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)__MessagesMessageBoxThreadF, &data, 0, &threadID);
     if (thread != NULL)
     {
-        WaitForSingleObject(thread, INFINITE); // pockame az ho user odmackne
+        WaitForSingleObject(thread, INFINITE);         // wait until the user dismisses it
         CloseHandle(thread);
     }
     else
@@ -229,24 +219,24 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
 int C__Messages::MessageBox(HWND hWnd, const char* lpCaption, UINT uType)
 {
     int ret;
-    MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    MessagesStrStream.flush();     // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     if (!IsWindow(hWnd))
         hWnd = NULL;
     ret = ::MessageBoxA(hWnd, MessagesStringBuf.c_str(), lpCaption, uType);
-    MessagesStringBuf.erase(); // priprava pro dalsi message
+    MessagesStringBuf.erase();     // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     size_t len = MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // zaloha textu
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, len);     // backup copy of the text
     char* txt;
     txt = (char*)message; // je to FIXED -> HANDLE==PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), len);
     else
         txt = (char*)__MessagesLowMemory;
-    MessagesStringBuf.erase(); // priprava pro dalsi message
-    LeaveMessagesModul();      // ted uz muzou zacit blbnout ostatni thready + message loopy
+    MessagesStringBuf.erase();     // prepare for the next message
+    LeaveMessagesModul();          // other threads and message loops may resume now
 
     if (!IsWindow(hWnd))
         hWnd = NULL;
@@ -267,20 +257,10 @@ int C__Messages::MessageBox(HWND hWnd, const char* lpCaption, UINT uType)
 C__MessagesW::C__MessagesW() : MessagesStrStream(&MessagesStringBuf)
 {
 #ifdef _DEBUG
-    // nove streamy pouzivaji interne locales, ktere maji implementovany
-    // jednotlive "facets" pomoci lazy creation - jsou alokovany na heapu
-    // kdyz jsou potreba, tedy kdyz nekdo posle do streamu neco, co ma
-    // formatovani zavisle na lokalich pravidlech, treba cislo, datum,
-    // nebo boolean. Tyto "facets" jsou pak dealokovany pri exitu
-    // programu s prioritou compiler, tzn. po nasi kontrole memory leaku.
-    // Takze pokud nekdo pouzije stream k vypisu cehokoli lokalizovatelneho,
-    // nas debug heap zacne hlasit memory leaky, i kdyz zadne nejsou. Abychom
-    // tomu predesli, donutime locales vytvorit vsechny "facets" ted, dokud
-    // jeste nehlidame heap.
-    // Zatim pouzivame pouze vystupni stream a pouze se stringy (bez konverze)
-    // a cisly. Takze poslat cislo do stringstreamu by melo stacit. Pokud
-    // v budoucnu zacneme pouzivat streamy vic a debug heap zacne hlasit
-    // leaky, budeme zde muset pridat vic vstupu/vystupu.
+    // New streams use internal locales whose individual "facets" are created lazily and allocated on the heap only when needed, for example when something with locale-dependent formatting such as a number, date, or boolean is sent to the stream.
+    // These "facets" are then deallocated at program exit with compiler priority, i.e. after our memory leak check.
+    // So if someone uses a stream to output anything locale-dependent, the debug heap starts reporting memory leaks even though there are none. To prevent that, force the locales to create all "facets" now, while we are not tracking the heap yet.
+    // For now we use only output streams, and only with strings (without conversion) and numbers. So sending a number to the stringstream should be enough. If we start using streams more in the future and the debug heap starts reporting leaks again, we will have to add more input/output here.
     std::wstringstream s;
     s << 1;
 #endif // _DEBUG
@@ -295,8 +275,8 @@ struct C__MessageBoxDataW
 };
 
 int CALLBACK __MessagesWMessageBoxThreadF(C__MessageBoxDataW* data)
-{ // nesmi cekat na odezvu volajiciho threadu, protoze ten nebude reagovat
-    // proto je parent==NULL -> zadne disablovani oken atd.
+{ // must not wait for the calling thread to respond, because it will not respond
+    // therefore parent == NULL -> no window disabling, etc.
     data->Return = MessageBoxW(NULL, data->Text, data->Caption, data->Type | MB_SETFOREGROUND);
     return 0;
 }
@@ -308,14 +288,14 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     data.Type = uType;
     data.Return = 0;
 
-    MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    MessagesStrStream.flush();     // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     data.Text = MessagesStringBuf.c_str();
-    MessagesStringBuf.erase(); // priprava pro dalsi message
+    MessagesStringBuf.erase();     // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     int len = (int)MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // zaloha textu
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len);     // backup copy of the text
     if (message != NULL)
     {
         memcpy((WCHAR*)message, MessagesStringBuf.c_str(), sizeof(WCHAR) * len); // je to FIXED -> HANDLE==PTR
@@ -323,16 +303,16 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     }
     else
         data.Text = __MessagesLowMemoryW;
-    MessagesStringBuf.erase(); // priprava pro dalsi message
-    LeaveMessagesModul();      // ted uz muzou zacit blbnout ostatni thready + message loopy
+    MessagesStringBuf.erase();     // prepare for the next message
+    LeaveMessagesModul();          // other threads and message loops may resume now
 #endif                         // MULTITHREADED_MESSAGES_ENABLE
 
-    // MessageBox nahodime v novem threadu, aby nerozeslal message tohoto threadu
+    // run the MessageBox in a new thread so it does not dispatch this thread's messages
     DWORD threadID;
     HANDLE thread = CreateThread(NULL, 0, (LPTHREAD_START_ROUTINE)__MessagesWMessageBoxThreadF, &data, 0, &threadID);
     if (thread != NULL)
     {
-        WaitForSingleObject(thread, INFINITE); // pockame az ho user odmackne
+        WaitForSingleObject(thread, INFINITE);         // wait until the user dismisses it
         CloseHandle(thread);
     }
     else
@@ -349,24 +329,24 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
 int C__MessagesW::MessageBox(HWND hWnd, const WCHAR* lpCaption, UINT uType)
 {
     int ret;
-    MessagesStrStream.flush(); // flushnuti do bufferu (v lpText)
+    MessagesStrStream.flush();     // flush into the buffer (lpText)
 
 #ifndef MULTITHREADED_MESSAGES_ENABLE
     if (!IsWindow(hWnd))
         hWnd = NULL;
     ret = ::MessageBoxW(hWnd, MessagesStringBuf.c_str(), lpCaption, uType);
-    MessagesStringBuf.erase(); // priprava pro dalsi message
+    MessagesStringBuf.erase();     // prepare for the next message
 #else                          // MULTITHREADED_MESSAGES_ENABLE
     size_t len = MessagesStringBuf.length() + 1;
-    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // zaloha textu
+    HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len);     // backup copy of the text
     WCHAR* txt;
     txt = (WCHAR*)message; // je to FIXED -> HANDLE==PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), sizeof(WCHAR) * len);
     else
         txt = (WCHAR*)__MessagesLowMemoryW;
-    MessagesStringBuf.erase(); // priprava pro dalsi message
-    LeaveMessagesModul();      // ted uz muzou zacit blbnout ostatni thready + message loopy
+    MessagesStringBuf.erase();     // prepare for the next message
+    LeaveMessagesModul();          // other threads and message loops may resume now
 
     if (!IsWindow(hWnd))
         hWnd = NULL;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/messages.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 37 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 98/98 review unit(s).
- Validation passed with 37 rewrite(s), 61 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/messages.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 14672 output token(s).
- Copilot CLI: 1 premium request(s).