### PR TITLE
[translation] Fix src/plugins/7zip/7zthreads.cpp comments

### DIFF
--- a/src/plugins/7zip/7zthreads.cpp
+++ b/src/plugins/7zip/7zthreads.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -36,7 +37,7 @@ BOOL CALLBACK SubClassedProgressDlgProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPA
             return S_OK;
 
         case WM_7ZIP_ADDTEXT:
-            Salamander->ProgressDialogAddText((char*)lParam, TRUE); // delayed paint, to avoid slow down by frequent refresh
+            Salamander->ProgressDialogAddText((char*)lParam, TRUE); // Delayed paint to avoid slowdown from frequent refreshes
             return S_OK;
 
         case WM_7ZIP_CREATEFILE:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/7zthreads.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 10/10 review unit(s).
- Validation passed with 1 rewrite(s), 9 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/7zip/7zthreads.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 2067 output token(s).
- Copilot CLI: 1 premium request(s).