### PR TITLE
[translation] Fix src/plugins/undelete/library/stream.h comments

### DIFF
--- a/src/plugins/undelete/library/stream.h
+++ b/src/plugins/undelete/library/stream.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/stream.h
+++ b/src/plugins/undelete/library/stream.h
@@ -117,7 +117,7 @@ public:
     ~CStreamReader() { Release(); }
 
     BOOL Init(CVolume<CHAR>* volume, DATA_STREAM_I<CHAR>* str);
-    // when 'numRead' is not NULL, it will return number of read clusters or -1 when special error occurred
+    // when 'numRead' is not NULL, it receives the number of clusters read or -1 when a special error occurs
     BOOL GetClusters(BYTE* buffer, QWORD num, QWORD* numRead = NULL);
     BOOL IsSafeChunk(QWORD n) { return RunLength >= n; }
     void Release();


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/stream.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 60 comment units, 60 review results, 60 resolved results, and 60 apply results.
- Branch-target comment guard passed for `src/plugins/undelete/library/stream.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/stream.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 88122 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 68606 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 19516 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
