### PR TITLE
[translation] Fix src/plugins/regedt/fs5.cpp comments

### DIFF
--- a/src/plugins/regedt/fs5.cpp
+++ b/src/plugins/regedt/fs5.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -1099,7 +1100,7 @@ void CPluginFSInterface::OpenActiveFolder(const char* fsName, HWND parent)
     // regedit has no parameter to set which Registry path should be displayed
     // but we can set HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Applets\Regedit\LastKey
     // in the form (e.g.) "Computer\HKEY_CURRENT_USER\AppEvents\Schemes\Apps"
-    // NOTE: the word "Computer" is localized as "Počítač" on Czech Win7, fortunately regedit.exe
+    // NOTE: on localized Win7, the word "Computer" may be translated, but regedit.exe
     // does not require the word and the path may start directly at the HKEY_* root
 
     // store the current panel path into the LastKey value for RegEdit


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/regedt/fs5.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 69/69 review unit(s).
- Validation passed with 1 rewrite(s), 68 keep(s), and 0 manual item(s).
- Guard passed with 14 recorded check(s).
- `git diff --check -- src/plugins/regedt/fs5.cpp` completed without diff integrity failures.

## Telemetry
- Total: unknown provider call(s), 0 output token(s).
- Copilot CLI: unknown premium request(s).