### PR TITLE
[translation] Fix src/common/array.h comments

### DIFF
--- a/src/common/array.h
+++ b/src/common/array.h
@@ -4,10 +4,10 @@
 
 #pragma once
 
-// Use the _DEBUG or __ARRAY_DEBUG defines to enable various error state checking. Errors
-// are displayed using TRACE_E and TRACE_C macros.
-// Use the SAFE_ALLOC define to remove source code with testing if memory allocation
-// has not failed (see allochan.*).
+// Use the _DEBUG or __ARRAY_DEBUG defines to enable various error-state checks. Errors
+// are displayed using the TRACE_E and TRACE_C macros.
+// Use the SAFE_ALLOC define to remove code that tests whether memory allocation
+// failed (see allochan.*).
 
 // We need to make this module independent of the TRACE macros, so if they are not defined,
 // we define dummy replacements. Error reporting will not work in that case.
@@ -33,8 +33,8 @@ enum CDeleteType
 enum CErrorType
 {
     etNone,         // OK
-    etLowMemory,    // new - NULL
-    etUnknownIndex, // index is out of array range
+    etLowMemory,    // new returned NULL
+    etUnknownIndex, // index is out of range for the array
     etBadInsert,    // index of inserted item is out of array range
     etBadDispose,   // index of disposed item is out of array range
     etDestructed,   // array was already destructed using Destroy() method
@@ -80,12 +80,12 @@ public:
     }
 
     void Insert(int index, const DATA_TYPE& member);
-    int Add(const DATA_TYPE& member); // adds item to the end of array, returns item index
+    int Add(const DATA_TYPE& member); // adds an item to the end of the array, returns its index
 
-    void Insert(int index, const DATA_TYPE* members, int count); // insert 'count' of 'members' items
-    int Add(const DATA_TYPE* members, int count);                // add 'count' of 'members' items
+    void Insert(int index, const DATA_TYPE* members, int count); // insert 'count' items from 'members'
+    int Add(const DATA_TYPE* members, int count);                // adds 'count' items from 'members'
 
-    DATA_TYPE& At(int index) // returns pointer to item at 'index' possition
+    DATA_TYPE& At(int index) // returns a reference to the item at 'index'
     {
 #if defined(_DEBUG) || defined(__ARRAY_DEBUG)
         if (index >= 0 && index < Count)
@@ -102,7 +102,7 @@ public:
 #endif
     }
 
-    DATA_TYPE& operator[](int index) // returns pointer to item at 'index' possition
+    DATA_TYPE& operator[](int index) // returns a reference to the item at 'index'
     {
 #if defined(_DEBUG) || defined(__ARRAY_DEBUG)
         if (index >= 0 && index < Count)
@@ -131,12 +131,12 @@ public:
     void DestroyMembers();             // release items from memory (calling destructors), keep array
     void DetachMembers();              // detach all items (destructors are NOT called), keep array
     void Destroy();                    // complete array destruction (calling destructors)
-    void Delete(int index);            // delete item at 'index' possition (calling destructor), move remaining items
-    void Delete(int index, int count); // delete 'count' of items at 'index' possition (calling destructors), move remaining items
-    void Detach(int index);            // detach item at 'index' possition (destructor is NOT called), move remaining items
-    void Detach(int index, int count); // detach 'count' of items at 'index' possition (destructors are NOT called), move remaining items
+    void Delete(int index);            // deletes the item at 'index' (calling the destructor), moves remaining items
+    void Delete(int index, int count); // delete 'count' items at 'index' position (calling destructors), move remaining items
+    void Detach(int index);            // detach item at 'index' position (destructor is NOT called), move remaining items
+    void Detach(int index, int count); // detach 'count' items at 'index' position (destructors are NOT called), move remaining items
 
-    int SetDelta(int delta); // change 'Delta', return real used value; NOTE: can be used only for empty array
+    int SetDelta(int delta); // change 'Delta', return the actual value used; NOTE: can be used only for an empty array
 
 protected:
     DATA_TYPE* Data; // pointer to array
@@ -144,7 +144,7 @@ protected:
     int Base;        // smallest allocated size of array
     int Delta;       // allocated array size is enlarged/reduced by this value
 
-    virtual void Error(CErrorType err) // array error handling
+    virtual void Error(CErrorType err) // handles array errors
     {
         if (State == etNone)
             State = err;
@@ -154,7 +154,7 @@ protected:
     void EnlargeArray(); // enlarges array
     void ReduceArray();  // reduces array
 
-    void Move(CArrayDirection direction, int first, int count); // move selected items to next/previous index
+    void Move(CArrayDirection direction, int first, int count); // moves selected items to the next or previous index
 
     void CallCopyConstructor(DATA_TYPE* placement, const DATA_TYPE& member)
     {
@@ -372,12 +372,12 @@ public:
             TRACE_C("Index is out of range (index = " << index
                                                       << ", Count = " << Count << ").");
             Error(etUnknownIndex);
-            return Data[0]; // because of the compiler, we return a possibly invalid item
+            return Data[0]; // compiler workaround: return a possibly invalid item
         }
 #endif
     }
 
-    DATA_TYPE& operator[](int index) // returns a reference to the item at 'index'
+    DATA_TYPE& operator[](int index) // returns a reference to the item at the given position
     {                                // int is used only to avoid warnings; range up to 65535
 #if defined(_DEBUG) || defined(__ARRAY_DEBUG)
         if (index >= 0 && index < Count)
@@ -389,7 +389,7 @@ public:
             TRACE_C("Index is out of range (index = " << index
                                                       << ", Count = " << Count << ").");
             Error(etUnknownIndex);
-            return Data[0]; // because of the compiler, we return a possibly invalid item
+            return Data[0]; // return a possibly invalid element to satisfy the compiler
         }
 #endif
     }
@@ -696,7 +696,7 @@ TDirectArray<DATA_TYPE>::TDirectArray(int base, int delta)
 template <class DATA_TYPE>
 void TDirectArray<DATA_TYPE>::Destroy()
 {
-    if (State == etNone) // it can be also etDestructed
+    if (State == etNone) // State can also be etDestructed
     {
         if (Data != NULL)
         {
@@ -785,7 +785,7 @@ void TDirectArray<DATA_TYPE>::Insert(int index, const DATA_TYPE* members, int co
 #if defined(_DEBUG) || defined(__ARRAY_DEBUG)
     if (State == etNone)
     {
-        if (Count + count > Available && members + count - 1 >= Data && // array will be reallocated and inserted items are from this array (items will be released after array reallocation)
+        if (Count + count > Available && members + count - 1 >= Data && // array will be reallocated and the inserted items come from this array (the items will be released after reallocation)
             members < Data + Count)
         {
             TRACE_C("Inserted items could become invalid during operation.");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/array.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 20 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 112 comment units, 112 review results, 112 resolved results, and 112 apply results.
- Branch-target comment guard passed for `src/common/array.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/array.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 15 provider calls, 317835 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 13 calls, 295223 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 22612 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
