### PR TITLE
[translation] Fix src/plugins/unmime/decoder.cpp comments

### DIFF
--- a/src/plugins/unmime/decoder.cpp
+++ b/src/plugins/unmime/decoder.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************************\
 **                                                                                      **

--- a/src/plugins/unmime/decoder.cpp
+++ b/src/plugins/unmime/decoder.cpp
@@ -446,7 +446,7 @@ BOOL CBinHexDecoder::DecodeChar(char c)
     default:
         return TRUE;
     }
-    // execution jumps here once the breaks above reach the end; a bit of a hack, sorry...
+    // Control jumps here when the breaks above are hit; a bit of a hack.
     bFinished = TRUE;
     eCharState = CS_END;
     return TRUE;
@@ -535,7 +535,7 @@ void CBinHexDecoder::DecodeBinary(BYTE b)
         {
             if (!bCalcSize && iResourceLength)
             {
-                // We are gonna loose the resource fork
+                // The resource fork will be lost
                 if (!(G.nDontShowAnymore & DSA_RESOURCE_FORK_LOST))
                 {
                     BOOL checked = FALSE;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/decoder.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 32 comment units, 32 review results, 32 resolved results, and 32 apply results.
- Branch-target comment guard passed for `src/plugins/unmime/decoder.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unmime/decoder.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 135027 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 91647 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 43380 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
