### PR TITLE
[translation] Fix src/common/handles.cpp comments

### DIFF
--- a/src/common/handles.cpp
+++ b/src/common/handles.cpp
@@ -544,12 +544,7 @@ C__Handles::~C__Handles()
     // Check and list the remaining handles.
     if (Handles.Count != 0)
     {
-        // I had to replace the code below that uses MESSAGE_E, because when this
-        // destructor is called the stream facets in ALTAPDB have already been destroyed, and sending an int
-        // or handle to the stream simply crashes (this happens only in VC2010 and VC2012; in VC2008
-        // it still works). It does not happen in Salamander, probably because the RTL is in the DLL
-        // (ALTAPDB uses a static one); I did not investigate further. A better solution would be to destroy the
-        // facets only after this module, but unfortunately I cannot do that (only at the "lib" level).
+        // The code below that uses MESSAGE_E had to be replaced because when this destructor runs, the stream facets in ALTAPDB have already been destroyed, and sending an int or handle to the stream simply crashes (only in VC2010 and VC2012; it still works in VC2008). It does not happen in Salamander, probably because the RTL is in the DLL (ALTAPDB uses a static one), but that was not investigated further. A better solution would be to destroy the facets only after this module, but that cannot be done here (only at the "lib" level).
         char msgBuf[1000];
         sprintf_s(msgBuf,
 #ifdef MESSAGES_DEBUG
@@ -1891,8 +1886,8 @@ BOOL C__Handles::DuplicateHandle(HANDLE hSourceProcessHandle, HANDLE hSourceHand
                     "current process.");
         }
 
-        // GetCurrentProcess vraci jakysi pseudohandle, takze tahle konstrukce
-        // neni spravna, meli by se porovnat ID procesu a ne jejich handly ...
+        // GetCurrentProcess returns a pseudo-handle, so this is not correct;
+        // process IDs should be compared instead of process handles ...
 
         if ((dwOptions & DUPLICATE_CLOSE_SOURCE) &&
             hSourceProcessHandle == GetCurrentProcess())


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/handles.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 85/85 review unit(s).
- Validation passed with 2 rewrite(s), 83 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/handles.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 9716 output token(s).
- Copilot CLI: 1 premium request(s).