### PR TITLE
[translation] Fix src/plugins/shared/dbg.cpp comments

### DIFF
--- a/src/plugins/shared/dbg.cpp
+++ b/src/plugins/shared/dbg.cpp
@@ -18,7 +18,7 @@
 #endif // _MSC_VER
 
 // suppress warning C4996: This function or variable may be unsafe. Consider using strcat_s instead.
-// reason: lstrcat and other Windows routines are not safe anyway, so addressing it here is pointless
+// reason: lstrcat and other Windows routines simply are not safe, so addressing it here is pointless
 #pragma warning(push)
 #pragma warning(disable : 4996)
 
@@ -369,7 +369,7 @@ void C__Trace::SendMessageToServer(BOOL information, BOOL unicode, BOOL crash)
             // the bug report shows exactly where the macros are; the crash therefore follows
             // after this method completes
         }
-        else // block other TRACE_C threads until the message box opened for the
+        else // block other TRACE_C threads until the message box opened for the first TRACE_C is closed
         {    // first TRACE_C closes; they crash there too to keep things consistent
             if (msgBoxOpened)
             {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/dbg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 33 comment units, 33 review results, 33 resolved results, and 33 apply results.
- Branch-target comment guard passed for `src/plugins/shared/dbg.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/dbg.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 86195 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 45044 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 41151 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
