### PR TITLE
[translation] Fix src/plugins/shared/spl_arc.h comments

### DIFF
--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -38,150 +38,150 @@ private: // guards against incorrect direct method calls (see CPluginInterfaceFo
 public:
 #endif // INSIDE_SALAMANDER
 
-    // funkce pro "panel archiver view"; vola se pro nacteni obsahu archivu 'fileName';
-    // obsah se plni do objektu 'dir'; Salamander zjisti obsah
-    // pluginem pridanych sloupcu pomoci interfacu 'pluginData' (pokud plugin sloupce
-    // nepridava, vraci 'pluginData'==NULL); vraci TRUE pri uspesnem nacteni obsahu archivu,
-    // pokud vrati FALSE, navratova hodnota 'pluginData' se ignoruje (data v 'dir' je potreba
-    // uvolnit pomoci 'dir.Clear(pluginData)', jinak se uvolni jen Salamanderovska cast dat);
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera,
-    // POZOR: soubor fileName take nemusi existovat (pokud je otevren v panelu a odjinud smazan),
-    // ListArchive neni volan pro soubory nulove delky, ty maji automaticky prazdny obsah,
-    // pri pakovani do takovych souboru se soubor pred volanim PackToArchive smaze (pro
-    // kompatibilitu s externimi pakovaci)
+    // Function for 'panel archiver view'; called to load the contents of archive 'fileName'.
+    // The contents are stored in 'dir'; Salamander obtains the contents of
+    // plugin-added columns through the 'pluginData' interface (if the plugin does not add columns,
+    // 'pluginData' is returned as NULL). Returns TRUE if the archive contents are loaded successfully;
+    // if it returns FALSE, the returned 'pluginData' value is ignored (the data in 'dir' must be
+    // released with 'dir.Clear(pluginData)', otherwise only the Salamander-managed part of the data is released).
+    // 'salamander' is a set of useful methods exported by Salamander.
+    // WARNING: the file 'fileName' may also not exist (if it is open in a panel and deleted elsewhere).
+    // ListArchive is not called for zero-length files; they automatically have empty contents.
+    // When packing into such files, the file is deleted before calling PackToArchive (for
+    // compatibility with external packers)
     virtual BOOL WINAPI ListArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                     CSalamanderDirectoryAbstract* dir,
                                     CPluginDataInterfaceAbstract*& pluginData) = 0;
 
-    // funkce pro "panel archiver view", vola se pri pozadavku na rozpakovani souboru/adresaru
-    // z archivu 'fileName' do adresare 'targetDir' z cesty v archivu 'archiveRoot'; 'pluginData'
-    // je interface pro praci s informacemi o souborech/adresarich, ktere jsou specificke pluginu
-    // (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci metoda ListArchive
-    // v parametru 'pluginData' - takze muze byt i NULL); soubory/adresare jsou zadany enumeracni
-    // funkci 'next' jejimz parametrem je 'nextParam'; vraci TRUE pri uspesnem rozpakovani (nebyl
-    // pouzit Cancel, mohl byt pouzit Skip) - zdroj operace v panelu je odznacen, jinak vraci
-    // FALSE (neprovede se odznaceni); 'salamander' je sada uzitecnych metod vyvezenych ze
-    // Salamandera
+    // Function for 'panel archiver view'; called when files/directories are to be unpacked
+    // from archive 'fileName' to directory 'targetDir' from archive path 'archiveRoot'; 'pluginData'
+    // is an interface for working with file/directory information specific to the plugin
+    // (for example data from added columns; it is the same interface returned by ListArchive
+    // in the 'pluginData' parameter, so it may be NULL); the files/directories are specified by the enumeration
+    // function 'next' with parameter 'nextParam'; returns TRUE if unpacking succeeds (Cancel was not
+    // used; Skip may have been used) - the source of the operation is then unselected in the panel;
+    // otherwise returns FALSE (the source is not unselected); 'salamander' is a set of useful methods exported by
+    // Salamander
     virtual BOOL WINAPI UnpackArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       CPluginDataInterfaceAbstract* pluginData, const char* targetDir,
                                       const char* archiveRoot, SalEnumSelection next,
                                       void* nextParam) = 0;
 
