### PR TITLE
[translation] Fix src/plugins/7zip/extract.cpp comments

### DIFF
--- a/src/plugins/7zip/extract.cpp
+++ b/src/plugins/7zip/extract.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -364,7 +365,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
         }
     }
 
-    // release OutStream so the file can be deleted if needed
+    // release OutStream so the file can be deleted
     if (OutFileStream != NULL)
         OutFileStreamSpec->SetMTime(&ProcessedFileInfo.LastWrite);
     OutFileStream.Release();
@@ -376,7 +377,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
         return FALSE;
 
     case Delete:
-        // if cancel, bail out
+        // if canceled, exit
         if (!SafeDeleteFile(GetAnsiString(ProcessedFileInfo.FileName), DataErrorDeleteSilent))
             return FALSE;
         break;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/extract.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 48/48 review unit(s).
- Validation passed with 2 rewrite(s), 46 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/7zip/extract.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 7213 output token(s).
- Copilot CLI: 1 premium request(s).