### PR TITLE
[translation] Fix src/plugins/shared/spl_arc.h comments

### DIFF
--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -67,18 +67,18 @@ public:
                                       const char* archiveRoot, SalEnumSelection next,
                                       void* nextParam) = 0;
 
-    // Function for 'panel archiver view'; called when one file is requested for unpacking for view/edit
+    // Function for the panel archiver view; called when one file is requested for unpacking for view/edit
     // from archive 'fileName' to directory 'targetDir'; the file name inside the archive is 'nameInArchive';
     // 'pluginData' is an interface for working with file information specific to the plugin
-    // (for example data from added columns; it is the same interface returned by ListArchive
-    // v parametru 'pluginData' - takze muze byt i NULL); 'fileData' je ukazatel na strukturu CFileData
-    // for the unpacked file (the structure was built by the plugin when listing the archive); 'newFileName' (if not
-    // NULL) je nove jmeno pro rozbalovany soubor (pouziva se pokud puvodni jmeno z archivu neni mozne
-    // be unpacked to disk (for example 'aux', 'prn', etc.)); write TRUE to 'renamingNotSupported' (only if 'newFileName' is not
-    // NULL) zapsat TRUE pokud plugin nepodporuje prejmenovani pri vybalovani (standardni chybova hlaska
-    // the standard 'renaming not supported' error message is shown by Salamander); returns TRUE if the file is unpacked successfully
-    // (the file is at the requested path and neither Cancel nor Skip was used); 'salamander' is a set of useful methods
-    // exported by Salamander
+    // (for example, data from added columns; it is the same interface returned by ListArchive
+    // in the 'pluginData' parameter, so it may also be NULL); 'fileData' is a pointer to the CFileData
+    // structure of the file being unpacked (the structure was built by the plugin when listing the archive);
+    // 'newFileName' (if not NULL) is the new name for the unpacked file (used if the original name from the
+    // archive cannot be unpacked to disk, for example, 'aux', 'prn', etc.); write TRUE to
+    // 'renamingNotSupported' (only if 'newFileName' is not NULL) if the plugin does not support renaming
+    // during unpacking (the standard 'renaming not supported' error message is shown by Salamander);
+    // returns TRUE if the file is unpacked successfully (the file is at the requested path and neither
+    // Cancel nor Skip was used); 'salamander' is a set of useful methods exported by Salamander
     virtual BOOL WINAPI UnpackOneFile(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                       CPluginDataInterfaceAbstract* pluginData, const char* nameInArchive,
                                       const CFileData* fileData, const char* targetDir,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_arc.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 21 comment units, 21 review results, 21 resolved results, and 21 apply results.
- Branch-target comment guard passed for `src/plugins/shared/spl_arc.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_arc.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 90683 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 90683 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
