### PR TITLE
[translation] Fix src/common/strutils.h comments

### DIFF
--- a/src/common/strutils.h
+++ b/src/common/strutils.h
@@ -9,10 +9,10 @@
 // Converts a Unicode (UTF-16) string to an ANSI multibyte string; 'src' is the Unicode string;
 // 'srcLen' is the length of the Unicode string (excluding the terminating null; if -1 is passed,
 // the length is determined from the terminating null); 'bufSize' (must be greater than 0) is the size of the destination buffer
-// 'buf' pro ANSI string; je-li 'compositeCheck' TRUE, pouziva flag WC_COMPOSITECHECK
+// 'buf' for the ANSI string; if 'compositeCheck' is TRUE, the WC_COMPOSITECHECK flag is used
 // (see MSDN); it must not be used for file names (NTFS distinguishes between names written as
 // precomposed and composite, i.e. it does not normalize names); 'codepage' is the code page of the
-// ANSI stringu; vraci pocet znaku zapsanych do 'buf' (vcetne zakoncujici nuly); pri chybe
+// ANSI string; returns the number of characters written to 'buf' (including the terminating null); on error
 // returns 0 (see GetLastError()); always ensures 'buf' is null-terminated (even on error);
 // if 'buf' is too small, the function returns 0, but at least part of the string is converted into 'buf'
 int ConvertU2A(const WCHAR* src, int srcLen, char* buf, int bufSize,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/strutils.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 8/8 review unit(s).
- Validation passed with 1 rewrite(s), 7 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/common/strutils.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4401 output token(s).
- Copilot CLI: 1 premium request(s).