### PR TITLE
[translation] Fix src/common/winlib.h comments

### DIFF
--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -67,7 +67,7 @@ enum CObjectType // for object type identification
 
 // ****************************************************************************
 
-class CWindowsObject // base class of all MS-Windows objects
+class CWindowsObject // base class for all Windows objects
 {
 public:
     HWND HWindow;
@@ -122,8 +122,8 @@ public:
 protected:
     CObjectOrigin ObjectOrigin;
 #ifndef _UNICODE
-    // windows: create: TRUE = the window is Unicode, otherwise ANSI; attach: TRUE = our window procedure
-    // is Unicode, otherwise ANSI; dialogs: TRUE = the dialog is Unicode, otherwise ANSI
+    // for windows: on create, TRUE = the window is Unicode, otherwise ANSI; on attach, TRUE = our window procedure
+    // is Unicode, otherwise ANSI; for dialogs: TRUE = the dialog is Unicode, otherwise ANSI
     BOOL UnicodeWnd;
 #endif // _UNICODE
 };
@@ -303,7 +303,7 @@ public:
     void EnsureControlIsFocused(int ctrlID);
 
     void EditLine(int ctrlID, TCHAR* buffer, DWORD bufferSizeInChars, BOOL select = TRUE);
-    void EditLine(int ctrlID, double& value, TCHAR* format, BOOL select = TRUE); // format napr. _T("%.2lf")
+    void EditLine(int ctrlID, double& value, TCHAR* format, BOOL select = TRUE); // format, e.g. _T("%.2lf")
     void EditLine(int ctrlID, int& value, BOOL select = TRUE);
     void EditLine(int ctrlID, __int64& value, BOOL select = TRUE, BOOL unsignedNum = FALSE /* signed number */,
                   BOOL hexMode = FALSE /* decimal mode */, BOOL ignoreOverflow = FALSE, BOOL quiet = FALSE);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 137 comment units, 137 review results, 137 resolved results, and 137 apply results.
- Branch-target comment guard passed for `src/common/winlib.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/winlib.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 126869 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 6 calls, 126869 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
