### PR TITLE
[translation] Fix src/common/crc32.h comments

### DIFF
--- a/src/common/crc32.h
+++ b/src/common/crc32.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -15,7 +16,7 @@
 extern const DWORD StaticCrcTab[256];
 #endif
 
-//fill up crc table
+//populate the CRC table
 void MakeCrcTable(DWORD* crcTab);
 
 //run a set of bytes through the crc shift register, if buffer is a NULL


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/crc32.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 6/6 review unit(s).
- Validation passed with 1 rewrite(s), 5 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/crc32.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 3888 output token(s).
- Copilot CLI: 1 premium request(s).