### PR TITLE
[translation] Fix src/plugins/undelete/library/exfat.h comments

### DIFF
--- a/src/plugins/undelete/library/exfat.h
+++ b/src/plugins/undelete/library/exfat.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/exfat.h
+++ b/src/plugins/undelete/library/exfat.h
@@ -145,7 +145,7 @@ private:
     DWORD GetFATItem(DWORD index);
     QWORD GetFATItems() { return FATItems; }
     BOOL LoadDirectoryTree(FILE_RECORD_I<CHAR>* parent, DWORD dirFirstCluster, QWORD dirFileSize, BOOL dirClusterChainInFAT, BOOL isRootDirectory, CHAR* tracePath);
-    DWORD GetClusterChainLen(DWORD index);                                                                    // return number of clusters in cluster chain starting at 'index'
+    DWORD GetClusterChainLen(DWORD index);                                                                    // Returns the number of clusters in the cluster chain starting at 'index'
     BOOL LoadClusterChain(BYTE** buff, DWORD firstCluster, QWORD fileSize, BOOL chainInFAT, QWORD* clusters); // allocate 'buffer' and read clusters based on cluster chain starting at 'index', returns number of 'clusters'
     DWORD ConvertExFATAttr(DWORD exfatattr);
     void DosTimeToFileTime(DWORD dosTime, BYTE dosTime10ms, FILETIME* ft);
@@ -166,8 +166,8 @@ private:
     BOOL EstimateFileDamage(const FILE_RECORD_I<CHAR>* deletedFiles, CLUSTER_MAP_I** clusterMap);
     BOOL GetLostClustersMap(CClusterBitmap* clusterBitmap, CLUSTER_MAP_I* clusterMap);
 
-    // exFAT FAT table could contain 2^32 items (cluster),
-    // it is not possible to allocate/read it whole as we do with FAT32 volumes
+    // The exFAT FAT table can contain 2^32 items (clusters),
+    // so it is not possible to allocate/read it as a whole as we do for FAT32 volumes
     DWORD FATItems;          // total number of DWORD items in FAT
     DWORD* FATHead;          // buffer with first clusters of FAT, up to MAX_FAT_HEAD_SIZE size
     DWORD FATHeadItems;      // number of DWORD items in FATHead
@@ -933,7 +933,7 @@ BOOL CExFATSnapshot<CHAR>::FilterExistingDirectories(FILE_RECORD_I<CHAR>* record
         }
     }
     record->NumDirItems = j;
-    return j == 0; // returns TRUE when directory was removed
+    return j == 0; // Returns TRUE when all directory items were removed
 }
 
 template <typename CHAR>
@@ -1158,7 +1158,7 @@ void CExFATSnapshot<CHAR>::DrawDeletedFile(FILE_RECORD_I<CHAR>* record, CCluster
                 QWORD lcn;
                 QWORD length;
                 if (!runsWalker.GetNextRun(&lcn, &length, NULL))
-                    break; // unlikely error, moreover it doesn't matter
+                    break; // unlikely error; it does not matter here
                 if (lcn != -1)
                 {
                     // if value in bitmap is smaller than 2, increase it
@@ -1263,7 +1263,7 @@ BOOL CExFATSnapshot<CHAR>::EstimateFileDamage(const FILE_RECORD_I<CHAR>* deleted
         }
     }
 
-    if (this->UdFlags & UF_GETLOSTCLUSTERMAP) // is lost cluster map required?
+    if (this->UdFlags & UF_GETLOSTCLUSTERMAP) // is a lost cluster map required?
     {
         if (clusterMap != NULL)
         {
@@ -1312,7 +1312,7 @@ BOOL CExFATSnapshot<CHAR>::GetLostClustersMap(CClusterBitmap* clusterBitmap, CLU
             // for cluster number 'i' find related two bits in bitmap
             BYTE c;
             clusterBitmap->GetValue(i - 2, &c); // exFAT bitmap is zero based
-            if (c == 0 || c == 2)               // cluster is not used (or we don't know about it) || there is FC_FAIR or FC_POOR
+            if (c == 0 || c == 2)               // cluster is not used (or we do not know about it), or it is FC_FAIR or FC_POOR
             {
                 // if it is beginning of segment that we are interested in, store lcnFirst and set we are in segment
                 if (!inside)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/exfat.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 154 comment units, 154 review results, 154 resolved results, and 154 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/exfat.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/exfat.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 181831 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 161718 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20113 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
