### PR TITLE
[translation] Fix src/plugins/unfat/fat.cpp comments

### DIFF
--- a/src/plugins/unfat/fat.cpp
+++ b/src/plugins/unfat/fat.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/unfat/fat.cpp
+++ b/src/plugins/unfat/fat.cpp
@@ -263,7 +263,7 @@ BOOL CFATImage::AddDirectory(char* root, TDirectArray<DWORD>* fat,
         return FALSE;
     }
 
-    int fatIndex = 0; // ignore the zeroth entry from the 'fat' array; we already received 'sector'
+    int fatIndex = 0; // ignore the zeroth entry in the 'fat' array; we already have 'sector'
 
     CDirEntry dirEnt;
     wchar_t longName[63 * 13 + 1];
@@ -363,7 +363,7 @@ BOOL CFATImage::AddDirectory(char* root, TDirectArray<DWORD>* fat,
             {
                 if (dirEnt.Long.Chksum != longNameChksum)
                 {
-                    // invalid data; abort reading
+                    // corrupt entry, stop reading the long name
                     longNameOrd = 0; // do not read long_name
                     TRACE_E("CFATImage::AddDirectory: Different checksum in the long name. offset=0x" << _i64toa(seek.Value, seekStr, 16));
                     continue;
@@ -380,7 +380,7 @@ BOOL CFATImage::AddDirectory(char* root, TDirectArray<DWORD>* fat,
             continue;                        // move on to the next part of the long_name or to the short_name
         }
 
-        if (longNameOrd > 1) // are we stuck in the middle (neither 0 nor 1)?
+        if (longNameOrd > 1) // are we in the middle of reading the long name (neither 0 nor 1)?
             longNameOrd = 0; // the long_name was not fully read -> discard it
 
         CFileData file;
@@ -389,7 +389,7 @@ BOOL CFATImage::AddDirectory(char* root, TDirectArray<DWORD>* fat,
         {
             longNameOrd = 0;
             TRACE_E("CFATImage::AddDirectory: Error converting to 8.3 name. offset=0x" << _i64toa(seek.Value, seekStr, 16));
-            continue; // skip the nonsensical name
+            continue; // skip the invalid name
         }
 
         // skip . and ..
@@ -586,7 +586,7 @@ BOOL CFATImage::AddDirectory(char* root, TDirectArray<DWORD>* fat,
 BOOL CFATImage::LoadFAT(DWORD cluster, TDirectArray<DWORD>* fat, HWND hParent,
                         DWORD buttons, DWORD* pressedButton, DWORD* silentMask)
 {
-    if (pressedButton != NULL)          // if we return FALSE and do not change this value
+    if (pressedButton != NULL)          // If we return FALSE without changing this value, it means the entire operation was canceled.
         *pressedButton = DIALOG_CANCEL; // we meant cancellation of the entire operation
 
     fat->DetachMembers();
@@ -775,7 +775,7 @@ BOOL CFATImage::UnpackFile(CSalamanderForOperationsAbstract* salamander, const c
     CQuadWord allocFileSize = fileData->Size;
     BOOL allocateWholeFile = FALSE;
     if (*allocWholeFileOnStart != awfDisabled &&  // preallocating the whole file is not disabled
-        allocFileSize > minAllocFileSize &&       // fileSize validity condition + below the copy buffer size preallocation makes no sense (smaller files all use COPY_MIN_FILE_SIZE) (and there is no point below 1 byte)
+        allocFileSize > minAllocFileSize &&       // file size validity condition; below the copy buffer size, preallocation makes no sense (all smaller files use COPY_MIN_FILE_SIZE) (and it also makes no sense for files smaller than 1 byte)
         allocFileSize < CQuadWord(0, 0x80000000)) // the file size must be a positive number (otherwise seeking is impossible - these are numbers above 8EB, so this likely never happens)
     {
         allocateWholeFile = TRUE;
@@ -856,7 +856,7 @@ BOOL CFATImage::UnpackFile(CSalamanderForOperationsAbstract* salamander, const c
         remains.Value -= read;
     }
 
-    if (fileData->Size < COPY_MIN_FILE_SIZE) // small file -- enlarge it for progress reporting
+    if (fileData->Size < COPY_MIN_FILE_SIZE) // small file -- count it as larger for progress reporting
     {
         remains = COPY_MIN_FILE_SIZE - fileData->Size;
         if (!salamander->ProgressAddSize((int)remains.Value, TRUE))
@@ -881,10 +881,10 @@ EXIT:
     }
     else
     {
-        // FIXME: (consult with Petr) I am not sure here
-        // if the source has no attribute, SafeCreateFile assigned it 'A'
+        // FIXME: (consult with Petr) this is unclear
+        // if the source has no attributes, SafeCreateFile assigned it 'A'
         // this guarantees an exact copy, but it is not compatible with Salamander's Copy command
-        // every plugin behaves differently; it is a mess
+        // each plugin behaves differently; the behavior is inconsistent
 
         if (!SetFileAttributes(targetName, fileData->Attr))
             TRACE_E("SetFileAttributes failed");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unfat/fat.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 8 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 95 comment units, 95 review results, 95 resolved results, and 95 apply results.
- Branch-target comment guard passed for `src/plugins/unfat/fat.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unfat/fat.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 14 provider calls, 264516 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 11 calls, 222166 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 42350 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