-    // funkce pro "panel archiver view", vola se pri pozadavku na rozpakovani jednoho souboru pro view/edit
-    // z archivu 'fileName' do adresare 'targetDir'; jmeno souboru v archivu je 'nameInArchive';
-    // 'pluginData' je interface pro praci s informacemi o souboru, ktere jsou specificke pluginu
-    // (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci metoda ListArchive
+    // Function for 'panel archiver view'; called when one file is requested for unpacking for view/edit
+    // from archive 'fileName' to directory 'targetDir'; the file name inside the archive is 'nameInArchive';
+    // 'pluginData' is an interface for working with file information specific to the plugin
+    // (for example data from added columns; it is the same interface returned by ListArchive
     // v parametru 'pluginData' - takze muze byt i NULL); 'fileData' je ukazatel na strukturu CFileData
-    // vypakovavaneho souboru (strukturu sestavil plugin pri listovani archivu); 'newFileName' (neni-li
+    // for the unpacked file (the structure was built by the plugin when listing the archive); 'newFileName' (if not
     // NULL) je nove jmeno pro rozbalovany soubor (pouziva se pokud puvodni jmeno z archivu neni mozne
-    // vybalit na disk (napr. "aux", "prn", atd.)); do 'renamingNotSupported' (jen neni-li 'newFileName'
+    // be unpacked to disk (for example 'aux', 'prn', etc.)); write TRUE to 'renamingNotSupported' (only if 'newFileName' is not
     // NULL) zapsat TRUE pokud plugin nepodporuje prejmenovani pri vybalovani (standardni chybova hlaska
-    // "renaming not supported" se zobrazi ze Salamandera); vraci TRUE pri uspesnem rozpakovani souboru
-    // (soubor je na zadane ceste, nebyl pouzit Cancel ani Skip), 'salamander' je sada uzitecnych metod
-    // vyvezenych ze Salamandera
+    // the standard 'renaming not supported' error message is shown by Salamander); returns TRUE if the file is unpacked successfully
+    // (the file is at the requested path and neither Cancel nor Skip was used); 'salamander' is a set of useful methods
+    // exported by Salamander
     virtual BOOL WINAPI UnpackOneFile(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       CPluginDataInterfaceAbstract* pluginData, const char* nameInArchive,
                                       const CFileData* fileData, const char* targetDir,
                                       const char* newFileName, BOOL* renamingNotSupported) = 0;
 
-    // funkce pro "panel archiver edit" a "custom archiver pack", vola se pri pozadavku na zapakovani
-    // souboru/adresaru do archivu 'fileName' na cestu 'archiveRoot', soubory/adresare jsou zadany
-    // zdrojovou cestou 'sourcePath' a enumeracni funkci 'next' s parametrem 'nextParam',
-    // je-li 'move' TRUE, zapakovane soubory/adresare by mely byt odstranene z disku, vraci TRUE
-    // pokud se podari zapakovat/odstranit vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt
-    // pouzit Skip) - zdroj operace v panelu je odznacen, jinak vraci FALSE (neprovede se odznaceni),
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera
+    // Function for 'panel archiver edit' and 'custom archiver pack'; called when files/directories are to be packed
+    // into archive 'fileName' at path 'archiveRoot'; the files/directories are specified by
+    // source path 'sourcePath' and the enumeration function 'next' with parameter 'nextParam'.
+    // If 'move' is TRUE, the packed files/directories should be removed from disk. Returns TRUE
+    // if all files/directories are packed/removed successfully (Cancel was not used; Skip may have
+    // been used) - the source of the operation is then unselected in the panel; otherwise returns FALSE (the source is not unselected);
+    // 'salamander' is a set of useful methods exported by Salamander
     virtual BOOL WINAPI PackToArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       const char* archiveRoot, BOOL move, const char* sourcePath,
                                       SalEnumSelection2 next, void* nextParam) = 0;
 
