### PR TITLE
[translation] Fix src/plugins/7zip/FStreams.cpp comments

### DIFF
--- a/src/plugins/7zip/FStreams.cpp
+++ b/src/plugins/7zip/FStreams.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -31,8 +32,8 @@ BOOL ShowRetryAbortBox(HWND hParentWnd, int resID, DWORD err, ...)
     _stprintf(buf, _T("%s\n\n%s"), msg, SalamanderGeneral->GetErrorText(err));
 
     TCHAR btnBuffer[128];
-    /* used by the export_mnu.py script, which generates salmenu.mnu for the Translator
-   let the message box buttons handle hotkey collisions by simulating a menu
+    /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
+   treat message box buttons as a menu to resolve hotkey collisions
 MENU_TEMPLATE_ITEM MsgBoxButtons[] = 
 {
   {MNTT_PB, 0


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/FStreams.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 4/4 review unit(s).
- Validation passed with 1 rewrite(s), 3 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/7zip/FStreams.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3746 output token(s).
- Copilot CLI: 1 premium request(s).