### PR TITLE
[translation] Fix src/plugins/shared/mhandles.cpp comments

### DIFF
--- a/src/plugins/shared/mhandles.cpp
+++ b/src/plugins/shared/mhandles.cpp
@@ -77,15 +77,15 @@ const char* err(DWORD error);
                      __MessagesTitle, (buttons))
 
 /*
- * shows a message box with the specified text and error icon, not in a new
- *     thread, dispatches the calling thread's messages
+ * Shows a message box with the specified text and error icon. It does not run in a new
+ * thread and dispatches messages for the calling thread.
  */
 #define MESSAGE_E(parent, str, buttons) \
     MESSAGE(parent, str, MB_ICONEXCLAMATION | (buttons))
 
 /*
- * shows a message box with the specified text and information icon, in a new thread,
- *     does not dispatch the calling thread's messages
+ * Shows a message box with the specified text and information icon. It runs in a new
+ * thread and does not dispatch messages for the calling thread.
  */
 #define MESSAGE_TI(str, buttons) \
     MESSAGE_T(str, MB_ICONINFORMATION | (buttons))
@@ -138,7 +138,7 @@ struct C__MessageBoxData
 };
 
 int CALLBACK __MessagesMessageBoxThreadF(C__MessageBoxData* data)
-{ // must not wait for the calling thread's response, because it will not respond
+{ // must not wait for a response from the calling thread, because it will not respond
     // therefore parent==NULL -> no window disabling, etc.
     data->Return = MessageBox(NULL, data->Text, data->Caption, data->Type | MB_SETFOREGROUND);
     return 0;
@@ -695,7 +695,7 @@ C__Handles::~C__Handles()
         else if (Handles[i].Handle.Origin == __hoGetStockObject)
             Handles.Delete(i);
     }
-    // check and list remaining handles
+    // check and list remaining open handles
     if (Handles.Count != 0)
     {
         if (MESSAGE_E(NULL, "Some monitored handles remained opened.\n"
@@ -860,7 +860,7 @@ BOOL C__Handles::DeleteHandle(C__HandlesType& type, HANDLE handle,
             }
         }
     }
-    if (foundTypeOK != -1) // found only a handle exempt from release
+    if (foundTypeOK != -1) // found only a handle that does not need to be released
     {
         type = Handles[foundTypeOK].Handle.Type;
         if (origin != NULL)
@@ -2393,7 +2393,7 @@ HDWP C__Handles::DeferWindowPos(HDWP hWinPosInfo, HWND hWnd, HWND hWndInsertAfte
 {
     HDWP ret = ::DeferWindowPos(hWinPosInfo, hWnd, hWndInsertAfter, x, y, cx, cy, uFlags);
 
-    if (ret != hWinPosInfo) // the structure was reallocated - we must update the monitored handle value
+    if (ret != hWinPosInfo) // the structure was reallocated; we must update the tracked handle value
     {
         CheckClose(TRUE, (HANDLE)hWinPosInfo, __htDeferWindowPos, __GetHandlesOrigin(__hoDeferWindowPos), ERROR_SUCCESS, FALSE);
         CheckCreate(ret != NULL, __htDeferWindowPos, __hoDeferWindowPos, (HANDLE)ret, GetLastError());


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/mhandles.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 63 comment units, 63 review results, 63 resolved results, and 63 apply results.
- Branch-target comment guard passed for `src/plugins/shared/mhandles.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/mhandles.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 98332 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 55970 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 42362 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
