### PR TITLE
[translation] Fix src/plugins/unchm/chmfile.cpp comments

### DIFF
--- a/src/plugins/unchm/chmfile.cpp
+++ b/src/plugins/unchm/chmfile.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/unchm/chmfile.cpp
+++ b/src/plugins/unchm/chmfile.cpp
@@ -99,7 +99,7 @@ BOOL CCHMFile::Open(const char* fileName, BOOL quiet /* = FALSE*/)
         }
         else
         {
-            // can not obtain last write, use current time
+            // cannot obtain the last write time; use the current time
             SYSTEMTIME st;
             GetLocalTime(&st);
             SystemTimeToFileTime(&st, &FileTime);
@@ -240,7 +240,7 @@ BOOL CCHMFile::EnumObjects(CSalamanderDirectoryAbstract* dir, CPluginDataInterfa
 
     SEnumObjHelper* helper = new SEnumObjHelper(this, dir, pluginData);
     ChmEnumerate(CHM, CHM_ENUMERATE_NORMAL, ChmEnumObjectsCallBack, (void*)helper);
-    // for DEBUG purposes
+    // For debugging
     //  ChmEnumerate(CHM, CHM_ENUMERATE_ALL, ChmEnumObjectsCallBack, (void *) helper);
     delete helper;
 
@@ -276,11 +276,11 @@ int CCHMFile::ExtractObject(CSalamanderForOperationsAbstract* salamander, const 
     // set file time
     SetFileTime(file, &ft, &ft, &ft);
 
-    // the overall operation can continue; skip only
+    // the overall operation can continue; only skip this file
     if (toSkip)
         return UNPACK_ERROR;
 
-    // the overall operation cannot continue; cancel
+    // The overall operation cannot continue. Cancel.
     if (file == INVALID_HANDLE_VALUE)
         return UNPACK_CANCEL;
 
@@ -336,14 +336,14 @@ int CCHMFile::ExtractObject(CSalamanderForOperationsAbstract* salamander, const 
             break;
         }
 
-        if (!salamander->ProgressAddSize((int)len, TRUE)) // delayedPaint==TRUE so we do not slow down
+        if (!salamander->ProgressAddSize((int)len, TRUE)) // delayedPaint==TRUE so we do not slow the operation down
         {
             salamander->ProgressDialogAddText(LoadStr(IDS_CANCELOPER), FALSE);
             salamander->ProgressEnableCancel(FALSE);
 
             ret = UNPACK_CANCEL;
             whole = FALSE;
-            break; // interrupt the action
+            break; // interrupt the operation
         }
     } // while
 
@@ -356,14 +356,14 @@ int CCHMFile::ExtractObject(CSalamanderForOperationsAbstract* salamander, const 
         if (ret == UNPACK_OK)
             ret = UNPACK_CANCEL;
 
-        // because it is created with the read-only attribute, we must clear the R attribute
-        // to allow the file to be deleted
+        // because the file is created with the read-only attribute, we must clear that attribute
+        // so the file can be deleted
         attrs &= ~FILE_ATTRIBUTE_READONLY;
         if (!SetFileAttributes(name, attrs))
             Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());
 
         // the user canceled the operation
-        // delete the incomplete file afterwards
+        // delete the incomplete file
         if (!DeleteFile(name))
             Error(LoadStr(IDS_CANT_DELETE_TEMP_FILE), GetLastError());
     }
@@ -380,16 +380,16 @@ BOOL CCHMFile::UnpackDir(const char* dirName, const CFileData* fileData)
         return UNPACK_ERROR;
 
     /*
-  DWORD attrs = fileData->Attr;
+      DWORD attrs = fileData->Attr;
 
-  // set attrs to dir
-  if (Options.ClearReadOnly)
-    // set ReadOnly Attribute
-    attrs &= ~FILE_ATTRIBUTE_READONLY;
+      // set attributes for the directory
+      if (Options.ClearReadOnly)
+        // clear the ReadOnly attribute
+        attrs &= ~FILE_ATTRIBUTE_READONLY;
 
-  if (!SetFileAttributes(dirName, attrs))
-    Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());
-*/
+      if (!SetFileAttributes(dirName, attrs))
+        Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());
+    */
 
     return UNPACK_OK;
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unchm/chmfile.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 27 comment units, 27 review results, 27 resolved results, and 27 apply results.
- Branch-target comment guard passed for `src/plugins/unchm/chmfile.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unchm/chmfile.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 176143 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 88599 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 87544 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
