### PR TITLE
[translation] Fix src/plugins/uniso/udf.cpp comments

### DIFF
--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -17,9 +17,9 @@
 typedef wchar_t unicode_t;
 
 #define SECTOR_SIZE 0x800
-#define INVALID_SECTOR_NUMBER -11111111 // reasonable negative number; Should not be -1 or so!!
+#define INVALID_SECTOR_NUMBER -11111111 // A suitable negative number; should not be -1 or similar.
 
-// Maximum length of filenames allowed in UDF.
+// Maximum filename length allowed in UDF.
 #define MAX_UDF_FILE_NAME_LEN 2048
 
 // Flags for testing the File Identifier Descriptor
@@ -65,7 +65,7 @@ UDFTimeStampToFileTime(CUDF::CTimeStamp& stamp, FILETIME* ft)
     { // Valid timezone, offset in minutes
         __int64 newtime = ft->dwLowDateTime + (((__int64)ft->dwHighDateTime) << 32);
 
-        if (offset & 0x800) // negative 12-bit number -> extend to 32-bit negative number
+        if (offset & 0x800) // negative 12-bit number -> sign-extend to a 32-bit negative number
             offset |= 0xFFFFF000;
         newtime -= ((__int64)offset) * 60 * 1000 * 1000 * 10; // from min units to 100ns units
         ft->dwLowDateTime = (DWORD)(newtime & 0x00000000ffffffff);
@@ -90,7 +90,7 @@ UnicodeUncompress(BYTE* compressed, int numberOfBytes, unicode_t* unicode)
     unsigned int compID;
     int returnValue, unicodeIndex, byteIndex;
 
-    // Use 'compressed' to store current byte being read.
+    // 'compressed' points to the compressed input bytes being read.
     compID = compressed[0];
 
     // First check for valid compID.
@@ -104,7 +104,7 @@ UnicodeUncompress(BYTE* compressed, int numberOfBytes, unicode_t* unicode)
         byteIndex = 1;
         if (16 == compID)
         {
-            // Make it odd number: length byte plus even number of text bytes
+            // Make it an odd number: a length byte plus an even number of text bytes
             numberOfBytes = ((numberOfBytes - 1) & 0xFFFE) + 1;
         }
 
@@ -113,7 +113,7 @@ UnicodeUncompress(BYTE* compressed, int numberOfBytes, unicode_t* unicode)
         {
             if (compID == 16)
             {
-                // Move the first byte to the high bits of the unicode char.
+                // Move the first byte to the high bits of the Unicode character.
                 unicode[unicodeIndex] = compressed[byteIndex++] << 8;
             }
             else
@@ -122,7 +122,7 @@ UnicodeUncompress(BYTE* compressed, int numberOfBytes, unicode_t* unicode)
             }
             if (byteIndex < numberOfBytes)
             {
-                // Then the next byte to the low bits.
+                // Then put the next byte into the low bits.
                 unicode[unicodeIndex] |= compressed[byteIndex++];
             }
             unicodeIndex++;
@@ -145,7 +145,7 @@ void DecodeOSTACompressed(BYTE* id, int len, char* result)
         return;
     }
     uncompressed[ucompChars] = 0;
-    int length = MIN(ucompChars, UnicodeLength(uncompressed)) + 1 /*terminating zero*/;
+    int length = MIN(ucompChars, UnicodeLength(uncompressed)) + 1 /*null terminator*/;
 
     char final[1024];
 
@@ -390,10 +390,10 @@ void CUDF::ReadDescriptorTag(BYTE sector[], CDescriptorTag* tag)
 
 //
 // in:
-//    data
+//    data, partition
 //
 // out:
-//    ad, partition
+//    ad
 int CUDF::ShortAD(Uint8* data, CUDF::CAD* ad, WORD partNumber)
 {
     ad->Length = GET_DWORD(data, 0);
@@ -512,7 +512,7 @@ int CUDF::ReadFileEntry(Uint8* data, bool bEFE, Uint16 part, CICBTag* icbTag, CU
                 ad->Length = l_ad;
                 ad->Location = 0; // To be determined by the caller
                 ad->Partition = part;
-                return -1; // -1 tells the caller the data is inlined, but Location is not set
+                return -1; // -1 tells the caller that Location is not set yet
             }
         }
         else
@@ -521,11 +521,11 @@ int CUDF::ReadFileEntry(Uint8* data, bool bEFE, Uint16 part, CICBTag* icbTag, CU
             break;
         }
     }