-    // funkce pro "panel archiver edit", vola se pri pozadavku na smazani souboru/adresaru z archivu
-    // 'fileName'; soubory/adresare jsou zadany cestou 'archiveRoot' a enumeracni funkci 'next'
-    // s parametrem 'nextParam'; 'pluginData' je interface pro praci s informacemi o souborech/adresarich,
-    // ktere jsou specificke pluginu (napr. data z pridanych sloupcu; jde o stejny interface, ktery vraci
-    // metoda ListArchive v parametru 'pluginData' - takze muze byt i NULL); vraci TRUE pokud se
-    // podari smazat vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt pouzit Skip) - zdroj
-    // operace v panelu je odznacen, jinak vraci FALSE (neprovede se odznaceni); 'salamander' je sada
-    // uzitecnych metod vyvezenych ze Salamandera
+    // Function for 'panel archiver edit'; called when files/directories are to be deleted from archive
+    // 'fileName'; the files/directories are specified by path 'archiveRoot' and the enumeration function 'next'
+    // with parameter 'nextParam'; 'pluginData' is an interface for working with file/directory information
+    // specific to the plugin (for example data from added columns; it is the same interface returned by
+    // ListArchive in the 'pluginData' parameter, so it may be NULL); returns TRUE if all
+    // files/directories are deleted successfully (Cancel was not used; Skip may have been used) - the source
+    // of the operation is then unselected in the panel; otherwise returns FALSE (the source is not unselected); 'salamander' is a set of
+    // useful methods exported by Salamander
     virtual BOOL WINAPI DeleteFromArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                           CPluginDataInterfaceAbstract* pluginData, const char* archiveRoot,
                                           SalEnumSelection next, void* nextParam) = 0;
 
-    // funkce pro "custom archiver unpack"; vola se pri pozadavku na rozbaleni souboru/adresaru z archivu
-    // 'fileName' do adresare 'targetDir'; soubory/adresare jsou zadany maskou 'mask'; vraci TRUE pokud
-    // se podari rozbalit vsechny soubory/adresare (nebyl pouzit Cancel, mohl byt pouzit Skip);
-    // je-li 'delArchiveWhenDone' TRUE, je potreba napridavat do 'archiveVolumes' vsechny svazky archivu
-    // (vcetne null-terminatoru; neni-li vicesvazkovy, bude tam jen 'fileName'), vrati-li se z teto funkce
-    // TRUE (uspesne rozbaleni), dojde nasledne ke smazani vsech souboru z 'archiveVolumes';
-    // 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera
+    // Function for 'custom archiver unpack'; called when files/directories are to be unpacked from archive
+    // 'fileName' to directory 'targetDir'; the files/directories are specified by mask 'mask'. Returns TRUE if
+    // all files/directories are unpacked successfully (Cancel was not used; Skip may have been used).
+    // If 'delArchiveWhenDone' is TRUE, all archive volumes must be added to 'archiveVolumes'
+    // (including null terminators; if the archive is not multi-volume, only 'fileName' is stored there). If this function returns
+    // TRUE (successful unpacking), all files from 'archiveVolumes' are then deleted;
+    // 'salamander' is a set of useful methods exported by Salamander
     virtual BOOL WINAPI UnpackWholeArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                            const char* mask, const char* targetDir, BOOL delArchiveWhenDone,
                                            CDynamicString* archiveVolumes) = 0;
 
-    // funkce pro "panel archiver view/edit", vola se pred zavrenim panelu s archivem
+    // Function for 'panel archiver view/edit'; called before the panel with the archive is closed
     // POZOR: pokud se nepodari otevrit novou cestu, archiv muze v panelu zustat (nezavisle na tom,
-    //        co vrati CanCloseArchive); metodu tedy nelze pouzit pro destrukci kontextu;
-    //        je urcena napriklad pro optimalizaci operace Delete z archivu, kdy muze pri
-    //        jeho opousteni nabidnou "setreseni" archivu
-    //        pro destrukci kontextu lze pouzit metodu CPluginInterfaceAbstract::ReleasePluginDataInterface,
-    //        viz dokument archivatory.txt
-    // 'fileName' je jmeno archivu; 'salamander' je sada uzitecnych metod vyvezenych ze Salamandera;
-    // 'panel' oznacuje panel, ve kterem je archiv otevreny (PANEL_LEFT nebo PANEL_RIGHT);
-    // vraci TRUE pokud je zavreni mozne, je-li 'force' TRUE, vraci TRUE vzdy; pokud probiha
+    //        whatever CanCloseArchive returns); this method therefore cannot be used to destroy the context;
+    //        it is intended, for example, to optimize Delete from an archive, when leaving it may
+    //        offer to 'shake' the archive
+    //        to destroy the context, use CPluginInterfaceAbstract::ReleasePluginDataInterface,
+    //        see archivatory.txt
+    // 'fileName' is the archive name; 'salamander' is a set of useful methods exported by Salamander;
+    // 'panel' identifies the panel in which the archive is open (PANEL_LEFT or PANEL_RIGHT);
+    // returns TRUE if closing is possible; if 'force' is TRUE, it always returns TRUE; if
     // critical shutdown (vice viz CSalamanderGeneralAbstract::IsCriticalShutdown), nema
