### PR TITLE
[translation] Fix src/plugins/unchm/unchm.cpp comments

### DIFF
--- a/src/plugins/unchm/unchm.cpp
+++ b/src/plugins/unchm/unchm.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/unchm/unchm.cpp
+++ b/src/plugins/unchm/unchm.cpp
@@ -59,7 +59,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         break;
     }
     }
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 char* LoadStr(int resID)
@@ -154,7 +154,7 @@ BOOL Error(int resID, BOOL quiet, ...)
 BOOL Error(char* msg, DWORD err, BOOL quiet)
 {
     if (!quiet)
-        if (err != ERROR_FILE_NOT_FOUND && err != ERROR_NO_MORE_FILES) // this is an error
+        if (err != ERROR_FILE_NOT_FOUND && err != ERROR_NO_MORE_FILES) // actual error
         {
             char buf[1024];
             sprintf(buf, "%s\n\n%s", msg, SalamanderGeneral->GetErrorText(err));


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unchm/unchm.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 53 comment units, 53 review results, 53 resolved results, and 53 apply results.
- Branch-target comment guard passed for `src/plugins/unchm/unchm.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unchm/unchm.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 161680 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 8 calls, 141645 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20035 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
