### PR TITLE
[translation] Fix src/common/str.cpp comments

### DIFF
--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -143,7 +143,7 @@ int StrICmp(const char* s1, const char* s2)
     {
         res = (unsigned)LowerCase[*s1] - (unsigned)LowerCase[*s2++];
         if (res != 0)
-            return (res < 0) ? -1 : 1; // < a >
+            return (res < 0) ? -1 : 1; // < or >
         if (*s1++ == 0)
             return 0; // ==
     }
@@ -160,14 +160,14 @@ int StrICmp(const char* s1, const char* s2)
     mov     edi,[s1] // edi = s1
     mov     edx,table // edx = LowerCase
 
-    mov     eax,255 // fall into loop
+    mov     eax,255 // enter the loop
     xor     ebx,ebx
 
     align   4
 
         // compare
 chk_null:
-    or      al,al // not that if al == 0, then eax == 0!
+    or      al,al // note that if al == 0, then eax == 0
     jz      short done
 
     mov     al,[esi] // al = *s2
@@ -259,14 +259,14 @@ int StrNICmp(const char* s1, const char* s2, int n)
 lupe:                      
     mov     al,[esi] // al = *s1
                            
-    or      eax,eax // see if *s1 is null
+    or      eax,eax // check whether *s1 is null
                            
     mov     bl,[edi] // bl = *s2
                            
     jz      short eject // jump if *s1 is null
 
     or      ebx,ebx // see if *s2 is null
-    jz      short eject // jump if so
+    jz      short eject // jump if *s2 is null
 
     inc     esi
     inc     edi
@@ -388,16 +388,16 @@ int StrICmpEx(const char* s1, int l1, const char* s2, int l2)
     {
         res = (unsigned)LowerCase[*s1++] - (unsigned)LowerCase[*s2++];
         if (res != 0)
-            return (res < 0) ? -1 : 1; // < a >
+            return (res < 0) ? -1 : 1; // < or >
     }
     if (l1 != l2)
-        return (l1 < l2) ? -1 : 1; // < a >
+        return (l1 < l2) ? -1 : 1; // < or >
     else
         return 0;
 }
 
 /*
-// princip asm funkce
+// logic of the assembly function
 int StrICmpEx(const char *s1, int l1, const char *s2, int l2)
 {
   int l = (l1 < l2) ? l1 : l2;
@@ -426,7 +426,7 @@ int StrICmpEx(const char* s1, int l1, const char* s2, int l2)
             // load up arguments
       mov     ecx,[l] // ecx = byte count
       or      ecx,ecx        
-      jz      toend // if count = 0, we are done
+      jz      toend // if the byte count is 0, we are done
                            
       mov     esi,s1 // esi = buf1
       mov     edi,s2 // edi = buf2
@@ -485,7 +485,7 @@ int StrICmpEx(const char* s1, int l1, const char* s2, int l2)
 //*****************************************************************************
 
 /*
-// puvodni funkce
+// original function
 int StrCmpEx(const char *s1, int l1, const char *s2, int l2)
 {
   int res, l = (l1 < l2) ? l1 : l2;
@@ -586,7 +586,7 @@ int StrLen(const char *str)
 /*
 //*****************************************************************************
 //
-// Tabulky pro prevod kodu Kamenickych do MS Windows
+// Tables for converting Kamenicky encoding to MS Windows
 //
 
 BYTE KodKamenickych[CONVERT_TAB_CHARS] =


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/str.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 11 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 126 comment units, 126 review results, 126 resolved results, and 126 apply results.
- Branch-target comment guard passed for `src/common/str.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/str.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 36 provider calls, 670045 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 9 calls, 164436 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 27 calls, 505609 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
