### PR TITLE
[translation] Fix src/plugins/undelete/fs1.cpp comments

### DIFF
--- a/src/plugins/undelete/fs1.cpp
+++ b/src/plugins/undelete/fs1.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/fs1.cpp
+++ b/src/plugins/undelete/fs1.cpp
@@ -102,16 +102,16 @@ CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* plugin
                         panel, pluginFSName, pluginFSNameIndex, isDir);
 
     CPluginFSInterface* fs = (CPluginFSInterface*)pluginFS;
-    if (isDir) // sub-dir or up-dir
+    if (isDir) // subdirectory or parent directory
     {
         char newPath[MAX_PATH];
         strcpy(newPath, fs->Path);
-        if (isDir == 2) // up-dir
+        if (isDir == 2) // parent directory
         {
             char* cutDir = NULL;
             if (SalamanderGeneral->CutDirectory(newPath, &cutDir)) // cut last component from the path
             {
-                int topIndex; // next top-index, -1 -> invalid
+                int topIndex; // next top index; -1 means invalid
                 if (!fs->TopIndexMem.FindAndPop(newPath, topIndex))
                     topIndex = -1;
                 // change path in panel
@@ -127,15 +127,15 @@ CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* plugin
             strcpy(backupPath, newPath);
             int topIndex = SalamanderGeneral->GetPanelTopIndex(panel);
 
-            if (SalamanderGeneral->SalPathAppend(newPath, file.Name, MAX_PATH)) // set path
+            if (SalamanderGeneral->SalPathAppend(newPath, file.Name, MAX_PATH)) // append the name to the path
             {
                 // change path in panel
                 fs = NULL; // after ChangePanelPathToXXX the pointer could be invalid
                 if (SalamanderGeneral->ChangePanelPathToPluginFS(panel, pluginFSName, newPath))
                 {
                     fs = (CPluginFSInterface*)SalamanderGeneral->GetPanelPluginFS(panel); // we need to get current object (in case FS changes)
-                    if (fs != NULL && fs == pluginFS)                                     // if it is original FS
-                        fs->TopIndexMem.Push(backupPath, topIndex);                       // store top-index for return
+                    if (fs != NULL && fs == pluginFS)                                     // if this is the original FS
+                        fs->TopIndexMem.Push(backupPath, topIndex);                       // store the top index for returning
                 }
             }
         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/fs1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 28 comment units, 28 review results, 28 resolved results, and 28 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/fs1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/fs1.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 178625 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 6 calls, 135604 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 43021 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
