### PR TITLE
[translation] Fix src/plugins/shared/spl_vers.h comments

### DIFF
--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -100,10 +100,10 @@
 // VERSINFO_BETAVERSION_TXT:
 //
 // Changes with every build; for a release version, VERSINFO_BETAVERSION_TXT will be "".
-// If we release a special beta fix build such as 2.5 beta 9a, increment
+// If a special beta fix build such as 2.5 beta 9a is released, increment
 // VERSINFO_BUILDNUMBER by one and set VERSINFO_BETAVERSION_TXT==" beta 9a".
 //
-// VERSINFO_BETAVERSIONSHORT_TXT is used for bug report names; it should be as short as possible
+// VERSINFO_BETAVERSIONSHORT_TXT is used to name bug reports; it should be as short as possible
 
 // examples ("x86" is for the 32-bit version, "x64" for the 64-bit version; in the following examples,
 // x86/x64 are interchangeable): " (x86)" (for release versions), " beta 2 (x64)", " beta 2 (SDK x86)",


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_vers.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/shared/spl_vers.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_vers.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 65762 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 65762 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
