### PR TITLE
[translation] Fix src/plugins/undelete/fs2.cpp comments

### DIFF
--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -152,9 +152,9 @@ BOOL WINAPI
 CPluginFSInterface::GetFullName(CFileData& file, int isDir, char* buf, int bufSize)
 {
     CALL_STACK_MESSAGE3("CPluginFSInterface::GetFullName(, %d, , %d)", isDir, bufSize);
-    lstrcpyn(buf, Path, bufSize); // if path doesn't fit, name doesn't fit too (report error)
+    lstrcpyn(buf, Path, bufSize); // If the path does not fit, the name will not fit either (report an error).
     if (isDir == 2)
-        return SalamanderGeneral->CutDirectory(buf, NULL); // up-dir
+        return SalamanderGeneral->CutDirectory(buf, NULL);     // parent directory
     else
         return SalamanderGeneral->SalPathAppend(buf, file.Name, bufSize);
 }
@@ -181,7 +181,7 @@ CPluginFSInterface::IsOurPath(int currentFSNameIndex, int fsNameIndex, const cha
     CALL_STACK_MESSAGE4("CPluginFSInterface::IsOurPath(%d, %d, %s)",
                         currentFSNameIndex, fsNameIndex, userPart);
     if (WantReconnect)
-        return FALSE; // user wants new connection
+        return FALSE;         // user requested a new connection
     char buffer[MAX_PATH];
     if (!RootPathFromFull(userPart, buffer, MAX_PATH))
         return FALSE;
@@ -226,7 +226,7 @@ CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fsNameI
     if (forceRefresh)
         IsSnapshotValid = FALSE;
 
-    // tests and inits
+    // checks and initialization
     if (mode != 3 && (pathWasCut != NULL || cutFileName != NULL))
     {
         TRACE_E("Incorrect value of 'mode' in CPluginFSInterface::ChangePath().");
@@ -322,7 +322,7 @@ CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fsNameI
         IsSnapshotValid = TRUE;
     }
 
-    // walk through all path components, also moving in directories structure
+    // Walk through all path components while traversing the directory structure
     CurrentDir = Snapshot->Root;
     // we will cut path to individual parts
     char temp[MAX_PATH];
@@ -341,12 +341,12 @@ CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fsNameI
             DIR_ITEM_I<char>* di = &CurrentDir->DirItems[i];
             if (!namecmp(di->FileName->FNName, component))
             {
-                if (di->Record->IsDir) // yes, it is direcotry
+                if (di->Record->IsDir) // yes, it is a directory
                 {
                     SalamanderGeneral->SalPathAppend(Path, component, MAX_PATH);
                     CurrentDir = di->Record;
                 }
-                else // it is file
+                else // it is a file
                 {
                     if (cutFileName != NULL)
                         lstrcpyn(cutFileName, di->FileName->FNName, MAX_PATH);
@@ -361,8 +361,8 @@ CPluginFSInterface::ChangePath(int currentFSNameIndex, char* fsName, int fsNameI
         {
             if (pathWasCut != NULL)
                 *pathWasCut = TRUE;
-            // originally here was mode > 1 but I received messages when connecting from directory
-            // where are no deleted files (so path doesn't point there)
+            // Originally this was `mode > 1`, but I received messages when connecting from a directory
+            // with no deleted files, so the path did not point there.
             if (mode == 3)
                 String<char>::Error(IDS_UNDELETE, IDS_PATHNOTFOUND);
             return mode != 3;
@@ -390,7 +390,7 @@ CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
         return FALSE;
     }
 
-    // set valid 'fd' data members
+    // Set valid members of fd
     dir->SetValidData(VALID_DATA_EXTENSION |
                       VALID_DATA_DOSNAME |
                       VALID_DATA_SIZE |
@@ -417,7 +417,7 @@ CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
     }
     dir->SetApproximateCount(filesCount, dirsCount);
 
-    // add up-dir if we are not in root
+    // add the up-directory entry if we are not at the root
     CFileData fd;
     memset(&fd, 0, sizeof(fd));
     if (CurrentDir != Snapshot->Root)
@@ -755,7 +755,7 @@ BOOL CPluginFSInterface::CopyFile(FILE_RECORD_I<char>* record, char* filename, c
     }
     else
     {
-        // for view it is simple
+        // for viewing, this is simple
         lstrcpyn(path, targetPath, MAX_PATH);
         lstrcpyn(SourcePath, filename, MAX_PATH);
         oldlen = 0;
@@ -852,7 +852,7 @@ BOOL CPluginFSInterface::CopyFile(FILE_RECORD_I<char>* record, char* filename, c
 
             if (BackupEncryptedFiles)
             {
-                BYTE buffer2[5000]; // WriteEncryptedFileRaw is also using buffer with size 5000
+                BYTE buffer2[5000]; // WriteEncryptedFileRaw also uses a 5000-byte buffer
                 ULONG length;
                 ULONG numw;
                 do
@@ -913,7 +913,7 @@ BOOL CPluginFSInterface::CopyFile(FILE_RECORD_I<char>* record, char* filename, c
             {
                 DWORD numw;
                 CStreamReader<char> reader;
-                reader.Init(&Volume, stream); // fixme: return value
+                reader.Init(&Volume, stream); // FIXME: check the return value
                 QWORD bytesleft = stream->DSSize;
                 QWORD clustersleft = (bytesleft - 1) / Volume.BytesPerCluster + 1;
                 BOOL exitLoop = FALSE;
@@ -979,13 +979,13 @@ BOOL CPluginFSInterface::CopyFile(FILE_RECORD_I<char>* record, char* filename, c
                     bytesleft -= nb;
                 }
             }
-            if (ret && streamIndex == copyStreams.Count - 1) // set time
+            if (ret && streamIndex == copyStreams.Count - 1) // set file times
                 SetFileTime(file.HFile, &record->TimeCreation, &record->TimeLastAccess, &record->TimeLastWrite);
             SalamanderSafeFile->SafeFileClose(&file);
         }
 
         if (encrypted)
-            break; // we don't walk through all streams for encrypted files
+            break; // do not iterate through all streams for encrypted files
     }
 
     // remove file on error
@@ -1079,7 +1079,7 @@ QWORD CPluginFSInterface::GetDirSize(FILE_RECORD_I<char>* record, int plus, BOOL
         if (r->IsDir)
             size += GetDirSize(r, plus, encrypted);
         else
-            size += GetFileSize(r, encrypted) + plus; // +1 for all-zero-size situation
+            size += GetFileSize(r, encrypted) + plus; // +1 for the all-zero-size case
     }
     return size + plus;
 }
@@ -1158,7 +1158,7 @@ void UndeleteGetResolvedRootPath(const char* path, char* resolvedPath)
     {
         BOOL cutPathIsPossible = TRUE;
         SalamanderGeneral->ResolveLocalPathWithReparsePoints(resolvedPath, path, &cutPathIsPossible, NULL, NULL, NULL, NULL, NULL);
-        // we need root for GetVolumeInformation
+        // we need the root path for GetVolumeInformation
         if (cutPathIsPossible)
         {
             SalamanderGeneral->GetRootPath(rootPath, resolvedPath);
@@ -1421,8 +1421,8 @@ CPluginFSInterface::ViewFile(const char* fsName, HWND parent,
     strcat(uniqueFileName, ":");
     strcat(uniqueFileName, Path);
     SalamanderGeneral->SalPathAppend(uniqueFileName + strlen(fsName) + 1, file.Name, MAX_PATH);
-    // name on disk are case-insensitive, disk-cache is case-sensitive, we will convert
-    // to lowercase so disk-cache will behave as case-insensitive
+    // Names on disk are case-insensitive, but the disk cache is case-sensitive, so we convert
+    // to lowercase to make the disk cache behave case-insensitively
     SalamanderGeneral->ToLowerCase(uniqueFileName);
 
     // get name of file copy in disk-cache
@@ -1431,7 +1431,7 @@ CPluginFSInterface::ViewFile(const char* fsName, HWND parent,
     if (tmpFileName == NULL)
         return; // fatal error
 
-    // find out if we need prepare file copy for disk-cache (download)
+    // Determine whether we need to prepare a file copy for the disk cache (download)
     BOOL newFileOK = FALSE;
     CQuadWord newFileSize(0, 0);
     if (!fileExists) // we need it
@@ -1460,7 +1460,7 @@ CPluginFSInterface::ViewFile(const char* fsName, HWND parent,
             HANDLE hFile = HANDLES_Q(CreateFile(tmpFileName, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,
                                                 NULL, OPEN_EXISTING, 0, NULL));
             if (hFile != INVALID_HANDLE_VALUE)
-            { // ignore error, file size doesn't matter so much
+            { // ignore errors; file size is not critical here
                 DWORD err;
                 SalamanderGeneral->SalGetFileSize(hFile, newFileSize, err); // ignore errors
                 HANDLES(CloseHandle(hFile));
@@ -1471,7 +1471,7 @@ CPluginFSInterface::ViewFile(const char* fsName, HWND parent,
     // open viewer
     HANDLE fileLock;
     BOOL fileLockOwner;
-    if (!fileExists && !newFileOK || // open viewer only when file copy is OK
+    if (!fileExists && !newFileOK || // open the viewer only if the file copy succeeded
         !salamander->OpenViewer(parent, tmpFileName, &fileLock, &fileLockOwner))
     { // clear "lock" on error
         fileLock = NULL;
@@ -1771,7 +1771,7 @@ BOOL CPluginFSInterface::TestUndeleteOnExistingFile(FILE* file, FILE_RECORD_I<ch
 {
     BOOL ret;
 
-    // allocate buffer
+    // allocate buffers
     BYTE* buffer = new BYTE[COPY_BUFFER];
     BYTE* orgBuffer = new BYTE[COPY_BUFFER];
     int bufclusters = COPY_BUFFER / Volume.BytesPerCluster;
@@ -1850,7 +1850,7 @@ BOOL CPluginFSInterface::TestUndeleteOnExistingFile(FILE* file, FILE_RECORD_I<ch
             TRACE_I("fopen() failed on " << path);
         }
         if (encrypted)
-            break; // we don't walk through all streams for encrypted files
+            break; // Skip the remaining streams for encrypted files
         stream = stream->DSNext;
     }
     delete[] buffer;

--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -154,7 +155,7 @@ CPluginFSInterface::GetFullName(CFileData& file, int isDir, char* buf, int bufSi
     CALL_STACK_MESSAGE3("CPluginFSInterface::GetFullName(, %d, , %d)", isDir, bufSize);
     lstrcpyn(buf, Path, bufSize); // If the path does not fit, the name will not fit either (report an error).
     if (isDir == 2)
-        return SalamanderGeneral->CutDirectory(buf, NULL);     // parent directory
+        return SalamanderGeneral->CutDirectory(buf, NULL); // parent directory
     else
         return SalamanderGeneral->SalPathAppend(buf, file.Name, bufSize);
 }
@@ -181,7 +182,7 @@ CPluginFSInterface::IsOurPath(int currentFSNameIndex, int fsNameIndex, const cha
     CALL_STACK_MESSAGE4("CPluginFSInterface::IsOurPath(%d, %d, %s)",
                         currentFSNameIndex, fsNameIndex, userPart);
     if (WantReconnect)
-        return FALSE;         // user requested a new connection
+        return FALSE; // user requested a new connection
     char buffer[MAX_PATH];
     if (!RootPathFromFull(userPart, buffer, MAX_PATH))
         return FALSE;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/fs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 23 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 160 comment units, 160 review results, 160 resolved results, and 160 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/fs2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/fs2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 31 provider calls, 632705 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 19 calls, 390801 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 12 calls, 241904 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
