### PR TITLE
[translation] Fix src/plugins/unfat/unfat.cpp comments

### DIFF
--- a/src/plugins/unfat/unfat.cpp
+++ b/src/plugins/unfat/unfat.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/unfat/unfat.cpp
+++ b/src/plugins/unfat/unfat.cpp
@@ -68,7 +68,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         break;
     }
     }
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 char* LoadStr(int resID)
@@ -90,7 +90,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
-    // this plugin is made for the current version of Salamander or newer - perform a check
+    // this plugin is intended for the current version of Salamander and later, so check it
     if (SalamanderVersion < LAST_VERSION_OF_SALAMANDER)
     { // reject older versions
         MessageBox(salamander->GetParentWindow(),
@@ -376,7 +376,7 @@ BOOL CPluginInterfaceForArchiver::UnpackArchive(CSalamanderForOperationsAbstract
                     if (!salamander->ProgressAddSize((int)size2.Value, TRUE))
                     {
                         ret = FALSE;
-                        break; // the operation was cancelled
+                        break; // Operation cancelled
                     }
                 }
                 else
@@ -529,7 +529,7 @@ BOOL ExtractArchive(CSalamanderDirectoryAbstract const* dir, CSalamanderMaskGrou
                     unpack = FALSE; // the item lies under skipPath so it is ignored
                 }
                 else
-                    skipPath[0] = 0; // the item does not belong under skipPath, discard skipPath
+                    skipPath[0] = 0; // the item does not lie under skipPath, so discard skipPath
             }
 
             if (unpack)
@@ -572,7 +572,7 @@ BOOL ExtractArchive(CSalamanderDirectoryAbstract const* dir, CSalamanderMaskGrou
                 unpack = FALSE; // the item lies under skipPath so it is ignored
             }
             else
-                skipPath[0] = 0; // the item does not belong under skipPath, discard skipPath
+                skipPath[0] = 0; // the item is not under skipPath, so clear skipPath
         }
 
         if (unpack)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unfat/unfat.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 79 comment units, 79 review results, 79 resolved results, and 79 apply results.
- Branch-target comment guard passed for `src/plugins/unfat/unfat.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unfat/unfat.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 10 provider calls, 235926 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 9 calls, 214420 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 21506 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
