### PR TITLE
[translation] Fix src/plugins/undelete/dialogs.cpp comments

### DIFF
--- a/src/plugins/undelete/dialogs.cpp
+++ b/src/plugins/undelete/dialogs.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/dialogs.cpp
+++ b/src/plugins/undelete/dialogs.cpp
@@ -220,7 +220,7 @@ INT_PTR CCopyProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         }
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
 
     case WM_COMMAND:
@@ -389,13 +389,13 @@ void CConnectDialog::InitDrives()
 
         case PATH_TYPE_FS:
         {
-            // remove the "del:" prefix so correct path will be selected when opening this dialog box on Undelete path
+            // Remove the "del:" prefix so the correct path is selected when opening this dialog box from an Undelete path.
             if (archiveOrFS != NULL)
                 memmove(sourcePanelPath, archiveOrFS + 1, strlen(archiveOrFS + 1) + 1);
             break;
         }
 
-        // can't do much about this
+        // not much can be done here
         default:
             break;
         }
@@ -429,7 +429,7 @@ void CConnectDialog::InitDrives()
         int serial = 0;
         for (i = 0; i < volumeListing.Count; ++i)
         {
-            // for simple disks get the icon from system, for mount points or unmounted disks get just plain HDD icon
+            // for regular disks, get the icon from the system; for mount points or unmounted disks, use a plain HDD icon
             // (passing MountPoints instead of volumeName is much faster for some disks)
             HICON icn;
             if (volumeListing[i].MountPoint && (3 == strlen(volumeListing[i].MountPoint)))


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 45 comment units, 45 review results, 45 resolved results, and 45 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/dialogs.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/dialogs.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 120613 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 98830 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 21783 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
