### PR TITLE
[translation] Fix src/plugins/shared/spl_view.h comments

### DIFF
--- a/src/plugins/shared/spl_view.h
+++ b/src/plugins/shared/spl_view.h
@@ -38,19 +38,19 @@ public:
 
     // Called when the viewer is requested to open and load file
     // 'name'; 'left'+'top'+'width'+'height'+'showCmd'+'alwaysOnTop' is the recommended window placement;
-    // okna, je-li 'returnLock' FALSE nemaji 'lock'+'lockOwner' zadny vyznam, je-li 'returnLock'
+    // window; if 'returnLock' is FALSE, 'lock'+'lockOwner' have no meaning; if 'returnLock' is
     // TRUE, mel by viewer vratit system-event 'lock' v nonsignaled stavu, do signaled stavu 'lock'
     // becomes signaled when viewing file 'name' ends (the file is removed from the temporary
-    // z docasneho adresare), dale by mel vratit v 'lockOwner' TRUE pokud ma byt objekt 'lock' uzavren
-    // volajicim (FALSE znamena, ze si viewer 'lock' rusi sam - v tomto pripade viewer musi pro
-    // prechod 'lock' do signaled stavu pouzit metodu CSalamanderGeneralAbstract::UnlockFileInCache);
-    // pokud viewer nenastavi 'lock' (zustava NULL) je soubor 'name' platny jen do ukonceni volani teto
-    // metody ViewFile; neni-li 'viewerData' NULL, jde o predani rozsirenych parametru viewru (viz
+    // directory at that moment); it should also return TRUE in 'lockOwner' if the 'lock' object is to be closed
+    // by the caller (FALSE means the viewer closes 'lock' itself - in that case the viewer must use
+    // CSalamanderGeneralAbstract::UnlockFileInCache to make 'lock' signaled);
+    // if the viewer does not set 'lock' (it remains NULL), file 'name' is valid only until this
+    // ViewFile call ends; if 'viewerData' is not NULL, it passes extended viewer parameters (see
     // CSalamanderGeneralAbstract::ViewFileInPluginViewer); 'enumFilesSourceUID' je UID zdroje (panelu
     // or Find window) from which the viewer is opened; if it is -1, the source is unknown (archives
-    // file_systemy nebo Alt+F11, atd.) - viz napr. CSalamanderGeneralAbstract::GetNextFileNameForViewer;
+    // or file systems, or Alt+F11, etc.) - see e.g. CSalamanderGeneralAbstract::GetNextFileNameForViewer;
     // 'enumFilesCurrentIndex' is the index of the opened file in the source (panel or Find window); if it is -1,
-    // neni zdroj nebo index znamy; vraci TRUE pri uspechu (FALSE znamena neuspech, 'lock' a
+    // the source or index is unknown; returns TRUE on success (FALSE means failure, 'lock' and
     // 'lockOwner' have no meaning in that case)
     virtual BOOL WINAPI ViewFile(const char* name, int left, int top, int width, int height,
                                  UINT showCmd, BOOL alwaysOnTop, BOOL returnLock, HANDLE* lock,
@@ -58,11 +58,11 @@ public:
                                  int enumFilesSourceUID, int enumFilesCurrentIndex) = 0;
 
     // Called when the viewer is requested to open and load file
-    // 'name'; this method should not display any "invalid file format" dialogs; those
-    // dialogs are displayed only when the ViewFile method of this interface is called; checks whether
-    // file 'name' can be displayed in the viewer (e.g. the file has a matching signature)
-    // a pokud je, vraci TRUE; pokud vrati FALSE, zkusi Salamander pro 'name' najit jiny
-    // viewer (v prioritnim seznamu vieweru, viz konfiguracni stranka Viewers)
+    // 'name'; this method should not display any "invalid file format" dialogs; such
+    // dialogs are shown only when the ViewFile method of this interface is called; this method determines whether
+    // file 'name' can be displayed by the viewer (e.g. the file has a matching signature),
+    // and if so returns TRUE; if it returns FALSE, Salamander tries to find another
+    // viewer for 'name' (in the viewer priority list; see the Viewers configuration page)
     virtual BOOL WINAPI CanViewFile(const char* name) = 0;
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_view.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 12/12 review unit(s).
- Validation passed with 2 rewrite(s), 10 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_view.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 9975 output token(s).
- Copilot CLI: 1 premium request(s).