### PR TITLE
[translation] Fix src/common/ms_init.cpp comments

### DIFF
--- a/src/common/ms_init.cpp
+++ b/src/common/ms_init.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/ms_init.cpp
+++ b/src/common/ms_init.cpp
@@ -5,8 +5,8 @@
 
 #include <windows.h>
 
-// modul MS_INIT zajistuje volani konstruktoru statickych objektu ve spravnem poradi
-// a na urovni "lib" (pred "user")
+// MS_INIT ensures that constructors of static objects are called in the correct order
+// and at the "lib" level (before "user")
 
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/ms_init.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 20/20 review unit(s).
- Validation passed with 1 rewrite(s), 19 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/ms_init.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 1686 output token(s).
- Copilot CLI: 1 premium request(s).