### PR TITLE
[translation] Fix src/common/crc32.h comments

### DIFF
--- a/src/common/crc32.h
+++ b/src/common/crc32.h
@@ -6,7 +6,7 @@
 
 //#define STATIC_CRC_TAB
 
-//size of crc tab in the memory
+// size of the CRC table in memory
 #define CRC_TAB_SIZE 256 * sizeof(DWORD)
 //initial value of crc shift register
 #define INIT_CRC 0L


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/crc32.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/common/crc32.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/crc32.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 62314 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 41602 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20712 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
