### PR TITLE
[translation] Fix src/plugins/shared/spl_base.h comments (chunk 5/7)

### DIFF
--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -480,7 +480,7 @@ public:
 
     // called before the plugin is unloaded (naturally only if SalamanderPluginEntry returned
     // this object and not NULL); returns TRUE if the unload may proceed,
-    // 'parent' je parent messageboxu, 'force' je TRUE pokud se nebere ohled na navratovou
+    // 'parent' is the parent window for message boxes, 'force' is TRUE if the return
     // value is ignored; if it returns TRUE, this object and all other objects obtained from it
     // will no longer be used and the plugin will be unloaded; if a critical shutdown is in progress (see
     // CSalamanderGeneralAbstract::IsCriticalShutdown), nema smysl se usera na cokoliv ptat
@@ -490,19 +490,19 @@ public:
     // have nothing left to execute => usually neither a bug report nor Windows exception info is generated)
     virtual BOOL WINAPI Release(HWND parent, BOOL force) = 0;
 
-    // funkce pro load defaultni konfigurace a pro "load/save configuration" (load ze soukromeho klice
-    // pluginu v registry), 'parent' je parent messageboxu, je-li 'regKey' == NULL, jde o
-    // defaultni konfiguraci, 'registry' je objekt pro praci s registry, tato metoda se vola vzdy
-    // po SalamanderPluginEntry a pred ostatnimi volanimi (vola se load ze soukromeho klice, je-li
-    // tato funkce pluginem poskytovana a klic v registry existuje, jinak vola jen load defaultni
-    // konfigurace)
+    // method for loading the default configuration and for "load/save configuration" (loading from the plugin's private
+    // registry key), 'parent' is the parent window for message boxes; if 'regKey' == NULL, the default
+    // configuration is being loaded; 'registry' is the object used to work with the registry; this method is always called
+    // after SalamanderPluginEntry and before other calls (loading from the private key is performed if
+    // this function is provided by the plugin and the registry key exists; otherwise only the default
+    // configuration is loaded)
     virtual void WINAPI LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) = 0;
 
-    // funkce pro "load/save configuration", vola se pro ulozeni konfigurace pluginu do jeho soukromeho
-    // klice v registry, 'parent' je parent messageboxu, 'registry' je objekt pro praci s registry,
-    // uklada-li Salamander konfiguraci, vola take tuto metodu (je-li pluginem poskytovana); Salamander
-    // tez nabizi ukladani konfigurace pluginu pri jeho unloadu (napr. rucne z Plugins Manageru),
-    // v tomto pripade se ulozeni provede jen pokud v registry existuje klic Salamandera
+    // method for "load/save configuration"; called to save the plugin configuration to its private
+    // registry key, 'parent' is the parent window for message boxes, 'registry' is the object used to work with the registry;
+    // when Salamander saves its configuration, it also calls this method (if the plugin provides it); Salamander
+    // also supports saving the plugin configuration when the plugin is unloaded (for example, manually from Plugins Manager);
+    // in that case, saving is performed only if Salamander's registry key exists
     virtual void WINAPI SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRegistryAbstract* registry) = 0;
 
     // called in response to the Configuration button in the Plugins window
@@ -641,7 +641,7 @@ public:
     // releases the 'pluginData' interface that Salamander obtained from the plugin by calling
     // CPluginInterfaceForArchiverAbstract::ListArchive nebo
     // CPluginFSInterfaceAbstract::ListCurrentPath; pred timto volanim jeste
-    // file and directory data (CFileData::PluginData) are also released by the methods of
+    // file and directory data (CFileData::PluginData) are released using methods of
     // CPluginDataInterfaceAbstract
     virtual void WINAPI ReleasePluginDataInterface(CPluginDataInterfaceAbstract* pluginData) = 0;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_base.h`.
- Covers chunk 5 of 7 for this oversized file review.
- Reviews 20 of 135 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 4 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 146/146 review unit(s).
- Validation passed with 4 rewrite(s), 132 keep(s), and 10 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_base.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 11436 output token(s).
- Copilot CLI: 1 premium request(s).