### PR TITLE
[translation] Fix src/plugins/uniso/nrg.cpp comments

### DIFF
--- a/src/plugins/uniso/nrg.cpp
+++ b/src/plugins/uniso/nrg.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/nrg.cpp
+++ b/src/plugins/uniso/nrg.cpp
@@ -269,7 +269,7 @@ readCDTX(CFile& file, NRGHeader* header, CISOImage* iso)
     dst = data;
     int i;
     for (i = header->Size; i > 0; i -= 12 + 6)
-    { // Remove some unknown data (there are blocks of 12 bytes of labels followed by unkown 6 bytes)
+    { // Remove some unknown data (there are blocks of 12 bytes of labels followed by unknown 6 bytes)
         memmove(dst, src, min(12, i));
         dst += 12;
         src += 12 + 6;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/nrg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 14 comment units, 14 review results, 14 resolved results, and 14 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/nrg.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/nrg.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 107860 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 66075 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 41785 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
