### PR TITLE
[translation] Fix src/plugins/7zip/update.h comments

### DIFF
--- a/src/plugins/7zip/update.h
+++ b/src/plugins/7zip/update.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -147,7 +148,7 @@ public:
 public:
     AString ProcessedFileName;
 
-    // synchronization for calls
+    // call synchronization
     CRITICAL_SECTION CSUpdate;
 
     TIndirectArray<CFileItem>* FileItems;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/update.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 11/11 review unit(s).
- Validation passed with 1 rewrite(s), 10 keep(s), and 0 manual item(s).
- Guard passed with 13 recorded check(s).
- `git diff --check -- src/plugins/7zip/update.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 5264 output token(s).
- Copilot CLI: 1 premium request(s).