### PR TITLE
[translation] Fix src/plugins/undelete/restore.cpp comments

### DIFF
--- a/src/plugins/undelete/restore.cpp
+++ b/src/plugins/undelete/restore.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/restore.cpp
+++ b/src/plugins/undelete/restore.cpp
@@ -134,7 +134,7 @@ static BOOL RestoreFile(const char* fileName, const char* sourcePath, const char
     if (skipped)
     {
         SalamanderSafeFile->SafeFileClose(&srcfile);
-        // skip file in progress
+        // the file was skipped in the progress dialog
         FileProgress = 0;
         TotalProgress += size.Value;
         UpdateRestoreProgress();
@@ -146,8 +146,8 @@ static BOOL RestoreFile(const char* fileName, const char* sourcePath, const char
     // recover encrypted files from backup
     if (real)
     {
-        // OpenEncryptedFileRaw (and others) unfortunately has own write to output file, we will open file
-        // with SafeFileCreate anyway for error handling, but we need to close it
+        // OpenEncryptedFileRaw (and related APIs) unfortunately writes to the output file itself; we open the file
+        // with SafeFileCreate anyway for error handling, but then we need to close it
         SalamanderSafeFile->SafeFileClose(&dstfile);
 
         // restore
@@ -157,7 +157,7 @@ static BOOL RestoreFile(const char* fileName, const char* sourcePath, const char
         if ((result = OpenEncryptedFileRaw(dstpath, CREATE_FOR_IMPORT, &context)) != ERROR_SUCCESS ||
             (result = WriteEncryptedFileRaw(RestoreCallback, (PVOID)&ctx, context)) != ERROR_SUCCESS)
         {
-            if (result != ERROR_CANCELLED) // return on cancel from user
+            if (result != ERROR_CANCELLED) // return if the user cancelled
             {
                 SetLastError(result);
                 String<char>::SysError(IDS_UNDELETE, IDS_ERRORENCRYPTED);
@@ -166,7 +166,7 @@ static BOOL RestoreFile(const char* fileName, const char* sourcePath, const char
         }
         CloseEncryptedFileRaw(context);
     }
-    else // otherwise only copy
+    else // otherwise, just copy
     {
         BYTE* buffer = new BYTE[COPY_BUFFER_SIZE];
 
@@ -201,7 +201,7 @@ static BOOL RestoreFile(const char* fileName, const char* sourcePath, const char
         }
         SetFileAttributes(dstpath, attr | FILE_ATTRIBUTE_ENCRYPTED);
     }
-    // on cancel remove incomplete file
+    // On cancel, remove the incomplete file
     else if (Progress->GetWantCancel())
     {
         DeleteFile(dstpath);
@@ -363,7 +363,7 @@ BOOL RestoreEncryptedFiles(const char* targetPath, HWND parent)
     if (!SalamanderGeneral->TestFreeSpace(parent, targetPath, CQuadWord().SetUI64(GrandTotal), String<char>::LoadStr(IDS_RESTORE)))
         return FALSE;
 
-    // todo: test if sourcePath == targetPath - it is error
+    // TODO: check whether sourcePath == targetPath; this is an error
 
     // open progress
     CRestoreProgressDlg dlg(parent, ooStatic);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/restore.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 31 comment units, 31 review results, 31 resolved results, and 31 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/restore.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/restore.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 13 provider calls, 266432 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 72292 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 9 calls, 194140 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
