### PR TITLE
[translation] Fix src/common/messages.cpp comments

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -189,7 +189,7 @@ int C__Messages::MessageBoxT(const char* lpCaption, UINT uType)
     HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // backup copy of the text
     if (message != NULL)
     {
-        memcpy((char*)message, MessagesStringBuf.c_str(), len); // je to FIXED -> HANDLE==PTR
+        memcpy((char*)message, MessagesStringBuf.c_str(), len); // it is FIXED, so HANDLE == PTR
         data.Text = (char*)message;
     }
     else
@@ -231,7 +231,7 @@ int C__Messages::MessageBox(HWND hWnd, const char* lpCaption, UINT uType)
     size_t len = MessagesStringBuf.length() + 1;
     HGLOBAL message = GlobalAlloc(GMEM_FIXED, len); // backup copy of the text
     char* txt;
-    txt = (char*)message; // je to FIXED -> HANDLE==PTR
+    txt = (char*)message; // it is FIXED, so HANDLE == PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), len);
     else
@@ -264,7 +264,7 @@ C__MessagesW::C__MessagesW() : MessagesStrStream(&MessagesStringBuf)
     // For now we use only output streams, and only with strings (without conversion) and numbers. So sending a number to the stringstream should be enough. If we start using streams more in the future and the debug heap starts reporting leaks again, we will have to add more input/output here.
     std::wstringstream s;
     s << 1;
-#endif // _DEBUG
+#endif // MULTITHREADED_MESSAGES_ENABLE
 }
 
 struct C__MessageBoxDataW
@@ -299,7 +299,7 @@ int C__MessagesW::MessageBoxT(const WCHAR* lpCaption, UINT uType)
     HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // backup copy of the text
     if (message != NULL)
     {
-        memcpy((WCHAR*)message, MessagesStringBuf.c_str(), sizeof(WCHAR) * len); // je to FIXED -> HANDLE==PTR
+        memcpy((WCHAR*)message, MessagesStringBuf.c_str(), sizeof(WCHAR) * len); // it is FIXED, so HANDLE == PTR
         data.Text = (WCHAR*)message;
     }
     else
@@ -341,7 +341,7 @@ int C__MessagesW::MessageBox(HWND hWnd, const WCHAR* lpCaption, UINT uType)
     size_t len = MessagesStringBuf.length() + 1;
     HGLOBAL message = GlobalAlloc(GMEM_FIXED, sizeof(WCHAR) * len); // backup copy of the text
     WCHAR* txt;
-    txt = (WCHAR*)message; // je to FIXED -> HANDLE==PTR
+    txt = (WCHAR*)message; // it is FIXED, so HANDLE == PTR
     if (txt != NULL)
         memcpy(txt, MessagesStringBuf.c_str(), sizeof(WCHAR) * len);
     else


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/messages.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 5 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 98/98 review unit(s).
- Validation passed with 5 rewrite(s), 77 keep(s), and 16 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/messages.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 8952 output token(s).
- Copilot CLI: 1 premium request(s).