### PR TITLE
[translation] Fix src/common/crc32.cpp comments

### DIFF
--- a/src/common/crc32.cpp
+++ b/src/common/crc32.cpp
@@ -76,15 +76,15 @@ void MakeCrcTable(DWORD* crcTab)
     const DWORD poly = 0xedb88320L; //polynomial exclusive-or pattern
 
     /*
-  //generate crc polonomial, using precomputed poly should be faster
-  // terms of polynomial defining this crc (except x^32):
-  static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
+      // Generate the CRC polynomial; using a precomputed poly should be faster
+      // Terms of the polynomial defining this CRC (except x^32):
+      static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
 
-  // make exclusive-or pattern from polynomial (0xedb88320L)
-  poly = 0L;
-  for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
-    poly |= 1L << (31 - p[n]);
-*/
+      // Make the exclusive-or pattern from the polynomial (0xedb88320L)
+      poly = 0L;
+      for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
+        poly |= 1L << (31 - p[n]);
+    */
     for (n = 0; n < 256; n++)
     {
         c = (DWORD)n;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/crc32.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 10 comment units, 10 review results, 10 resolved results, and 10 apply results.
- Branch-target comment guard passed for `src/common/crc32.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/crc32.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 64914 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43693 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 21221 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
