### PR TITLE
[translation] Fix src/plugins/undelete/library/dataruns.h comments

### DIFF
--- a/src/plugins/undelete/library/dataruns.h
+++ b/src/plugins/undelete/library/dataruns.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/dataruns.h
+++ b/src/plugins/undelete/library/dataruns.h
@@ -299,7 +299,7 @@ public:
                 // switch to next data pointers
                 CurrentPtrs = CurrentPtrs->DPNext;
                 CurrentRun = CurrentPtrs->Runs;
-                CurrentLCN = 0; // each data pointers starting first offset from 0
+                CurrentLCN = 0; // each data pointer starts with its first offset from 0
                 newPtrs = TRUE;
             }
         } while (runHeader == 0); // skip all 0x00 headers
@@ -357,5 +357,5 @@ public:
     const DATA_POINTERS* StreamPtrs;  // stream data pointers
     const DATA_POINTERS* CurrentPtrs; // iterator pointing to current data pointers
     const BYTE* CurrentRun;           // iterator pointing to current data run
-    QWORD CurrentLCN;                 // logic cluster iterator
+    QWORD CurrentLCN;                 // logical cluster iterator
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/dataruns.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 33 comment units, 33 review results, 33 resolved results, and 33 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/dataruns.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/dataruns.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 86872 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 67484 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 19388 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
