### PR TITLE
[translation] Fix src/plugins/uniso/BlockedFile.h comments

### DIFF
--- a/src/plugins/uniso/BlockedFile.h
+++ b/src/plugins/uniso/BlockedFile.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/uniso/BlockedFile.h
+++ b/src/plugins/uniso/BlockedFile.h
@@ -105,7 +105,7 @@ protected:
     UInt64 FileSize;
 
     CCachedBlock* BlockCache[32]; // 32 MRU blocks
-    int MRUCachedBlock;           // index into MRUCachedBlock
+    int MRUCachedBlock;           // index of the MRU cached block
     CCachedBlock* pCurBlock;
     bool bUnknownBlockErrShown;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/BlockedFile.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 6 comment units, 6 review results, 6 resolved results, and 6 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/BlockedFile.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/BlockedFile.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 43059 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43059 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
