### PR TITLE
[translation] Fix src/plugins/shared/winliblt.h comments

### DIFF
--- a/src/plugins/shared/winliblt.h
+++ b/src/plugins/shared/winliblt.h
@@ -72,7 +72,7 @@ enum CObjectType // for identifying the object type
 
 // ****************************************************************************
 
-class CWindowsObject // base class for all MS-Windows objects
+class CWindowsObject // base class for all Windows objects
 {
 public:
     HWND HWindow;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/winliblt.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 95 comment units, 95 review results, 95 resolved results, and 95 apply results.
- Branch-target comment guard passed for `src/plugins/shared/winliblt.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/winliblt.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 86175 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 86175 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
