### PR TITLE
[translation] Fix src/common/trace.cpp comments (chunk 2/3)

### DIFF
--- a/src/common/trace.cpp
+++ b/src/common/trace.cpp
@@ -596,7 +596,7 @@ BOOL C__Trace::Connect(BOOL onUserRequest)
                                                                                         *(DWORD*)&mapAddress[4] /* ClientOrServerProcessId (here it is the server PID) */);
                                                     // get the pipe and semaphore handles
                                                     if (hServerProcess != NULL &&
-                                                        DuplicateHandle(hServerProcess, (HANDLE)(DWORD_PTR)(*(DWORD*)&mapAddress[8]) /* HReadOrWritePipe (here it is HWritePipe) */, // server
+                                                        DuplicateHandle(hServerProcess, (HANDLE)(DWORD_PTR)(*(DWORD*)&mapAddress[8]) /* HReadOrWritePipe (here it is HWritePipe) */, // client
                                                                         GetCurrentProcess(), &hWritePipeFromSrv,                                                                     // client
                                                                         GENERIC_WRITE, FALSE, 0) &&
                                                         DuplicateHandle(hServerProcess, (HANDLE)(DWORD_PTR)(*(DWORD*)&mapAddress[12]) /* HPipeSemaphore */, // server
@@ -604,11 +604,11 @@ BOOL C__Trace::Connect(BOOL onUserRequest)
                                                                         0, FALSE, DUPLICATE_SAME_ACCESS))
                                                     {
                                                         *((int*)mapAddress) = 3;                         // write result -> 3 = success, we have the handles
-                                                        *(DWORD*)&mapAddress[4] = GetCurrentProcessId(); // ClientOrServerProcessId (tady jde o PID klienta)
+                                                        *(DWORD*)&mapAddress[4] = GetCurrentProcessId(); // ClientOrServerProcessId (client PID here)
                                                     }
                                                     else
                                                     {
-                                                        *((BOOL*)mapAddress) = FALSE; // write result -> failed
+                                                        *((BOOL*)mapAddress) = FALSE; // write result -> failure
                                                     }
                                                     if (hServerProcess != NULL)
                                                         CloseHandle(hServerProcess);
@@ -627,7 +627,7 @@ BOOL C__Trace::Connect(BOOL onUserRequest)
                                                         CloseHandle(HWritePipe);
                                                         HWritePipe = hWritePipeFromSrv; // use the pipe from the server (close the client one)
 
-                                                        if (expectedServerVer == TRACE_CLIENT_VERSION) // hura, povedlo se pripojit na novy Trace Server!
+                                                        if (expectedServerVer == TRACE_CLIENT_VERSION) // successfully connected to the new Trace Server!
                                                         {
 #ifdef TRACE_IGNORE_AUTOCLEAR
                                                             ret = SendIgnoreAutoClear(TRUE); // ignore; disconnect on error


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/trace.cpp`.
- Covers chunk 2 of 3 for this oversized file review.
- Reviews 80 of 174 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 4 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 179/179 review unit(s).
- Validation passed with 4 rewrite(s), 175 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/trace.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 10064 output token(s).
- Copilot CLI: 1 premium request(s).