### PR TITLE
[translation] Fix src/common/winlib.h comments

### DIFF
--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -3,9 +3,9 @@
 
 #pragma once
 
-// makro __DEBUG_WINLIB zapina nekolik testu zaludnych chyb WinLibu
+// __DEBUG_WINLIB enables several checks for tricky WinLib bugs
 
-// konstanty pro stringy WinLibu (jen interni pouziti ve WinLibu)
+// WinLib string constants (for internal WinLib use only)
 enum CWLS
 {
     WLS_INVALID_NUMBER,
@@ -14,26 +14,26 @@ enum CWLS
     WLS_COUNT
 };
 
-// nastaveni vlastnich textu do WinLibu
-void SetWinLibStrings(const TCHAR* invalidNumber, // "neni cislo" (u transferbufferu cisel)
-                      const TCHAR* error);        // titulek "chyba" (u transferbufferu cisel)
+// set custom WinLib strings
+void SetWinLibStrings(const TCHAR* invalidNumber, // "not a number" (for numeric transfer buffers)
+                      const TCHAR* error);                              // title "error" (for numeric transfer buffers)
 
 extern HINSTANCE HInstance;
-extern const TCHAR* CWINDOW_CLASSNAME;  // jmeno tridy universalniho okna
-extern const TCHAR* CWINDOW_CLASSNAME2; // jmeno tridy universalniho okna - nema CS_VREDRAW | CS_HREDRAW
+extern const TCHAR* CWINDOW_CLASSNAME;  // universal window class name
+extern const TCHAR* CWINDOW_CLASSNAME2; // universal window class name - no CS_VREDRAW | CS_HREDRAW
 
 #ifndef _UNICODE
-extern const WCHAR* CWINDOW_CLASSNAMEW;  // jmeno tridy unicodoveho universalniho okna
-extern const WCHAR* CWINDOW_CLASSNAME2W; // jmeno tridy unicodoveho universalniho okna - nema CS_VREDRAW | CS_HREDRAW
+extern const WCHAR* CWINDOW_CLASSNAMEW;  // Unicode universal window class name
+extern const WCHAR* CWINDOW_CLASSNAME2W; // Unicode universal window class name - no CS_VREDRAW | CS_HREDRAW
 #endif                                   // _UNICODE
 
 class CWinLibHelp;
 
-// je potreba zavolat pred pouzitim WinLibu
+// must be called before using WinLib
 BOOL InitializeWinLib();
-// je potreba zavolat po pouziti WinLibu
+// must be called after using WinLib
 void ReleaseWinLib();
-// je treba zavolat pred pouzivanim helpu
+// must be called before using help
 BOOL SetupWinLibHelp(CWinLibHelp* winLibHelp);
 
 class CWinLibHelp
@@ -46,16 +46,16 @@ public:
 
 // ****************************************************************************
 
-enum CObjectOrigin // pouzito pri destrukci oken a dialogu
+enum CObjectOrigin // used when destroying windows and dialogs
 {
-    ooAllocated, // pri WM_DESTROY se bude dealokovat
-    ooStatic,    // pri WM_DESTROY se HWindow nastavi na NULL
-    ooStandard   // pro modalni dlg =ooStatic, pro nemodalni dlg =ooAllocated
+    ooAllocated,     // deallocated on WM_DESTROY
+    ooStatic,        // HWindow is set to NULL on WM_DESTROY
+    ooStandard       // for modal dialogs = ooStatic, for modeless dialogs = ooAllocated
 };
 
 // ****************************************************************************
 
