### PR TITLE
[translation] Fix src/plugins/undelete/library/bitmap.h comments

### DIFF
--- a/src/plugins/undelete/library/bitmap.h
+++ b/src/plugins/undelete/library/bitmap.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/bitmap.h
+++ b/src/plugins/undelete/library/bitmap.h
@@ -12,7 +12,7 @@
 //   significant bit in BitmapPartsH.
 //
 
-#define BITMAP_PART_SIZE (5 * 1000 * 1024) // keep this const DWORD aligned!
+#define BITMAP_PART_SIZE (5 * 1000 * 1024) // keep this constant DWORD-aligned
 
 class CClusterBitmap
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/bitmap.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 13 comment units, 13 review results, 13 resolved results, and 13 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/bitmap.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/bitmap.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 43470 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43470 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
