### PR TITLE
[translation] Fix src/common/trace.cpp comments (chunk 1/3)

### DIFF
--- a/src/common/trace.cpp
+++ b/src/common/trace.cpp
@@ -243,7 +243,7 @@ DWORD
 C__TraceThreadCache::GetUniqueThreadId(DWORD tid)
 {
     if (CacheUID[__TraceCacheGetIndex(tid)] != -1 && // je-li platny zaznam
-        CacheTID[__TraceCacheGetIndex(tid)] == tid)  // a je-li shodny s tid
+        CacheTID[__TraceCacheGetIndex(tid)] == tid)  // and the TID matches
     {
         return CacheUID[__TraceCacheGetIndex(tid)]; // UID is in the cache
     }
@@ -488,7 +488,7 @@ BOOL C__Trace::Connect(BOOL onUserRequest)
 
     BOOL ret = FALSE;
     if (HWritePipe != NULL)
-        ret = TRUE; // pokud je jiz spojeni navazano
+        ret = TRUE; // if the connection is already established
     else
     {
         // try to open the mutex for access to the shared memory


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/trace.cpp`.
- Covers chunk 1 of 3 for this oversized file review.
- Reviews 80 of 174 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 179/179 review unit(s).
- Validation passed with 2 rewrite(s), 177 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/trace.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 7730 output token(s).
- Copilot CLI: 1 premium request(s).