### PR TITLE
[translation] Fix src/plugins/shared/htmlhelp.h comments

### DIFF
--- a/src/plugins/shared/htmlhelp.h
+++ b/src/plugins/shared/htmlhelp.h
@@ -331,7 +331,7 @@ extern "C"
         LPCTSTR pszUrlJump2;            // URL for HHWIN_BUTTON_JUMP2
         RECT rcMinSize;                 // Minimum size for window (ignored in version 1)
         int cbInfoTypes;                // size of paInfoTypes;
-        LPCTSTR pszCustomTabs;          // multiple zero-terminated strings
+        LPCTSTR pszCustomTabs;          // multiple null-terminated strings
     } HH_WINTYPE, *PHH_WINTYPE;
 
     enum
@@ -404,11 +404,11 @@ extern "C"
     //
     typedef enum tagHH_GPROPID
     {
-        HH_GPROPID_SINGLETHREAD = 1,    // VARIANT_BOOL: True for single thread
+        HH_GPROPID_SINGLETHREAD = 1,    // VARIANT_BOOL: TRUE for single-threaded operation
         HH_GPROPID_TOOLBAR_MARGIN = 2,  // long: Provides a left/right margin around the toolbar.
         HH_GPROPID_UI_LANGUAGE = 3,     // long: LangId of the UI.
         HH_GPROPID_CURRENT_SUBSET = 4,  // BSTR: Current subset.
-        HH_GPROPID_CONTENT_LANGUAGE = 5 // long: LandId for desired content.
+        HH_GPROPID_CONTENT_LANGUAGE = 5 // long: LANGID for desired content.
     } HH_GPROPID;
 
 ///////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/htmlhelp.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 187 comment units, 187 review results, 187 resolved results, and 187 apply results.
- Branch-target comment guard passed for `src/plugins/shared/htmlhelp.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/htmlhelp.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 12 provider calls, 265601 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 12 calls, 265601 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
