### PR TITLE
[translation] Fix src/plugins/uniso/rawfs.cpp comments

### DIFF
--- a/src/plugins/uniso/rawfs.cpp
+++ b/src/plugins/uniso/rawfs.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/rawfs.cpp
+++ b/src/plugins/uniso/rawfs.cpp
@@ -93,11 +93,11 @@ int CRawFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char*
         // set file time
         file.SetFileTime(&ft, &ft, &ft);
 
-        // the overall operation can continue further: skip only
+        // the overall operation can continue; skip only this file
         if (toSkip)
             throw UNPACK_ERROR;
 
-        // the overall operation cannot continue any further: cancel
+        // the overall operation cannot continue; cancel
         if (hFile == INVALID_HANDLE_VALUE)
             throw UNPACK_CANCEL;
 
@@ -111,8 +111,8 @@ int CRawFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char*
     }
 */
 
-        // it is possible that the extent does not need to be subtracted here; there is no data to test with, so I don't know :(
-        // but the more probable variant is that it should be subtracted
+        // it is possible that the extent does not need to be subtracted here; there is no data to test this, so it is unclear
+        // but it is more likely that it should be subtracted
         DWORD block = fp->Extent - ExtentOffset;
         CQuadWord remain = fileData->Size;
 
@@ -163,7 +163,7 @@ int CRawFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char*
             ULONG written;
             if (!file.Write(sector, nbytes, &written, name, NULL))
             {
-                // Error message was already displayed by SafeWriteFile()
+                // The error message has already been displayed.
                 ret = UNPACK_CANCEL;
                 bFileComplete = FALSE;
                 break;
@@ -183,13 +183,13 @@ int CRawFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char*
         if (!bFileComplete)
         {
             // because it was created with the read-only attribute, we must clear
-            // the R attribute so the file can be deleted
+            // the read-only attribute so the file can be deleted
             attrs &= ~FILE_ATTRIBUTE_READONLY;
             if (!SetFileAttributes(name, attrs))
                 Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());
 
-            // the user cancelled the operation
-            // delete the incomplete file afterwards
+            // user canceled the operation
+            // delete the incomplete file
             if (!DeleteFile(name))
                 Error(LoadStr(IDS_CANT_DELETE_TEMP_FILE), GetLastError());
         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/rawfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 16 comment units, 16 review results, 16 resolved results, and 16 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/rawfs.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/rawfs.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 134874 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 46503 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 88371 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
