### PR TITLE
[translation] Fix src/plugins/uniso/xdvdfs.cpp comments

### DIFF
--- a/src/plugins/uniso/xdvdfs.cpp
+++ b/src/plugins/uniso/xdvdfs.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/xdvdfs.cpp
+++ b/src/plugins/uniso/xdvdfs.cpp
@@ -186,12 +186,12 @@ int CXDVDFS::ScanDir(DWORD sector, DWORD size, char* path, CSalamanderDirectoryA
         return ERR_TERMINATE;
     }
 
-    // read root
+    // read directory data
     if (Image->ReadBlock(sector, size, data) != size)
     {
         delete[] data;
         Error(IDS_ERROR_LISTING_IMAGE, FALSE, sector);
-        // if reading the sector with the root fails
+        // if reading the root sector fails
         return (sector == VD.RootSector) ? ERR_CONTINUE : ERR_TERMINATE;
     }
 
@@ -238,7 +238,7 @@ int CXDVDFS::ScanDir(DWORD sector, DWORD size, char* path, CSalamanderDirectoryA
             strcat(path, "\\");
             strcat(path, fileName);
 
-            // descend only when everything is OK
+            // recurse only if everything is OK
             if (ret == ERR_OK)
             {
                 ret = ScanDir(de.StartSector, de.FileSize, path, dir, pluginData);
@@ -250,7 +250,7 @@ int CXDVDFS::ScanDir(DWORD sector, DWORD size, char* path, CSalamanderDirectoryA
         }
 
         offset += 0x000E + len;
-        // align the offset to a DWORD
+        // align the offset to a DWORD boundary
         offset = ((offset + 3) / 4) * 4;
     }
 
@@ -358,14 +358,14 @@ int CXDVDFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char
                 break;
             }
 
-            if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint==TRUE, so we do not slow things down
+            if (!salamander->ProgressAddSize(nbytes, TRUE)) // delayedPaint==TRUE, so we do not slow the operation down
             {
                 salamander->ProgressDialogAddText(LoadStr(IDS_CANCELING_OPERATION), FALSE);
                 salamander->ProgressEnableCancel(FALSE);
 
                 ret = UNPACK_CANCEL;
                 bFileComplete = FALSE;
-                break; // action interrupted
+                break; // operation interrupted
             }
 
             ULONG written;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/xdvdfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 36 comment units, 36 review results, 36 resolved results, and 36 apply results.
- Branch-target comment guard passed for `src/plugins/uniso/xdvdfs.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/uniso/xdvdfs.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 204308 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 94065 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 110243 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
