### PR TITLE
[translation] Fix src/common/winlib.h comments

### DIFF
--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -122,8 +122,8 @@ public:
 protected:
     CObjectOrigin ObjectOrigin;
 #ifndef _UNICODE
-    // okna: create: TRUE = okno je unicodove, jinak je ANSI; attach: TRUE = nase window procedura
-    // je unicodova, jinak je ANSI; dialogy: TRUE = dialog je unicodovy, jinak je ANSI
+    // windows: create: TRUE = the window is Unicode, otherwise ANSI; attach: TRUE = our window procedure
+    // is Unicode, otherwise ANSI; dialogs: TRUE = the dialog is Unicode, otherwise ANSI
     BOOL UnicodeWnd;
 #endif // _UNICODE
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 141/141 review unit(s).
- Validation passed with 1 rewrite(s), 139 keep(s), and 1 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/winlib.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4111 output token(s).
- Copilot CLI: 1 premium request(s).