-enum CObjectType // pro rozpoznani typu objektu
+enum CObjectType // for object type identification
 {
     otBase,
     otWindow,
@@ -66,7 +66,7 @@ enum CObjectType // pro rozpoznani typu objektu
 
 // ****************************************************************************
 
-class CWindowsObject // predek vsech MS-Windows objektu
+class CWindowsObject // base class of all MS-Windows objects
 {
 public:
     HWND HWindow;
@@ -102,9 +102,9 @@ public:
         SetHelpID(helpID);
     }
 
-    virtual ~CWindowsObject() {} // aby se u potomku volal jejich destruktor
+    virtual ~CWindowsObject() {}     // so derived destructors are called
 
-    virtual BOOL Is(int) { return FALSE; } // identifikace objektu
+    virtual BOOL Is(int) { return FALSE; }     // object type identification
     virtual int GetObjectType() { return otBase; }
 
     virtual BOOL IsAllocated() { return ObjectOrigin == ooAllocated; }
@@ -201,7 +201,7 @@ public:
                 HWND hwndParent,        // handle of parent or owner window
                 HMENU hmenu,            // handle of menu or child-window identifier
                 HINSTANCE hinst,        // handle of application instance
-                LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                LPVOID lpvParam);                       // pointer to the window object being created
 
     HWND CreateEx(DWORD dwExStyle,        // extended window style
                   LPCTSTR lpszClassName,  // address of registered class name
@@ -214,7 +214,7 @@ public:
                   HWND hwndParent,        // handle of parent or owner window
                   HMENU hmenu,            // handle of menu or child-window identifier
                   HINSTANCE hinst,        // handle of application instance
-                  LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                  LPVOID lpvParam);                         // pointer to the window object being created
 
 #ifndef _UNICODE
     HWND CreateW(LPCWSTR lpszClassName,  // address of registered class name
@@ -227,7 +227,7 @@ public:
                  HWND hwndParent,        // handle of parent or owner window
                  HMENU hmenu,            // handle of menu or child-window identifier
                  HINSTANCE hinst,        // handle of application instance
-                 LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                 LPVOID lpvParam);                        // pointer to the window object being created
 
     HWND CreateExW(DWORD dwExStyle,        // extended window style
                    LPCWSTR lpszClassName,  // address of registered class name
@@ -240,7 +240,7 @@ public:
                    HWND hwndParent,        // handle of parent or owner window
                    HMENU hmenu,            // handle of menu or child-window identifier
                    HINSTANCE hinst,        // handle of application instance
-                   LPVOID lpvParam);       // ukazatel na objekt vytvareneho okna
+                   LPVOID lpvParam);                          // pointer to the window object being created
 #endif                                     // _UNICODE
 
     void AttachToWindow(HWND hWnd);
@@ -277,8 +277,8 @@ protected:
 
 enum CTransferType
 {
-    ttDataToWindow,  // data jdou do okna
-    ttDataFromWindow // data jdou z okna
+    ttDataToWindow,      // data to the window
+    ttDataFromWindow     // data from the window
 };
 
 // ****************************************************************************
@@ -286,7 +286,7 @@ enum CTransferType
 class CTransferInfo
 {
 public:
-    int FailCtrlID; // INT_MAX - vse v poradku, jinak ID controlu s chybou
+    int FailCtrlID;     // INT_MAX = no error, otherwise the ID of the failing control
     CTransferType Type;
 
     CTransferInfo(HWND hDialog, CTransferType type)
@@ -315,7 +315,7 @@ public:
 #endif // _UNICODE
 
 protected:
-    HWND HDialog; // handle dialogu, pro ktery se provadi transfer
+    HWND HDialog;     // handle of the dialog for which the transfer is performed
 };
 
 // ****************************************************************************
@@ -323,8 +323,8 @@ protected:
 class CDialog : public CWindowsObject
 {
 public:
-    CWindowsObject::SetObjectOrigin; // kvuli zkompilovatelnosti CPropSheetPage
-    CWindowsObject::HWindow;         // kvuli zkompilovatelnosti CPropSheetPage
+    CWindowsObject::SetObjectOrigin;     // needed so CPropSheetPage compiles
+    CWindowsObject::HWindow;             // needed so CPropSheetPage compiles
 
 #ifdef _UNICODE
     CDialog(HINSTANCE modul, int resID, HWND parent, CObjectOrigin origin = ooStandard) : CWindowsObject(origin)
@@ -366,8 +366,8 @@ public:
 
     void SetParent(HWND parent) { Parent = parent; }
     HWND GetParent() { return Parent; }
-    INT_PTR Execute(); // modalni dialog
-    HWND Create();     // nemodalni dialog
+    INT_PTR Execute();     // modal dialog
+    HWND Create();         // modeless dialog
 
     static INT_PTR CALLBACK CDialogProc(HWND hwndDlg, UINT uMsg,
                                         WPARAM wParam, LPARAM lParam);
@@ -377,7 +377,7 @@ protected:
 
     virtual void NotifDlgJustCreated() {}
 
-    BOOL Modal; // kvuli zpusobu destrukce dialogu
+    BOOL Modal;     // because of the way the dialog is destroyed
     HINSTANCE Modul;
     int ResID;
     HWND Parent;
@@ -395,7 +395,7 @@ struct CWindowData
     CWindowsObject* Wnd;
 };
 
