### PR TITLE
[translation] Fix src/common/multimon.cpp comments

### DIFF
--- a/src/common/multimon.cpp
+++ b/src/common/multimon.cpp
@@ -54,7 +54,7 @@ void MultiMonGetClipRectByWindow(HWND hByWnd, RECT* workClipRect, RECT* monitorC
     if (hByWnd != NULL && IsWindowVisible(hByWnd) && !IsIconic(hByWnd)) // Note: the same condition is also used in MultiMonCenterWindow.
     {
         hMonitor = MonitorFromWindow(hByWnd, MONITOR_DEFAULTTONEAREST);
-        // Get the desktop work area.
+        // Get the monitor work area.
         GetMonitorInfo(hMonitor, &mi);
     }
     else
@@ -277,7 +277,7 @@ BOOL MultiMonEnsureRectVisible(RECT* rect, BOOL partialOK)
     if (intersect && partialOK)
         return FALSE; // The rectangle is already partially visible, so return FALSE.
 
-    // Make sure the rectangle does not extend past the monitor.
+    // Ensure the rectangle does not extend beyond the monitor work area.
     if (rect->right - rect->left > clipRect.right - clipRect.left)
         rect->right = clipRect.right - clipRect.left + rect->left;
     if (rect->bottom - rect->top > clipRect.bottom - clipRect.top)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/multimon.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 35 comment units, 35 review results, 35 resolved results, and 35 apply results.
- Branch-target comment guard passed for `src/common/multimon.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/multimon.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 133317 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 110334 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 22983 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
