### PR TITLE
[translation] Fix src/plugins/shared/spl_gen.h comments (chunk 14/14)

### DIFF
--- a/src/plugins/shared/spl_gen.h
+++ b/src/plugins/shared/spl_gen.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //


### PR DESCRIPTION
## Summary
- Adds the missing `CommentsTranslationProject: TRANSLATED` header marker in `src/plugins/shared/spl_gen.h`.
- Covers chunk 14 of 14 for this oversized file review.
- Reviews 1 of 521 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Adds the translation header marker without changing any existing translated comments.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 539/539 review unit(s).
- Validation passed with 0 rewrite(s), 539 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_gen.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 468 output token(s).
- Copilot CLI: 1 premium request(s).