-#define WNDMGR_CACHE_SIZE 256 // (2kB cache) musi byt v souladu s GetCacheIndex
+#define WNDMGR_CACHE_SIZE 256 // (2kB cache) must be consistent with GetCacheIndex
 
 inline int GetCacheIndex(HWND hWnd)
 {
@@ -420,7 +420,7 @@ public:
     int search, cache, maxWndCount;
 #endif
 
-    CWinLibCS CS; // je public, aby slo lokalne zamezit zmenam ve Windows Manageru
+    CWinLibCS CS;     // public so Windows Manager changes can be prevented locally
 
 public:
     CWindowsManager();
@@ -431,7 +431,7 @@ public:
     int GetCount();
 
 private:
-    HWND LastHWnd[WNDMGR_CACHE_SIZE]; // posledni pozadavek - cache
+    HWND LastHWnd[WNDMGR_CACHE_SIZE];     // last-request cache
     CWindowsObject* LastWnd[WNDMGR_CACHE_SIZE];
 
     inline BOOL GetIndex(HWND hWnd, int& index);
@@ -456,7 +456,7 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
     {
         m = (l + r) / 2;
         HWND hw = At(m).HWnd;
-        if (hw == hWnd) // nalezeno
+        if (hw == hWnd)         // found
         {
             index = m;
             CS.Leave();
@@ -464,9 +464,9 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
         }
         else if (hw > hWnd)
         {
-            if (l == r || l > m - 1) // nenalezeno
+            if (l == r || l > m - 1)             // not found
             {
-                index = m; // mel by byt na teto pozici
+                index = m;                 // should be at this position
                 CS.Leave();
                 return FALSE;
             }
@@ -474,9 +474,9 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
         }
         else
         {
-            if (l == r) // nenalezeno
+            if (l == r)             // not found
             {
-                index = m + 1; // mel by byt az za touto pozici
+                index = m + 1;                 // should be after this position
                 CS.Leave();
                 return FALSE;
             }
@@ -502,13 +502,13 @@ struct CWindowQueueItem
 class CWindowQueue
 {
 protected:
-    const TCHAR* QueueName; // jmeno fronty (jen pro debugovaci ucely)
+    const TCHAR* QueueName;     // queue name (for debugging only)
     CWindowQueueItem* Head;
     int Count;
-    CWinLibCS CS; // pristup z vice threadu -> nutna synchronizace
+    CWinLibCS CS;     // access from multiple threads -> synchronization required
 
 public:
-    CWindowQueue(const TCHAR* queueName /* napr. "Find Dialogs" */)
+    CWindowQueue(const TCHAR* queueName /* e.g. "Find Dialogs" */)
     {
         QueueName = queueName;
         Head = NULL;
@@ -516,12 +516,12 @@ public:
     }
     ~CWindowQueue();
 
-    BOOL Add(CWindowQueueItem* item); // prida polozku do fronty, vraci uspech
-    void Remove(HWND hWindow);        // odstrani polozku z fronty
-    BOOL Empty();                     // vraci TRUE pokud je fronta prazdna
-    int GetWindowCount();             // vraci pocet oken ve fronte
+    BOOL Add(CWindowQueueItem* item);     // adds an item to the queue, returns success status
+    void Remove(HWND hWindow);            // removes an item from the queue
+    BOOL Empty();                         // returns TRUE if the queue is empty
+    int GetWindowCount();                 // returns the number of windows in the queue
 
-    // posle (PostMessage - okna muzou byt v ruznych threadech) vsem oknum zpravu
+    // posts the message to all windows (PostMessage - windows may be in different threads)
     void BroadcastMessage(DWORD uMsg, WPARAM wParam, LPARAM lParam);
 };
 

--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -16,7 +17,7 @@ enum CWLS
 
 // set custom WinLib strings
 void SetWinLibStrings(const TCHAR* invalidNumber, // "not a number" (for numeric transfer buffers)
-                      const TCHAR* error);                              // title "error" (for numeric transfer buffers)
+                      const TCHAR* error);        // title "error" (for numeric transfer buffers)
 
 extern HINSTANCE HInstance;
 extern const TCHAR* CWINDOW_CLASSNAME;  // universal window class name
@@ -48,9 +49,9 @@ public:
 
 enum CObjectOrigin // used when destroying windows and dialogs
 {
-    ooAllocated,     // deallocated on WM_DESTROY
-    ooStatic,        // HWindow is set to NULL on WM_DESTROY
-    ooStandard       // for modal dialogs = ooStatic, for modeless dialogs = ooAllocated
+    ooAllocated, // deallocated on WM_DESTROY
+    ooStatic,    // HWindow is set to NULL on WM_DESTROY
+    ooStandard   // for modal dialogs = ooStatic, for modeless dialogs = ooAllocated
 };
 
 // ****************************************************************************
@@ -102,9 +103,9 @@ public:
         SetHelpID(helpID);
     }
 
-    virtual ~CWindowsObject() {}     // so derived destructors are called
+    virtual ~CWindowsObject() {} // so derived destructors are called
 
-    virtual BOOL Is(int) { return FALSE; }     // object type identification
+    virtual BOOL Is(int) { return FALSE; } // object type identification
     virtual int GetObjectType() { return otBase; }
 
     virtual BOOL IsAllocated() { return ObjectOrigin == ooAllocated; }
@@ -201,7 +202,7 @@ public:
                 HWND hwndParent,        // handle of parent or owner window
                 HMENU hmenu,            // handle of menu or child-window identifier
                 HINSTANCE hinst,        // handle of application instance
-                LPVOID lpvParam);                       // pointer to the window object being created
+                LPVOID lpvParam);       // pointer to the window object being created
 
     HWND CreateEx(DWORD dwExStyle,        // extended window style
                   LPCTSTR lpszClassName,  // address of registered class name
@@ -214,7 +215,7 @@ public:
                   HWND hwndParent,        // handle of parent or owner window
                   HMENU hmenu,            // handle of menu or child-window identifier
                   HINSTANCE hinst,        // handle of application instance
-                  LPVOID lpvParam);                         // pointer to the window object being created
+                  LPVOID lpvParam);       // pointer to the window object being created
 
 #ifndef _UNICODE
     HWND CreateW(LPCWSTR lpszClassName,  // address of registered class name
@@ -227,7 +228,7 @@ public:
                  HWND hwndParent,        // handle of parent or owner window
                  HMENU hmenu,            // handle of menu or child-window identifier
                  HINSTANCE hinst,        // handle of application instance
-                 LPVOID lpvParam);                        // pointer to the window object being created
+                 LPVOID lpvParam);       // pointer to the window object being created
 
     HWND CreateExW(DWORD dwExStyle,        // extended window style
                    LPCWSTR lpszClassName,  // address of registered class name
@@ -240,7 +241,7 @@ public:
                    HWND hwndParent,        // handle of parent or owner window
                    HMENU hmenu,            // handle of menu or child-window identifier
                    HINSTANCE hinst,        // handle of application instance
-                   LPVOID lpvParam);                          // pointer to the window object being created
+                   LPVOID lpvParam);       // pointer to the window object being created
 #endif                                     // _UNICODE
 
     void AttachToWindow(HWND hWnd);
