### PR TITLE
[translation] Fix src/common/sheets.h comments

### DIFF
--- a/src/common/sheets.h
+++ b/src/common/sheets.h
@@ -38,8 +38,8 @@ protected:
     // controls that resize with the dialog (typically list views)
     TDirectArray<CElasticLayoutCtrl> ResizeCtrls;
     // temporary array populated by FindMoveCtrls; ideally this would be a local variable, but
-    // for easier calls to the FindMoveControls callback (which needs it passed in)
-    // I keep it as a class member
+    // for convenient calls to the FindMoveControls callback (to which it must be passed)
+    // it is stored as a class member
     TDirectArray<CElasticLayoutCtrl> MoveCtrls;
 };
 
@@ -179,7 +179,7 @@ protected:
     CPropSheetPage* ChildDialog;
     int ExitButton; // ID of the button that closed the dialog
 
-    // dimensions in pixels
+    // dimensions in points
     SIZE MinWindowSize;  // minimum dialog size (determined by the largest child dialog)
     DWORD* WindowHeight; // current dialog height
     int TreeWidth;       // tree view width, calculated from the contents


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/sheets.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 37 comment units, 37 review results, 37 resolved results, and 37 apply results.
- Branch-target comment guard passed for `src/common/sheets.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/sheets.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 70765 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 70765 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
