### PR TITLE
[translation] Fix src/plugins/uniso/hfs.h comments

### DIFF
--- a/src/plugins/uniso/hfs.h
+++ b/src/plugins/uniso/hfs.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/uniso/hfs.h
+++ b/src/plugins/uniso/hfs.h
@@ -73,7 +73,6 @@ public:
         UInt32 pmBootEntry2;  // reserved
         UInt32 pmBootCksum;   // boot code checksum
         char pmProcessor[16]; // processor type
-                              //    UInt16  pmPad[0..188]; // reserved
     };
 
     struct HFSExtentDescriptor
@@ -234,7 +233,7 @@ public:
         kHFSRootFolderID = 2,           // Folder ID of the root folder
         kHFSExtentsFileID = 3,          // File ID of the extents overflow file
         kHFSCatalogFileID = 4,          // File ID of the catalog file
-        kHFSBadBlockFileID = 5,         // File ID of the bad block file. The bad block file is not a file in the same sense as a special file and a user file
+        kHFSBadBlockFileID = 5,         // File ID of the bad block file. The bad block file is not a file in the same sense as a special file or a user file
         kHFSAllocationFileID = 6,       // File ID of the allocation file (introduced with HFS Plus)
         kHFSStartupFileID = 7,          // File ID of the startup file (introduced with HFS Plus)
         kHFSAttributesFileID = 8,       // File ID of the attributes file (introduced with HFS Plus)
@@ -406,7 +405,7 @@ private:
     bool bSkipRootParent;
 
     BOOL SeekSector(int sector); // Seeks on disk (sector is usually 512 or 2048 bytes); TRUE on success
-    BOOL SeekBlock(int block);   // Seeks on HFS+ partition (block is usually 4096 bytes); TRUE on success
+    BOOL SeekBlock(int block);   // Seeks to the given block on the HFS+ partition (the block is usually 4096 bytes); returns TRUE on success
     __int64 SeekRel(int offset); // Seeks relatively; Returns new position
     BOOL Read(LPVOID buf, DWORD dwBytesToRead, DWORD* dwBytesRead);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/hfs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 106 comment units, 106 review results, 106 resolved results, and 106 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/hfs.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/hfs.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 210592 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 10 calls, 190839 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 19753 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
