### PR TITLE
[translation] Fix src/plugins/shared/spl_menu.h comments

### DIFF
--- a/src/plugins/shared/spl_menu.h
+++ b/src/plugins/shared/spl_menu.h
@@ -22,14 +22,13 @@
 
 class CSalamanderForOperationsAbstract;
 
-//
 // ****************************************************************************
 // CSalamanderBuildMenuAbstract
 //
-// sada metod Salamandera pro stavbu menu pluginu
+// set of Salamander methods for building a plugin menu
 //
-// jde o podmnozinu metod CSalamanderConnectAbstract, metody se stejne chovaji,
-// pouzivaji se stejne konstanty, popis viz CSalamanderConnectAbstract
+// this is a subset of the CSalamanderConnectAbstract methods; the methods behave the same,
+// use the same constants; see CSalamanderConnectAbstract for details
 
 class CSalamanderBuildMenuAbstract
 {
@@ -81,17 +80,17 @@ public:
     virtual DWORD WINAPI GetMenuItemState(int id, DWORD eventMask) = 0;
 
     // executes the menu command with identifier 'id'; for 'eventMask' see
-    // CSalamanderConnectAbstract::AddMenuItem, 'salamander' is the set of available
-    // Salamander methods for performing operations (WARNING: it may be NULL, see the description of the method
-    // CSalamanderGeneralAbstract::PostMenuExtCommand), 'parent' je parent messageboxu,
+    // CSalamanderConnectAbstract::AddMenuItem; 'salamander' is the set of Salamander methods
+    // available for performing operations (WARNING: it may be NULL; see the description of
+    // CSalamanderGeneralAbstract::PostMenuExtCommand); 'parent' is the parent window for message boxes,
     // returns TRUE if the selection in the panel should be cleared (Cancel was not used; Skip may have
-    // been used), otherwise returns FALSE (no deselection is performed);
-    // POZOR: Pokud prikaz zpusobi zmeny na nejake ceste (diskove/FS), mel by pouzit
-    //        CSalamanderGeneralAbstract::PostChangeOnPathNotification pro informovani
+    // been used); otherwise returns FALSE (the selection is left unchanged);
+    // WARNING: if the command causes changes on some path (disk/FS), it should use
+    //        CSalamanderGeneralAbstract::PostChangeOnPathNotification to notify
     //        the panel without an automatic refresh and any open FSs (active and disconnected)
     // NOTE: if the command works with files/directories from the path in the current panel or
-    //           even directly with this path, it is necessary to call
-    //           CSalamanderGeneralAbstract::SetUserWorkedOnPanelPath pro aktualni panel,
+    //           directly with that path itself, it is necessary to call
+    //           CSalamanderGeneralAbstract::SetUserWorkedOnPanelPath for the current panel,
     //           otherwise the path in this panel will not be added to the list of working
     //           directories - List of Working Directories (Alt+F12)
     virtual BOOL WINAPI ExecuteMenuItem(CSalamanderForOperationsAbstract* salamander, HWND parent,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_menu.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 24/24 review unit(s).
- Validation passed with 2 rewrite(s), 20 keep(s), and 2 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/shared/spl_menu.h` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 9226 output token(s).
- Copilot CLI: 1 premium request(s).