### PR TITLE
[translation] Fix src/common/dib.cpp comments

### DIFF
--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -83,7 +83,7 @@ HBITMAP LoadBitmapAndMapColors(HINSTANCE hInst, HRSRC hRsrc, int mapCount,
         TRACE_E("Unable to create bitmap.");
     HANDLES(ReleaseDC(NULL, hDCScreen));
 
-    // free copy of bitmap info struct and resource itself
+    // free the copy of the bitmap info struct and the resource itself
     free(lpBitmapInfo);
     FreeResource(hglb);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 19 comment units, 19 review results, 19 resolved results, and 19 apply results.
- Branch-target comment guard passed for `src/common/dib.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/dib.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 85659 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 44331 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 41328 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
