### PR TITLE
[translation] Fix src/common/winlib.h comments (chunk 2/2)

### DIFF
--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -389,9 +389,9 @@ protected:
 
 struct CWindowData
 {
-    // pokud jsou objekty oken (Wnd) umistene na stacku (typicky modalni dialogy, napr. SalMessageBox())
-    // a dojde k terminovani threadu, stack se zneplatni a tim jiz objekty oken nejsou pristupne,
-    // resime tak, ze na objekty (Wnd) sahame jen dokud jsou platne handly oken (HWnd)
+    // if window objects (Wnd) are allocated on the stack (typically modal dialogs, e.g. SalMessageBox())
+    // and the thread terminates, the stack becomes invalid and the window objects are no longer accessible,
+    // so we only access the objects (Wnd) while the window handles (HWnd) are still valid
     HWND HWnd;
     CWindowsObject* Wnd;
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.h`.
- Covers chunk 2 of 2 for this oversized file review.
- Reviews 49 of 129 eligible provider-review unit(s) in this pass.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file chunk, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 141/141 review unit(s).
- Validation passed with 1 rewrite(s), 139 keep(s), and 1 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/winlib.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 6280 output token(s).
- Copilot CLI: 1 premium request(s).