-    // smysl se usera na cokoliv ptat
+    // there is no point in prompting the user about anything
     virtual BOOL WINAPI CanCloseArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                         BOOL force, int panel) = 0;
 
-    // zjisti pozadovane nastaveni disk-cache (disk-cache se pouziva pro docasne kopie
-    // souboru pri otevirani souboru z archivu ve viewerech, editorech a pres systemove
-    // asociace); normalne (podari-li se po volani naalokovat kopii 'tempPath') se vola
-    // jen jednou a to pred prvnim pouzitim disk-cache (napr. pred prvnim otevrenim
-    // souboru z archivu ve vieweru/editoru); pokud vraci FALSE, pouziva
-    // se standardni nastaveni (soubory v TEMP adresari, kopie se mazou pomoci Win32
-    // API funkce DeleteFile() az pri prekroceni limitni velikosti cache nebo pri zavreni archivu)
-    // a vsechny ostatni navratove hodnoty se ignoruji; vraci-li TRUE, pouzivaji se nasledujici
-    // navratove hodnoty: neni-li 'tempPath' (buffer o velikosti MAX_PATH) prazdny retezec, budou
-    // se vsechny docasne kopie vypakovane pluginem z archivu ukladat do podadresaru teto cesty
-    // (tyto podadresare zrusi disk-cache pri ukonceni Salamandera, ale pluginu nic nebrani
-    // v jejich smazani drive, napr. pri svem unloadu; zaroven je vhodne pri loadu prvni instance
-    // pluginu (nejen v ramci jednoho spusteneho Salamandera) promazat podadresare "SAL*.tmp" na teto
-    // ceste - resi problemy vznikle zamknutymi soubory a pady softu) + je-li 'ownDelete' TRUE,
-    // bude se pro mazani kopii volat metoda DeleteTmpCopy a PrematureDeleteTmpCopy + je-li
-    // 'cacheCopies' FALSE, budou se kopie mazat hned jakmile se uvolni (napr. jakmile se zavre
-    // viewer), je-li 'cacheCopies' TRUE, budou se kopie mazat az pri prekroceni limitni velikosti
-    // cache nebo pri zavreni archivu
+    // Gets the required disk-cache settings (the disk cache is used for temporary copies
+    // of files opened from an archive in viewers, editors, and through system
+    // associations); normally, if a copy of 'tempPath' can be allocated after the call, this method is called
+    // only once, before the first use of the disk cache (for example before the first opening of
+    // a file from the archive in a viewer/editor); if it returns FALSE, the standard
+    // settings are used (files in the TEMP directory, and copies are deleted with the Win32
+    // API function DeleteFile() only after the cache size limit is exceeded or when the archive is closed)
+    // and all other return values are ignored; if it returns TRUE, the following
+    // return values are used: if 'tempPath' (a buffer of size MAX_PATH) is not an
+    // empty string, all temporary copies extracted by the plugin from the archive are stored in subdirectories of this path
+    // (these subdirectories are deleted by the disk cache when Salamander exits, but the plugin may
+    // delete them earlier, for example on unload; when the first instance of the
+    // plugin is loaded, not just within one running Salamander, it is also advisable to clean up the 'SAL*.tmp' subdirectories in this
+    // path - this handles problems caused by locked files and crashes) + if 'ownDelete' is TRUE,
+    // the DeleteTmpCopy and PrematureDeleteTmpCopy methods are called to delete the copies + if
+    // 'cacheCopies' is FALSE, the copies are deleted as soon as they are released (for example when the
+    // viewer is closed); if 'cacheCopies' is TRUE, the copies are deleted only after the cache size limit is exceeded
+    // or when the archive is closed
     virtual BOOL WINAPI GetCacheInfo(char* tempPath, BOOL* ownDelete, BOOL* cacheCopies) = 0;
 
-    // pouziva se jen pokud metoda GetCacheInfo vraci v parametru 'ownDelete' TRUE:
-    // smaze docasnou kopii vypakovanou z tohoto archivu (pozor na read-only soubory,
-    // u nich je treba nejprve zmenit atributy, a pak jdou teprve smazat), pokud mozno
-    // by nemelo zobrazovat zadna okna (uzivatel cinnost primo nevyvolal, muze ho rusit
-    // v jine cinnosti), pri delsich akcich se hodi vyuziti wait-okenka (viz
+    // Used only if GetCacheInfo returns TRUE in parameter 'ownDelete':
+    // deletes a temporary copy extracted from this archive (watch out for read-only files,
+    // their attributes must be changed before they can be deleted); if possible,
+    // it should not display any windows (the user did not invoke this directly and it may disturb them
+    // during other work); for longer actions it is useful to use a wait window (see
     // CSalamanderGeneralAbstract::CreateSafeWaitWindow); 'fileName' je jmeno souboru