@@ -277,8 +278,8 @@ protected:
 
 enum CTransferType
 {
-    ttDataToWindow,      // data to the window
-    ttDataFromWindow     // data from the window
+    ttDataToWindow,  // data to the window
+    ttDataFromWindow // data from the window
 };
 
 // ****************************************************************************
@@ -286,7 +287,7 @@ enum CTransferType
 class CTransferInfo
 {
 public:
-    int FailCtrlID;     // INT_MAX = no error, otherwise the ID of the failing control
+    int FailCtrlID; // INT_MAX = no error, otherwise the ID of the failing control
     CTransferType Type;
 
     CTransferInfo(HWND hDialog, CTransferType type)
@@ -315,7 +316,7 @@ public:
 #endif // _UNICODE
 
 protected:
-    HWND HDialog;     // handle of the dialog for which the transfer is performed
+    HWND HDialog; // handle of the dialog for which the transfer is performed
 };
 
 // ****************************************************************************
@@ -323,8 +324,8 @@ protected:
 class CDialog : public CWindowsObject
 {
 public:
-    CWindowsObject::SetObjectOrigin;     // needed so CPropSheetPage compiles
-    CWindowsObject::HWindow;             // needed so CPropSheetPage compiles
+    CWindowsObject::SetObjectOrigin; // needed so CPropSheetPage compiles
+    CWindowsObject::HWindow;         // needed so CPropSheetPage compiles
 
 #ifdef _UNICODE
     CDialog(HINSTANCE modul, int resID, HWND parent, CObjectOrigin origin = ooStandard) : CWindowsObject(origin)
@@ -366,8 +367,8 @@ public:
 
     void SetParent(HWND parent) { Parent = parent; }
     HWND GetParent() { return Parent; }
-    INT_PTR Execute();     // modal dialog
-    HWND Create();         // modeless dialog
+    INT_PTR Execute(); // modal dialog
+    HWND Create();     // modeless dialog
 
     static INT_PTR CALLBACK CDialogProc(HWND hwndDlg, UINT uMsg,
                                         WPARAM wParam, LPARAM lParam);
@@ -377,7 +378,7 @@ protected:
 
     virtual void NotifDlgJustCreated() {}
 
-    BOOL Modal;     // because of the way the dialog is destroyed
+    BOOL Modal; // because of the way the dialog is destroyed
     HINSTANCE Modul;
     int ResID;
     HWND Parent;
@@ -420,7 +421,7 @@ public:
     int search, cache, maxWndCount;
 #endif
 
-    CWinLibCS CS;     // public so Windows Manager changes can be prevented locally
+    CWinLibCS CS; // public so Windows Manager changes can be prevented locally
 
 public:
     CWindowsManager();
@@ -431,7 +432,7 @@ public:
     int GetCount();
 
 private:
-    HWND LastHWnd[WNDMGR_CACHE_SIZE];     // last-request cache
+    HWND LastHWnd[WNDMGR_CACHE_SIZE]; // last-request cache
     CWindowsObject* LastWnd[WNDMGR_CACHE_SIZE];
 
     inline BOOL GetIndex(HWND hWnd, int& index);
@@ -456,7 +457,7 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
     {
         m = (l + r) / 2;
         HWND hw = At(m).HWnd;
-        if (hw == hWnd)         // found
+        if (hw == hWnd) // found
         {
             index = m;
             CS.Leave();
@@ -464,9 +465,9 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
         }
         else if (hw > hWnd)
         {
-            if (l == r || l > m - 1)             // not found
+            if (l == r || l > m - 1) // not found
             {
-                index = m;                 // should be at this position
+                index = m; // should be at this position
                 CS.Leave();
                 return FALSE;
             }
@@ -474,9 +475,9 @@ BOOL CWindowsManager::GetIndex(HWND hWnd, int& index)
         }
         else
         {
-            if (l == r)             // not found
+            if (l == r) // not found
             {
-                index = m + 1;                 // should be after this position
+                index = m + 1; // should be after this position
                 CS.Leave();
                 return FALSE;
             }
@@ -502,10 +503,10 @@ struct CWindowQueueItem
 class CWindowQueue
 {
 protected:
-    const TCHAR* QueueName;     // queue name (for debugging only)
+    const TCHAR* QueueName; // queue name (for debugging only)
     CWindowQueueItem* Head;
     int Count;
-    CWinLibCS CS;     // access from multiple threads -> synchronization required
+    CWinLibCS CS; // access from multiple threads -> synchronization required
 
 public:
     CWindowQueue(const TCHAR* queueName /* e.g. "Find Dialogs" */)
@@ -516,10 +517,10 @@ public:
     }
     ~CWindowQueue();
 
-    BOOL Add(CWindowQueueItem* item);     // adds an item to the queue, returns success status
-    void Remove(HWND hWindow);            // removes an item from the queue
-    BOOL Empty();                         // returns TRUE if the queue is empty
-    int GetWindowCount();                 // returns the number of windows in the queue
+    BOOL Add(CWindowQueueItem* item); // adds an item to the queue, returns success status
+    void Remove(HWND hWindow);        // removes an item from the queue
+    BOOL Empty();                     // returns TRUE if the queue is empty
+    int GetWindowCount();             // returns the number of windows in the queue
 
     // posts the message to all windows (PostMessage - windows may be in different threads)
     void BroadcastMessage(DWORD uMsg, WPARAM wParam, LPARAM lParam);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 49 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 141/141 review unit(s).
- Validation passed with 49 rewrite(s), 91 keep(s), and 1 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/common/winlib.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 18509 output token(s).
- Copilot CLI: 1 premium request(s).