### PR TITLE
[translation] Fix src/plugins/uniso/iso9660.cpp comments

### DIFF
--- a/src/plugins/uniso/iso9660.cpp
+++ b/src/plugins/uniso/iso9660.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/iso9660.cpp
+++ b/src/plugins/uniso/iso9660.cpp
@@ -60,13 +60,13 @@ BOOL CISO9660::Open(BOOL quiet)
 
     // detecting CD-ROM Volume Descriptor Set
     BOOL isoDescriptors = FALSE;
-    // Read the VolumeDescriptor (2k) until we find it, but only up to to 1MB
+    // Read the Volume Descriptor (2 KB) until we find it, but only up to 1 MB
     while (!terminate)
     {
         // Try to read a block
         if (Image->ReadBlock(block, SECTOR_SIZE, sector) != SECTOR_SIZE)
         {
-            // Something went wrong, probably EOF?
+            // Read failed, possibly due to EOF.
             Error(IDS_ERROR_READING_SECTOR, quiet, block);
             ret = FALSE;
             break;
@@ -90,8 +90,8 @@ BOOL CISO9660::Open(BOOL quiet)
                 // Joliet has FileStructureVersion = 1
                 if (SVD.FileStructureVersion == 1)
                     Ext = extJoliet;
-                // Patera 2009.02.03: The following check seems correct and not the above one...
-                // Raptor provided "Pantera Safari.ISO" with corruped FileStructureVersion
+                // Patera 2009-02-03: The following check seems correct, unlike the one above...
+                // Raptor provided "Pantera Safari.ISO" with a corrupted FileStructureVersion
                 if ((SVD.EscapeSequences[0] == 0x25) && (SVD.EscapeSequences[1] == 0x2F) && ((SVD.EscapeSequences[2] == 0x40) || (SVD.EscapeSequences[2] == 0x43) || (SVD.EscapeSequences[2] == 0x45)))
                     Ext = extJoliet;
                 break;
@@ -169,7 +169,7 @@ void CISO9660::ExtractExtFileName(char* fileName, const char* src, CDirectoryRec
         srcSU++;
     }
 
-    // check whether there is any extension in the 'system use area'
+    // check whether the 'system use area' contains any extension
     if (srcSU < srcEnd && (Ext != extJoliet))
     {
         EExt ext = extNone;
@@ -457,7 +457,7 @@ int CISO9660::ListDirectoryRe(char* path, CDirectoryRecord* root,
     {
         delete[] data;
         Error(IDS_ERROR_LISTING_IMAGE, FALSE, block);
-        // if reading the sector with the root fails
+        // if reading the root sector fails
         return (block == (DWORD)Root.LocationOfExtent - ExtentOffset) ? ERR_CONTINUE : ERR_TERMINATE;
     }
 
@@ -497,11 +497,11 @@ int CISO9660::ListDirectoryRe(char* path, CDirectoryRecord* root,
                         int pathLen = (int)strlen(path);
                         strcat(path, "\\");
                         strcat(path, dirName);
-                        // descend only when everything is OK
+                        // recurse only when everything is OK
                         if (ret == ERR_OK)
                         {
                             ret = ListDirectoryRe(path, &dirRecord, dir, pluginData);
-                            // if we surface with a termination error, keep processing as much as possible
+                            // if we return with a termination error, keep processing as much as possible
                             if (ret == ERR_TERMINATE)
                                 ret = ERR_CONTINUE;
                         }
@@ -530,7 +530,7 @@ int CISO9660::ListDirectoryRe(char* path, CDirectoryRecord* root,
                         if (ret == ERR_OK)
                         {
                             ret = ListDirectoryRe(path, &dirRecord, dir, pluginData);
-                            // if we surface with a termination error, keep processing as much as possible
+                            // if we return with a termination error, continue processing as much as possible
                             if (ret == ERR_TERMINATE)
                                 ret = ERR_CONTINUE;
                         }
@@ -594,7 +594,7 @@ int CISO9660::UnpackFile(CSalamanderForOperationsAbstract* salamander, const cha
     // set file time
     file.SetFileTime(&ft, &ft, &ft);
 
-    // the overall operation can continue further: skip only
+    // the overall operation can continue; skip this file only
     if (toSkip)
         return UNPACK_ERROR;
 
@@ -658,14 +658,14 @@ int CISO9660::UnpackFile(CSalamanderForOperationsAbstract* salamander, const cha
 
         block++;
 
-        if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint==TRUE, so we do not slow things down
+        if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint==TRUE so we do not slow the operation down
         {
             salamander->ProgressDialogAddText(LoadStr(IDS_CANCELING_OPERATION), FALSE);
             salamander->ProgressEnableCancel(FALSE);
 
             ret = UNPACK_CANCEL;
             bFileComplete = FALSE;
-            break; // action interrupted
+            break; // operation interrupted
         }
 
         ULONG written;
@@ -700,7 +700,7 @@ int CISO9660::UnpackFile(CSalamanderForOperationsAbstract* salamander, const cha
             Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());
 
         // the user cancelled the operation
-        // delete the incomplete file afterwards
+        // delete the incomplete file
         if (!DeleteFile(name))
             Error(LoadStr(IDS_CANT_DELETE_TEMP_FILE), GetLastError());
     }
@@ -778,7 +778,7 @@ BOOL CISO9660::ReadBootRecord(BYTE* data, BOOL quiet)
     if (!Options.BootImageAsFile)
         return FALSE;
 
-    // check for El Torito specification
+    // check for the El Torito specification
     if (memcmp(BR.BootSystemIdentifier + 0, "EL TORITO SPECIFICATION", 23) == 0)
     {
         DWORD sector = 0;
@@ -802,6 +802,6 @@ BOOL CISO9660::ReadBootRecord(BYTE* data, BOOL quiet)
         delete[] catalog;
     }
 
-    // and finally
+    // Finally
     return result;
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/iso9660.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 14 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 65 comment units, 65 review results, 65 resolved results, and 65 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/iso9660.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/iso9660.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 20 provider calls, 361944 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 98251 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 263693 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
