### PR TITLE
[translation] Fix src/plugins/7zip/dialogs.cpp comments

### DIFF
--- a/src/plugins/7zip/dialogs.cpp
+++ b/src/plugins/7zip/dialogs.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -566,7 +567,7 @@ CExtOptionsDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (!CreateChilds())
         {
             DestroyWindow(HWindow); // error -> do not open the dialog
-            return FALSE;           // stop processing
+            return FALSE;           // end processing
         }
 
         // set archive name


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 51/51 review unit(s).
- Validation passed with 1 rewrite(s), 50 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/7zip/dialogs.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 5974 output token(s).
- Copilot CLI: 1 premium request(s).