### PR TITLE
[translation] Fix src/common/regexp.cpp comments (chunk 1/3)

### DIFF
--- a/src/common/regexp.cpp
+++ b/src/common/regexp.cpp
@@ -40,14 +40,14 @@
 
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 
-//#include "trace.h" aby to slo pripojit i k pluginum, stejne tu zatim zadny TRACE neni
+//needed so this can also be built for plugins; there is no TRACE here yet
 #include "str.h"
 #include "regexp.h"
 
 //*****************************************************************************
 //*****************************************************************************
 //
-// moje cast regexp.cpp
+// my section of regexp.cpp
 //
 //*****************************************************************************
 //*****************************************************************************
@@ -447,7 +447,7 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
             else
                 *--dstExpEnd = (*s == '(') ? ')' : ']';
 
-            if (oldSS - s >= 2) // pokud vyraz nekonci otevrenou zavorkou
+            if (oldSS - s >= 2) // if the expression does not end with an opening parenthesis
             {
                 if (*s == '(')
                 { // Copy the reversed expression - parenthesized group.
@@ -485,7 +485,7 @@ void CRegularExpression::ReverseRegExp(char*& dstExpEnd, char* srcExp, char* src
 //*****************************************************************************
 //*****************************************************************************
 //
-// puvodni regexp.cpp
+// original regexp.cpp
 //
 //*****************************************************************************
 //*****************************************************************************


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/regexp.cpp`.
- Covers chunk 1 of 3 for this oversized file review.
- Reviews 80 of 169 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 4 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 172/172 review unit(s).
- Validation passed with 4 rewrite(s), 168 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/regexp.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 14176 output token(s).
- Copilot CLI: 1 premium request(s).