### PR TITLE
[translation] Fix src/common/winlib.cpp comments (chunk 1/2)

### DIFF
--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -111,12 +111,11 @@ BOOL WinLibIsWindowsVersionOrGreater(WORD wMajorVersion, WORD wMinorVersion, WOR
     return VerifyVersionInfoW(&osvi, VER_MAJORVERSION | VER_MINORVERSION | VER_SERVICEPACKMAJOR, dwlConditionMask) != FALSE;
 }
 
-//
 // ****************************************************************************
 // CWindow
 //
-// lpvParam - v pripade, ze se pri CreateWindow zavola CWindow::CWindowProc
-//            (je v tride okna), musi obsahovat adresu objektu vytvareneho okna
+// lpvParam - if CWindow::CWindowProc is called during CreateWindow
+//            (it is in the window class), it must contain the address of the window object being created
 
 HWND CWindow::CreateEx(DWORD dwExStyle,        // extended window style
                        LPCTSTR lpszClassName,  // address of registered class name
@@ -329,7 +328,7 @@ CWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             return TRUE;
         }
         if (GetWindowLongPtr(HWindow, GWL_STYLE) & WS_CHILD)
-            break;   // pokud F1 nezpracujeme a pokud je to child okno, nechame F1 propadnout do parenta
+            break;   // if we do not handle F1 and this is a child window, let F1 fall through to the parent
         return TRUE; // if it is not a child, stop processing F1
     }
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.cpp`.
- Covers chunk 1 of 2 for this oversized file review.
- Reviews 80 of 152 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 157/157 review unit(s).
- Validation passed with 2 rewrite(s), 155 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/winlib.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 7554 output token(s).
- Copilot CLI: 1 premium request(s).