### PR TITLE
[translation] Fix src/plugins/unmime/parser.cpp comments

### DIFF
--- a/src/plugins/unmime/parser.cpp
+++ b/src/plugins/unmime/parser.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************************\
 **                                                                                      **
@@ -641,7 +642,7 @@ static void DestroyIllegalChars(LPSTR pszPath)
     }
 }
 
-////// JMENA DEKODOVANYCH SOUBORU //////////////////////////////////////////////
+////// NAMES OF DECODED FILES //////////////////////////////////////////////
 
 static void SetDefaultFileName(BOOL bAppendCharset)
 {
@@ -721,7 +722,7 @@ static void MakeNamesUnique(CParserOutput* pOutput)
     }
     // sort the index
     qsort(index, numblocks, sizeof(char*), compare_file_names);
-    // identical names now lie next to each other and we can easily catch them
+    // identical names are now adjacent, so we can detect them easily
     int k, l;
     for (k = 1, l = 0; k < numblocks; k++)
     {
@@ -871,7 +872,7 @@ static void EndCalcSize(CParserOutput* pOutput)
     }
 }
 
-////// FUNKCE PRO ULOZENI/OBNOVENI STAVU PARSERU ///////////////////////////////
+//FUNCTIONS FOR SAVING/RESTORING PARSER STATE ///////////////////////////////
 
 static void SaveState()
 {
@@ -1039,7 +1040,7 @@ static BOOL TestUUBlock(CParserOutput* pOutput, BOOL& bEnd)
 
 static BOOL TestYEncBlock(CParserOutput* pOutput, BOOL& bEnd)
 {
-    // are we on a header?
+    // is this the header?
     if (memcmp(cLine, "=ybegin", 7))
         return FALSE;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/parser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies 1 validated comment rewrite(s) in the final diff and injects the translation header marker.

## Model
- Model: GitHub Copilot GPT-5.4 HIGH
- Pipeline: OSTranslationCopilot
- Scope: one file, one submitted Copilot CLI prompt

## Verification
- Local clang/AST grounding passed for 112/112 review unit(s).
- Validation passed with 4 rewrite(s), 108 keep(s), and 0 manual item(s).
- Guard passed with 11 recorded check(s).
- `git diff --check -- src/plugins/unmime/parser.cpp` completed without diff integrity failures.

## Telemetry
- Total: 1 provider call(s), 4059 output token(s).
- Copilot CLI: 1 premium request(s).