### PR TITLE
[translation] Fix src/plugins/shared/dbg.h comments

### DIFF
--- a/src/plugins/shared/dbg.h
+++ b/src/plugins/shared/dbg.h
@@ -12,13 +12,13 @@
 
 #pragma once
 
-// definitions of the TRACE_I, TRACE_IW, TRACE_E, TRACE_EW, TRACE_C, TRACE_CW, and CALL_STACK_MESSAGEXXX macros for plugins,
-// in a plugin you must define the SalamanderDebug variable (type shown below) and
+// Definitions of the TRACE_I, TRACE_IW, TRACE_E, TRACE_EW, TRACE_C, TRACE_CW, and CALL_STACK_MESSAGEXXX macros for plugins.
+// In a plugin, you must define the SalamanderDebug variable (type shown below) and
 // initialize it in SalamanderPluginEntry:
 // SalamanderDebug = salamander->GetSalamanderDebug();
 //
-// TRACE is enabled by defining TRACE_ENABLE
-// CALL-STACK is disabled by defining CALLSTK_DISABLE
+// TRACE is enabled by defining the TRACE_ENABLE macro.
+// CALL-STACK is disabled by defining the CALLSTK_DISABLE macro.
 
 // WARNING: TRACE_C must not be used in DllMain, or in any code
 //        called from DllMain, otherwise a deadlock will occur; see
@@ -82,7 +82,7 @@ public:
     // return pointer to the beginning of the data, terminated by null
     const char* c_str()
     {
-        // add trailing null
+        // add a trailing null terminator
         sputc('\0');
 
         // decrement the pointer back, trailing null is not part of the data


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/dbg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 105 comment units, 105 review results, 105 resolved results, and 105 apply results.
- Branch-target comment guard passed for `src/plugins/shared/dbg.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/dbg.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 131444 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 106352 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 25092 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
