### PR TITLE
[translation] Fix src/plugins/shared/lukas/counter.h comments

### DIFF
--- a/src/plugins/shared/lukas/counter.h
+++ b/src/plugins/shared/lukas/counter.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 


### PR DESCRIPTION
## Summary
- Adds the missing `CommentsTranslationProject: TRANSLATED` header marker in `src/plugins/shared/lukas/counter.h`.
- Keeps the change comment-only; no executable code was modified.
- Adds the translation header marker without changing any existing translated comments.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 8/8 review unit(s).
- Validation passed with 0 rewrite(s), 8 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/lukas/counter.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4175 output token(s).
- Copilot CLI: 1 premium request(s).