### PR TITLE
[translation] Fix src/common/winlib.cpp comments (chunk 2/2)

### DIFF
--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -402,8 +402,8 @@ CWindow::CWindowProcInt(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
 #endif // _UNICODE
         if (wnd != NULL && wnd->Is(otWindow))
         {
-            // Petr: posunul jsem dolu pod wnd->WindowProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: moved this below wnd->WindowProc() so messages are still delivered during WM_DESTROY
+            //       (Lukas needed this)
             // WindowsManager.DetachWindow(hwnd);
 
             LRESULT res = wnd->WindowProc(uMsg, wParam, lParam);
@@ -411,8 +411,8 @@ CWindow::CWindowProcInt(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL
             // now back to the old procedure again (because of subclassing)
             WindowsManager.DetachWindow(hwnd);
 
-            // pokud aktualni WndProc je jina nez nase, nebudeme ji menit,
-            // protoze nekdo v rade subclasseni uz vratil puvodni WndProc
+            // if the current WndProc is different from ours, do not change it,
+            // because someone else in the subclass chain has already restored the original WndProc
 #ifdef _UNICODE
             WNDPROC currentWndProc = (WNDPROC)GetWindowLongPtr(wnd->HWindow, GWLP_WNDPROC);
             if (currentWndProc == CWindow::CWindowProc)
@@ -735,8 +735,8 @@ CDialog::CDialogProc(HWND hwndDlg, UINT uMsg, WPARAM wParam, LPARAM lParam)
         INT_PTR ret = FALSE; // in case the dialog does not handle it
         if (dlg != NULL && dlg->Is(otDialog))
         {
-            // Petr: posunul jsem dolu pod dlg->DialogProc(), aby behem WM_DESTROY
-            //       jeste dochazely zpravy (potreboval Lukas)
+            // Petr: moved this below dlg->DialogProc() so messages are still delivered during WM_DESTROY
+            //       (Lukas needed this)
             // WindowsManager.DetachWindow(hwndDlg);
 
             ret = dlg->DialogProc(uMsg, wParam, lParam);
@@ -850,7 +850,7 @@ void CWindowsManager::DetachWindow(HWND hWnd)
         {
             ResetState();
             TRACE_ET(_T("Unable to detach window from WindowsManager. hwnd = ") << hWnd);
-            At(i).Wnd = NULL; // alespon takhle ...
+            At(i).Wnd = NULL; // at least this way...
         }
     }
     else
@@ -1140,7 +1140,7 @@ void CTransferInfo::EditLine(int ctrlID, double& value, TCHAR* format, BOOL sele
             if (*s == 0)
             {
                 TCHAR* stopString;                  // dummy
-                value = _tcstod(buff, &stopString); // jen pokud je cislo
+                value = _tcstod(buff, &stopString); // only if the string is a number
             }
             else
                 value = 0; // on error, set zero


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.cpp`.
- Covers chunk 2 of 2 for this oversized file review.
- Reviews 72 of 152 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 5 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 157/157 review unit(s).
- Validation passed with 5 rewrite(s), 152 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/winlib.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 10589 output token(s).
- Copilot CLI: 1 premium request(s).