### PR TITLE
[translation] Fix src/plugins/mmviewer/ogg/oggparser.cpp comments

### DIFF
--- a/src/plugins/mmviewer/ogg/oggparser.cpp
+++ b/src/plugins/mmviewer/ogg/oggparser.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -25,7 +26,7 @@ typedef struct
     char* str;
 } OGG_COMMENT;
 
-int FindComment(const char* in_string, int& offset, OGG_COMMENT comments[]) //s=string za '='
+int FindComment(const char* in_string, int& offset, OGG_COMMENT comments[]) // s=string after '='
 {
     const char* in_string_orig = in_string;
     int i = 0;
@@ -90,8 +91,8 @@ CParserOGG::GetFileInfo(COutputInterface* output)
 {
     if (f)
     {
-        // tags will be printed in this order. reorder them as you like
-        // musi byt upcase
+        // Tags will be printed in this order. Reorder them as you like.
+        // Tag names must be uppercase.
         OGG_COMMENT comments[] = {
             {"TRACKNUMBER", IDS_OGG_TRACK, NULL},
             //The track number of this piece if part of a specific larger collection or album


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/ogg/oggparser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 2 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 22/22 review unit(s).
- Validation passed with 2 rewrite(s), 20 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/mmviewer/ogg/oggparser.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4654 output token(s).
- Copilot CLI: 1 premium request(s).