### PR TITLE
[translation] Fix src/plugins/shared/htmlhelp.h comments

### DIFF
--- a/src/plugins/shared/htmlhelp.h
+++ b/src/plugins/shared/htmlhelp.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************
 *                                                                           *
@@ -224,7 +225,7 @@ extern "C"
         int iType;               // the type of the information type ie. Inclusive, Exclusive, or Hidden
         LPCSTR pszCatName;       // Set to the name of the Category to enumerate the info types in a category; else NULL
         LPCSTR pszITName;        // volitile pointer to the name of the infotype. Allocated by call. Caller responsible for freeing
-        LPCSTR pszITDescription; // volitile pointer to the description of the infotype.
+        LPCSTR pszITDescription; // Pointer to the info type description.
     } HH_ENUM_IT, *PHH_ENUM_IT;
 
     typedef struct tagHH_ENUM_CAT
@@ -274,7 +275,7 @@ extern "C"
 
     typedef struct tagHH_FTS_QUERY
     {
-        int cbStruct;           // Sizeof structure in bytes.
+        int cbStruct;           // Size of the structure in bytes.
         BOOL fUniCodeStrings;   // TRUE if all strings are unicode.
         LPCTSTR pszSearchQuery; // String containing the search query.
         LONG iProximity;        // Word proximity.
@@ -301,7 +302,7 @@ extern "C"
         int nShowState;     // IN: show state (e.g., SW_SHOW)
 
         HWND hwndHelp;   // OUT: window handle
-        HWND hwndCaller; // OUT: who called this window
+        HWND hwndCaller; // OUT: caller window handle
 
         HH_INFOTYPE* paInfoTypes; // IN: Pointer to an array of Information Types
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/htmlhelp.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 3 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 186/186 review unit(s).
- Validation passed with 3 rewrite(s), 183 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/htmlhelp.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 12249 output token(s).
- Copilot CLI: 1 premium request(s).