### PR TITLE
[translation] Fix src/plugins/undelete/library/fat.cpp comments

### DIFF
--- a/src/plugins/undelete/library/fat.cpp
+++ b/src/plugins/undelete/library/fat.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/library/fat.cpp
+++ b/src/plugins/undelete/library/fat.cpp
@@ -53,7 +53,7 @@
 //                              of FILE_RECORD structures
 //
 
-BOOL ConvertFATName(const char* fatName, char* name) // convert name from format 83 to 8.3
+BOOL ConvertFATName(const char* fatName, char* name) // convert a name from FAT 8.3 format
 {
     CALL_STACK_MESSAGE_NONE
     //CALL_STACK_MESSAGE2("ConvertFATName(%s, )", fatName);
@@ -65,7 +65,7 @@ BOOL ConvertFATName(const char* fatName, char* name) // convert name from format
             // of there is extension, insert dot
             if (fatName[i] != ' ')
             {
-                if (p == name) // wrong file name
+                if (p == name) // invalid file name
                     return FALSE;
                 *p = '.';
                 p++;
@@ -77,7 +77,7 @@ BOOL ConvertFATName(const char* fatName, char* name) // convert name from format
         {
             *p = fatName[i];
             if (i == 0 && *p == 0x05)
-                *p = (char)0xE5; // 0x05 is used instead of 0xE5 in the Japan/KANJI
+                *p = (char)0xE5; // 0x05 is used instead of 0xE5 in Japanese/KANJI
             p++;
         }
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/fat.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 12 comment units, 12 review results, 12 resolved results, and 12 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/fat.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/fat.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 109729 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 87549 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 22180 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
