### PR TITLE
[translation] Fix src/plugins/shared/lukas/resedit.h comments

### DIFF
--- a/src/plugins/shared/lukas/resedit.h
+++ b/src/plugins/shared/lukas/resedit.h
@@ -1,20 +1,19 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
-//******************************************************************************
+// ******************************************************************************
 //
-// metody tridy CResEdit nahrazuji API funkce BeginUpdateResource, UpdateResource, EndUpdateResource
+// CResEdit class methods replace the BeginUpdateResource, UpdateResource, and EndUpdateResource API functions.
 //
-// co neni jeste vychytany:
-// - .rsrc section musi v exaci existovat
-// - .rsrc section muze byt pouze na konci PE souboru, neni-li (napr. u debug verse exace)
-//  dojde k prepsani zbytku exace
-// -nejde smazat resource z exace (v API to lze predanim hodnoty NULL parametru 'lpData' do
-//  funkce UpdateResource)
-// -nelze blize urcit chybu, vsechny tri metody nenastavuji last error a v pripade chyby
-//  vraceji pouze FALSE
+// Current limitations:
+// - the .rsrc section must exist in the executable
+// - the .rsrc section must be at the end of the PE file; otherwise (for example, in a debug build)
+//   the rest of the executable is overwritten
+// - deleting a resource from the executable is not supported (the API allows this by passing NULL as the 'lpData' parameter to UpdateResource)
+// - the exact error cannot be determined; none of the three methods sets last error, and they return only FALSE on failure
 
 class CResEditRoot
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/resedit.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 27/27 review unit(s).
- Validation passed with 1 rewrite(s), 26 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/lukas/resedit.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 6404 output token(s).
- Copilot CLI: 1 premium request(s).