### PR TITLE
[translation] Fix src/common/trace.cpp comments

### DIFF
--- a/src/common/trace.cpp
+++ b/src/common/trace.cpp
@@ -242,7 +242,7 @@ BOOL C__TraceThreadCache::Add(HANDLE handle, DWORD tid)
 DWORD
 C__TraceThreadCache::GetUniqueThreadId(DWORD tid)
 {
-    if (CacheUID[__TraceCacheGetIndex(tid)] != -1 && // je-li platny zaznam
+    if (CacheUID[__TraceCacheGetIndex(tid)] != -1 && // valid entry
         CacheTID[__TraceCacheGetIndex(tid)] == tid)  // and the TID matches
     {
         return CacheUID[__TraceCacheGetIndex(tid)]; // UID is in the cache


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/trace.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 179/179 review unit(s).
- Validation passed with 1 rewrite(s), 178 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/trace.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 13776 output token(s).
- Copilot CLI: 1 premium request(s).