-    // s kopii; pokud se maze vic souboru najednou (muze nastat napr. po zavreni
-    // editovaneho archivu), je 'firstFile' TRUE pro prvni soubor a FALSE pro ostatni
+    // for the copy; if several files are deleted at once (this can happen, for example, after an
+    // edited archive is closed), 'firstFile' is TRUE for the first file and FALSE for the remaining
     // soubory (pouziva se ke korektnimu zobrazeni wait-okenka - viz DEMOPLUG)
     //
-    // POZOR: vola se v hl. threadu na zaklade doruceni zpravy z disk-cache hl. oknu - posila se
-    // zprava o potrebe uvolnit docasnou kopii (typicky v okamziku zavreni vieweru nebo
-    // "rozeditovaneho" archivu v panelu), tedy muze dojit k opakovanemu vstupu do pluginu
-    // (pokud zpravu distribuuje message-loopa uvnitr pluginu), dalsi vstup do DeleteTmpCopy
-    // je vylouceny, protoze do ukonceni volani DeleteTmpCopy disk-cache zadne dalsi zpravy
-    // neposila
+    // WARNING: it is called in the main thread when a message from the disk cache is delivered to the main window -
+    // a message is sent requesting that a temporary copy be released (typically when a viewer or an
+    // archive being edited in a panel is closed), so reentry into the plugin may occur
+    // (if the message loop inside the plugin dispatches the message); another entry into DeleteTmpCopy
+    // is excluded because the disk cache sends no further messages until DeleteTmpCopy
+    // returns
     virtual void WINAPI DeleteTmpCopy(const char* fileName, BOOL firstFile) = 0;
 
-    // pouziva se jen pokud metoda GetCacheInfo vraci v parametru 'ownDelete' TRUE:
-    // pri unloadu pluginu zjisti, jestli se ma volat DeleteTmpCopy pro kopie, ktere jsou
-    // jeste pouzivane (napr. otevrene ve vieweru) - vola se jen pokud takove kopie
-    // existuji; 'parent' je parent pripadneho messageboxu s dotazem uzivateli (pripadne
-    // doporuceni, aby user zavrel vsechny soubory z archivu, aby je plugin mohl smazat);
-    // 'copiesCount' je pocet pouzivanych kopii souboru z archivu; vraci TRUE pokud se
-    // ma volat DeleteTmpCopy, pokud vrati FALSE, kopie zustanou na disku; pokud probiha
-    // critical shutdown (vice viz CSalamanderGeneralAbstract::IsCriticalShutdown), nema
-    // smysl se usera na cokoliv ptat a provadet zdlouhave akce (napr. shredovani souboru)
-    // POZNAMKA: behem provadeni PrematureDeleteTmpCopy je zajisteno, ze nedojde
-    // k volani DeleteTmpCopy
+    // Used only if GetCacheInfo returns TRUE in parameter 'ownDelete':
+    // on plugin unload, determines whether DeleteTmpCopy should be called for copies that are
+    // still in use (for example open in a viewer) - it is called only if such copies
+    // exist; 'parent' is the parent window of any message box shown to the user (for example
+    // to recommend that the user close all files from the archive so the plugin can delete them);
+    // 'copiesCount' is the number of copies of archive files still in use; returns TRUE if
+    // DeleteTmpCopy should be called; if it returns FALSE, the copies remain on disk. If a
+    // critical shutdown is in progress (see CSalamanderGeneralAbstract::IsCriticalShutdown), there is no
+    // point in prompting the user or performing lengthy actions (for example shredding files).
+    // NOTE: while PrematureDeleteTmpCopy is running, DeleteTmpCopy is guaranteed
+    // not to be called
     virtual BOOL WINAPI PrematureDeleteTmpCopy(HWND parent, int copiesCount) = 0;
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_arc.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 10 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 20/20 review unit(s).
- Validation passed with 10 rewrite(s), 10 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_arc.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 16855 output token(s).
- Copilot CLI: 1 premium request(s).