### PR TITLE
[translation] Fix src/common/sheets.cpp comments

### DIFF
--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -310,7 +310,7 @@ CPropSheetPage::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                (GetKeyState(VK_SHIFT) & 0x8000) != 0);
             return TRUE;
         }
-        break; // let F1 fall through to the parent
+        break; // Let F1 propagate to the parent
     }
 
     case WM_CONTEXTMENU:
@@ -446,7 +446,7 @@ CPropSheetPage::CPropSheetPageProc(HWND hwndDlg, UINT uMsg, WPARAM wParam,
     if (dlg != NULL)
         return dlg->DialogProc(uMsg, wParam, lParam);
     else
-        return FALSE; // error, or the message did not arrive between WM_INITDIALOG and WM_DESTROY
+        return FALSE; // Error, or the message was not received between WM_INITDIALOG and WM_DESTROY
 }
 
 //
@@ -569,7 +569,7 @@ CTPHCaptionWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         GetClientRect(HWindow, &r);
 
         int devCaps = GetDeviceCaps(hdc, NUMCOLORS);
-        if (devCaps == -1) // use the gradient only with more than 256 colors
+        if (devCaps == -1) // use the gradient only when more than 256 colors are available
         {
             HBRUSH hOldBrush = (HBRUSH)GetCurrentObject(hdc, OBJ_BRUSH);
 #define TPH_STEPS 100
@@ -762,7 +762,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                                (GetKeyState(VK_CONTROL) & 0x8000) != 0,
                                (GetKeyState(VK_SHIFT) & 0x8000) != 0);
         }
-        return TRUE; // do not let F1 fall through to the parent even if we do not call WinLibHelp->OnHelp()
+        return TRUE; // do not let F1 propagate to the parent even if we do not call WinLibHelp->OnHelp()
     }
 
     case WM_COMMAND:
@@ -806,7 +806,7 @@ CTreePropHolderDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         }
 
-        // forward the message so Enter reaches the default buttons
+        // forward the message so Enter is routed to the default buttons
         if (ChildDialog != NULL && HIWORD(wParam) == BN_CLICKED)
             ::SendMessage(ChildDialog->HWindow, uMsg, wParam, lParam);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/sheets.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 123 comment units, 123 review results, 123 resolved results, and 123 apply results.
- Branch-target comment guard passed for `src/common/sheets.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/sheets.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 224486 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 9 calls, 183449 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 41037 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
