### PR TITLE
[translation] Fix src/plugins/uniso/viewer.cpp comments

### DIFF
--- a/src/plugins/uniso/viewer.cpp
+++ b/src/plugins/uniso/viewer.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/viewer.cpp
+++ b/src/plugins/uniso/viewer.cpp
@@ -144,7 +144,7 @@ BOOL CISOImage::DumpInfo(FILE* outStream)
 {
     CALL_STACK_MESSAGE1("CISOImage::DumpInfo( )");
 
-    // display information about sessions
+    // display session information
     fprintf(outStream, LoadStr(*GetLabel() ? IDS_INFO_LABEL_LABEL : IDS_INFO_LABEL), GetLabel());
     fprintf(outStream, LoadStr(IDS_INFO_CNT_SESSIONS), Session.Count);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/viewer.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 8 comment units, 8 review results, 8 resolved results, and 8 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/viewer.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/viewer.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 86700 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43530 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 43170 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
