### PR TITLE
[translation] Fix src/plugins/unlha/unlha.cpp comments

### DIFF
--- a/src/plugins/unlha/unlha.cpp
+++ b/src/plugins/unlha/unlha.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unlha/unlha.cpp
+++ b/src/plugins/unlha/unlha.cpp
@@ -29,7 +29,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     if (fdwReason == DLL_PROCESS_ATTACH)
         DLLInstance = hinstDLL;
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 char* LoadStr(int resID)
@@ -58,12 +58,12 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     { // reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
-                   "UnLHA" /* neprekladat! */, MB_OK | MB_ICONERROR);
+                   "UnLHA" /* do not translate */, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
     // load the language module (.slg)
-    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "UnLHA" /* neprekladat! */);
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "UnLHA" /* DO NOT TRANSLATE */);
     if (HLanguage == NULL)
         return NULL;
 
@@ -163,7 +163,7 @@ BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* 
 
     while ((gh = LHAGetHeader(f, &hdr)) == GH_SUCCESS)
     {
-        // if it ends with '\', remove it (because of directories)
+        // if it ends with '\\', remove it (for directories)
         int l = lstrlen(hdr.name) - 1;
         if (hdr.name[l] == '\\')
         {
@@ -252,7 +252,7 @@ BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* 
         ret = FALSE;
     }
 
-    // some files have already been listed, so do not pack and display them
+    // some files have already been listed, so do not discard them and display them
     if (!ret && count)
         ret = TRUE;
 
@@ -301,8 +301,8 @@ BOOL CPluginInterfaceForArchiver::UnpackOneFile(CSalamanderForOperationsAbstract
 
     if (hdr.method == LHA_UNKNOWNMETHOD && hdr.original_size != 0 /* see below : */)
     {
-        // I do not know why, but LHA sometimes packs zero-length files with a nonsensical method name...
-        // If the file length is 0, I therefore ignore the method type.
+        // For unknown reasons, LHA sometimes packs zero-length files with a nonsensical method name...
+        // If the file length is 0, the method type is therefore ignored.
         SalamanderGeneral->ShowMessageBox(LoadStr(IDS_METHOD), LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
         fclose(f);
         return FALSE;
@@ -340,7 +340,7 @@ BOOL CPluginInterfaceForArchiver::UnpackOneFile(CSalamanderForOperationsAbstract
 
     if (!uf)
     {
-        if (iLHAErrorStrId != IDS_WRITEERROR) // because of SafeWriteFile
+        if (iLHAErrorStrId != IDS_WRITEERROR) // SafeWriteFile handles write errors
             SalamanderGeneral->ShowMessageBox(LoadStr(iLHAErrorStrId), LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
         return FALSE;
     }
@@ -601,7 +601,7 @@ void CPluginInterfaceForArchiver::UnpackInnerBody(FILE* f, const char* targetDir
         {
             if (!uf)
             {
-                if (iLHAErrorStrId != IDS_WRITEERROR) // because of SafeWriteFile
+                if (iLHAErrorStrId != IDS_WRITEERROR) // SafeWriteFile handles write errors
                     SalamanderGeneral->ShowMessageBox(LoadStr(iLHAErrorStrId), LoadStr(IDS_PLUGINNAME), MSGBOX_ERROR);
                 Abort = TRUE;
                 Ret = FALSE;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unlha/unlha.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 8 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 42 comment units, 42 review results, 42 resolved results, and 42 apply results.
- Branch-target comment guard passed for `src/plugins/unlha/unlha.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unlha/unlha.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 139600 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 95128 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 44472 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
