### PR TITLE
[translation] Fix src/plugins/uniso/dmg.cpp comments

### DIFF
--- a/src/plugins/uniso/dmg.cpp
+++ b/src/plugins/uniso/dmg.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/uniso/dmg.cpp
+++ b/src/plugins/uniso/dmg.cpp
@@ -67,7 +67,7 @@ static int UnBase64(char* s)
         *out++ = (b3 >> 2) | (b2 << 4);
         *out++ = b4 | (b3 << 6);
     }
-    // NOTE: we don't care about the last extra 1 or 2 or 3 bytes we added
+    // NOTE: Ignore the last extra 1, 2, or 3 bytes that were added
     return (int)(out - orig);
 }
 
@@ -362,8 +362,8 @@ CDMGFile::CADCBlock::CADCBlock(BlockInfo* blockInfo, HANDLE hFile)
             }
             else
             {
-                // NOTE: memcpy & memmove cannot be used in general, they read by dwords
-                // NOTE: http://www.macdisk.com/dmgen.php says something about memset... but it doesn't work - see SymArt_Demo.dmg
+                // NOTE: memcpy and memmove cannot be used in general; they read in DWORDs
+                // NOTE: http://www.macdisk.com/dmgen.php mentions memset, but it does not work; see SymArt_Demo.dmg
                 while (len-- > 0)
                     *out++ = *src++;
             }
@@ -382,8 +382,8 @@ CDMGFile::CADCBlock::CADCBlock(BlockInfo* blockInfo, HANDLE hFile)
             }
             else
             {
-                // NOTE: memcpy & memmove cannot be used in general, they read by dwords
-                // NOTE: http://www.macdisk.com/dmgen.php says something about memset... but it doesn't work - see SymArt_Demo.dmg
+                // NOTE: memcpy & memmove cannot generally be used; they read in DWORDs
+                // NOTE: http://www.macdisk.com/dmgen.php mentions memset... but it does not work - see SymArt_Demo.dmg
                 while (len-- > 0)
                     *out++ = *src++;
             }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/dmg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 27 comment units, 27 review results, 27 resolved results, and 27 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/dmg.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/dmg.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 91820 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 91820 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
