### PR TITLE
[translation] Fix src/plugins/undelete/library/miscstr.cpp comments

### DIFF
--- a/src/plugins/undelete/library/miscstr.cpp
+++ b/src/plugins/undelete/library/miscstr.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/library/miscstr.cpp
+++ b/src/plugins/undelete/library/miscstr.cpp
@@ -66,7 +66,7 @@ char* String<char>::LoadStr(int resID)
 
     RELOAD:
         int size = LoadStringA(hInstance, resID, StrAct, STRBUFSIZE - (int)(StrAct - StringBuffer));
-        // size contains number of copied characters without terminator
+        // size contains the number of copied characters, excluding the terminator
         //    DWORD error = GetLastError();
         if (size != 0 /* || error == NO_ERROR*/) // error is NO_ERROR even if string doesn't exist, we cannot use it
         {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/miscstr.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 17 comment units, 17 review results, 17 resolved results, and 17 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/miscstr.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/miscstr.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 107974 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 87423 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20551 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
