### PR TITLE
[translation] Fix src/plugins/uniso/eltorito.cpp comments

### DIFF
--- a/src/plugins/uniso/eltorito.cpp
+++ b/src/plugins/uniso/eltorito.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/eltorito.cpp
+++ b/src/plugins/uniso/eltorito.cpp
@@ -37,10 +37,10 @@ struct etDefaultEntry
     BYTE BootIndicator; // 88 - Bootable
                         // 00 - Not bootable
     BYTE BootMedia;     // 0 - No emulation
-                        // 1 - 1.2 meg diskette
-                        // 2 - 1.44 meg diskette
-                        // 3 - 2.88 meg diskette
-                        // 4 - Hard disk (drive 80)
+                        // 1 - 1.2 MB diskette
+                        // 2 - 1.44 MB diskette
+                        // 3 - 2.88 MB diskette
+                        // 4 - Hard disk (drive 80h)
     WORD LoadSegment;
     BYTE SystemType;
     BYTE Unused;
@@ -63,7 +63,7 @@ struct etSectionHeaderEntry
 // section entry
 struct etSectionEntry
 {
-    BYTE BootIndicator; // 88 - Bootlable
+    BYTE BootIndicator; // 88 - Bootable
                         // 00 - Not bootable
     BYTE BootMedia;
     // Bits 0-3 count as follows
@@ -85,7 +85,7 @@ struct etSectionEntry
     DWORD LoadRBA;
 };
 
-//
+// Fills boot record info from El Torito data.
 BOOL CISO9660::FillBootRecordInfoElTorito(CBootRecordInfo* bri, BYTE bootMedia, WORD sectorCount, DWORD loadRBA)
 {
     CALL_STACK_MESSAGE4("CISO9660::FillBootRecordInfoElTorito(, %u, %u, %u)", bootMedia, sectorCount, loadRBA);
@@ -169,7 +169,7 @@ BOOL CISO9660::ReadElTorito(BYTE* catalog, DWORD size, BOOL quiet)
     memcpy(&ve, catalog + offset, sizeof(ve));
     offset += ENTRY_LENGTH;
 
-    // check if it is validation entry
+    // check whether this is a validation entry
     if (ve.ID != 01 || ve.Reserved != 0x00 || ve.KeyByte[0] != 0x55 || ve.KeyByte[1] != 0xAA)
         return FALSE;
 
@@ -180,7 +180,7 @@ BOOL CISO9660::ReadElTorito(BYTE* catalog, DWORD size, BOOL quiet)
 
     if (de.BootIndicator == 0x88)
     {
-        // it is bootable
+        // bootable
         BootRecordInfo = new CBootRecordInfo;
         if (BootRecordInfo == NULL)
         {
@@ -192,7 +192,7 @@ BOOL CISO9660::ReadElTorito(BYTE* catalog, DWORD size, BOOL quiet)
         return TRUE;
     }
 
-    // it is valid entry, go on...
+    // valid entry, continue...
     //  BYTE entryBuffer[ENTRY_LENGTH];
 
     while (offset < size)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/eltorito.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 34 comment units, 34 review results, 34 resolved results, and 34 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/eltorito.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/eltorito.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 152687 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 69838 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 82849 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
