### PR TITLE
[translation] Fix src/plugins/uniso/udfiso.cpp comments

### DIFF
--- a/src/plugins/uniso/udfiso.cpp
+++ b/src/plugins/uniso/udfiso.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/udfiso.cpp
+++ b/src/plugins/uniso/udfiso.cpp
@@ -70,7 +70,7 @@ BOOL CUDFISO::Open(BOOL quiet)
         return FALSE;
     }
 
-    // Scan HFS part but silently ignore any problem
+    // Scan the HFS part, but silently ignore any problems
     if (hfs->Open((udf || iso) ? TRUE : quiet))
         HFS = hfs;
     else
@@ -103,8 +103,8 @@ BOOL CUDFISO::ListDirectory(char* path, int session, CSalamanderDirectoryAbstrac
 
         strcat(path, partPath);
 
-        // avoid creating virtual session folder
-        // (we have created ISO virtual folder (for partition) and therefore virtual session folder is not needed)
+        // Avoid creating a virtual session folder
+        // (the ISO virtual folder for the partition has already been created, so a virtual session folder is not needed)
         if (ISO->BootRecordInfo != NULL && session == -1)
             session = 1;
         ISO->ListDirectory(path, session, dir, pluginData);
@@ -124,7 +124,7 @@ BOOL CUDFISO::ListDirectory(char* path, int session, CSalamanderDirectoryAbstrac
         if (UDF->LVD.LogicalVolumeIdentifier[3] == 0 &&
             UDF->LVD.LogicalVolumeIdentifier[5] == 0)
         {
-            // seems to be 16bit char
+            // seems to be 16-bit chars
             WideCharToMultiByte(CP_ACP, 0, (WCHAR*)(UDF->LVD.LogicalVolumeIdentifier + 2), 64, volId, sizeof(volId) - 1, 0, 0);
             volId[sizeof(volId) - 1] = 0;
         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/udfiso.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 13 comment units, 13 review results, 13 resolved results, and 13 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/udfiso.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/udfiso.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 125715 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 62274 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 63441 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
