### PR TITLE
[translation] Fix src/plugins/undelete/undelete.h comments

### DIFF
--- a/src/plugins/undelete/undelete.h
+++ b/src/plugins/undelete/undelete.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/undelete.h
+++ b/src/plugins/undelete/undelete.h
@@ -141,7 +141,7 @@ public:
 class CTopIndexMem
 {
 protected:
-    // path for last stored top-index
+    // path for the last stored top-index
     char Path[MAX_PATH];
     int TopIndexes[TOP_INDEX_MEM_SIZE]; // stored top-index list
     int TopIndexesCount;                // count of stored top-index
@@ -154,7 +154,7 @@ public:
         TopIndexesCount = 0;
     } // clear memory
     void Push(const char* path, int topIndex);        // store top-index for given path
-    BOOL FindAndPop(const char* path, int& topIndex); // search top-index for given path, FALSE->not found
+    BOOL FindAndPop(const char* path, int& topIndex); // find the top index for the given path; FALSE if not found
 };
 
 class CPluginInterfaceForFS : public CPluginInterfaceForFSAbstract


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/undelete.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 30 comment units, 30 review results, 30 resolved results, and 30 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/undelete.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/undelete.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 108515 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 87856 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20659 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
