### PR TITLE
[translation] Fix src/common/crc32.cpp comments

### DIFF
--- a/src/common/crc32.cpp
+++ b/src/common/crc32.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 


### PR DESCRIPTION
## Summary
- Adds the missing `CommentsTranslationProject: TRANSLATED` header marker in `src/common/crc32.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Adds the translation header marker without changing any existing translated comments.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 9/9 review unit(s).
- Validation passed with 0 rewrite(s), 9 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/crc32.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 2137 output token(s).
- Copilot CLI: 1 premium request(s).