### PR TITLE
[translation] Fix src/common/messages.cpp comments

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -166,8 +166,8 @@ struct C__MessageBoxData
 };
 
 int CALLBACK __MessagesMessageBoxThreadF(C__MessageBoxData* data)
-{ // must not wait for the calling thread to respond, because it will not respond
-    // therefore parent == NULL -> no window disabling, etc.
+{ // must not wait for a response from the calling thread, because it will not respond
+    // therefore parent == NULL -> no disabling of windows, etc.
     data->Return = MessageBoxA(NULL, data->Text, data->Caption, data->Type | MB_SETFOREGROUND);
     return 0;
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/messages.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 97 comment units, 97 review results, 97 resolved results, and 97 apply results.
- Branch-target comment guard passed for `src/common/messages.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/messages.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 49277 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 49277 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