-    cnt -= maxAds; // # of used ad entries
+    cnt -= maxAds; // Number of used AD entries
     if (maxAds > 0)
     {
         // Terminate the sequence
-        // And also init ad for an empty file (i.e. there isn't a AD, L_AD == 0 )
+        // Also initialize ad for an empty file (i.e. there is no AD, L_AD == 0)
         ad->Length = 0;
         ad->Flags = 0;
         ad->Location = 0; // what should we put here?
@@ -678,7 +678,7 @@ BOOL CUDF::Open(BOOL quiet)
 
         if (block > lastBlock)
         {
-            // Just to make sure we don't read in a too big file, stop after 128 sectors.
+            // Just to make sure we do not read too large a file, stop after 128 sectors.
             ret = FALSE;
             break;
         }
@@ -909,7 +909,7 @@ int CUDF::ScanDir(CUDF::CAD dirICB, char* path,
     Uint8 fileChar;
     unsigned int p;
 
-    // Scan dir for ICB of file
+    // Scan the directory for the file ICB
     lbNum = LogSector(dirICB.Location, dirICB.Partition);
     if (!ReadBlockPhys(lbNum, 2, directory))
     {
@@ -985,10 +985,10 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
 {
     CALL_STACK_MESSAGE7("CUDF::UnpackFile( , %s, %s, %s, %p, %u, %d)", srcPath, path, nameInArc, fileData, silent, toSkip);
 
-    // TODO: extraction according to allocation strategy 4096
-    // if the file is a sequence of allocation descriptors, we cannot extract it because we would need to track
-    // where the allocation descriptors point and use the correct blocks (we have no image to test on,
-    // so it is not implemented, maybe someday)
+    // TODO: extraction for allocation strategy 4096
+    // If the file is a sequence of allocation descriptors, we cannot extract it because we would need to track
+    // where the allocation descriptors point and use the correct blocks (we do not have an image to test this on,
+    // so this is not implemented yet).
 
     if (fileData == NULL)
         return UNPACK_ERROR;
@@ -1032,7 +1032,7 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
 
         CICBTag icbTag;
         CAD icbs[32]; // Each ICB can describe at most 1GB-1B
-        // -> 9 ICB's should be enough for a DVD9, but we are paranoic
+        // 9 ICBs should be enough for a DVD9, but be conservative
 
         int nicbs = ReadFileEntry(fileEntry, UDF_TAGID_EXTFENTRY == tag.ID, fp->Partition, &icbTag, icbs, sizeof(icbs) / sizeof(CAD));
 
@@ -1040,7 +1040,7 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
         delete[] fileEntry;
         fileEntry = NULL;
 
-        // Verify that the icbs describe as many bytes as needed by the file
+        // Verify that the ICBs describe as many bytes as the file requires
         ULONGLONG acc = 0;
         if (-1 == nicbs)
         {
@@ -1117,7 +1117,7 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
             BYTE track = Image->GetTrackFromExtent(picb->Location);
             DWORD extentOfs = Image->GetTrack(track)->ExtentOffset;
 
-            // it is necessary to open the track we will read from (setting the track parameters)
+            // open the track to read from (sets the track parameters)
             if (!Image->OpenTrack(track))
             {
                 Error(IDS_CANT_OPEN_TRACK, silent == 1, track);
@@ -1166,21 +1166,21 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
                     break;
                 }
 
-                if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint==TRUE, to make things faster
+                if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint == TRUE to make this faster
                 {
                     salamander->ProgressDialogAddText(LoadStr(IDS_CANCELING_OPERATION), FALSE);
                     salamander->ProgressEnableCancel(FALSE);
 
                     ret = UNPACK_CANCEL;
                     bFileComplete = FALSE;
-                    break; // action interrupted
+                    break; // operation interrupted
                 }
 
                 ULONG written;
                 // picb->Offset is nonzero only for small (less than a sector) files inlined within File Entry
                 if (!file.Write(sector + picb->Offset, nbytes, &written, name, NULL))
                 {
-                    // Error message was already displayed by SafeWriteFile()
+                    // The error message was already displayed.
                     ret = UNPACK_CANCEL;
                     bFileComplete = FALSE;
                     break;
@@ -1203,7 +1203,7 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
         if (!bFileComplete)
         {
             // because it was created with the read-only attribute, we must clear
-            // the R attribute so the file can be deleted
+            // the read-only attribute so the file can be deleted
             attrs &= ~FILE_ATTRIBUTE_READONLY;
             if (!SetFileAttributes(name, attrs))
                 Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError(), silent == 1);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/udf.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 22 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 115 comment units, 115 review results, 115 resolved results, and 115 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/udf.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/udf.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 27 provider calls, 486767 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 16 calls, 277313 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 11 calls, 209454 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
