### PR TITLE
[translation] Fix src/plugins/shared/spl_file.h comments

### DIFF
--- a/src/plugins/shared/spl_file.h
+++ b/src/plugins/shared/spl_file.h
@@ -71,7 +71,7 @@ struct SAFE_FILE
     DWORD dwDesiredAccess;       // > backup of the CreateFile API parameters
     DWORD dwShareMode;           // > for possible retries
     DWORD dwCreationDisposition; // > in case of read or write errors
-    DWORD dwFlagsAndAttributes;  // >
+    DWORD dwFlagsAndAttributes;  // saved CreateFile flags and attributes for retrying the call if a read or write error occurs
     BOOL WholeFileAllocated;     // TRUE if SafeFileCreate preallocated the whole file
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_file.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 39 comment units, 39 review results, 39 resolved results, and 39 apply results.
- Branch-target comment guard passed for `src/plugins/shared/spl_file.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_file.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 94553 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 67983 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 26570 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
