### PR TITLE
[translation] Fix src/plugins/unmime/parser.cpp comments

### DIFF
--- a/src/plugins/unmime/parser.cpp
+++ b/src/plugins/unmime/parser.cpp
@@ -129,10 +129,10 @@ int iErrorStr;
 
 #define MIN_WEIGHT 5
 
-// List of header names - used to recognize the header block. 'name' is the header name,
-// 'main' is a boolean that determines whether the header appears only in the main headers
-// of the entire mail; 'weight' is the name weight - for a block to qualify as a header, the sum
-// of the header-name weights must be at least MIN_WEIGHT.
+// List of header names used to recognize a header block. 'name' is the header name,
+// 'main' is a boolean indicating whether the header appears only in the headers
+// of the entire mail; 'weight' is the header-name weight. For a block to qualify
+// as a header, the sum of the header-name weights must be at least MIN_WEIGHT.
 
 static struct HEADERINFO
 {
@@ -194,7 +194,7 @@ static struct HEADERINFO
 // MIN_WEIGHT.
 
 static BOOL bHeaderNamesSorted = FALSE; // the list of names is sorted during the first pass
-// of ParseMailFile and bHeaderNamesSorted is set to TRUE
+// ParseMailFile sorts it and sets bHeaderNamesSorted to TRUE
 
 // comparison function for qsort and bsearch
 static int __cdecl compare_header_names(const void* elem1, const void* elem2)
@@ -533,8 +533,8 @@ static void ParseContentType(LPCSTR pszText, LPSTR pszType, int iMaxType, LPSTR 
 static BOOL GetParameter(LPSTR pszText, LPCSTR pszParam, LPSTR pszBuffer, int iBufferSize)
 {
     CALL_STACK_MESSAGE3("GetParameter(%s, , , %d)", pszText, iBufferSize);
-    // create lowercase copies of the strings so I can search case-insensitively,
-    // I was afraid to use StrStrI... (I do not know if it is available on all systems)
+    // create lowercase copies of the strings so the search can be case-insensitive,
+    // StrStrI is avoided because it may not be available on all systems
     char* text = new char[strlen(pszText) + 1];
     strcpy(text, pszText);
     CharLower(text);
@@ -685,7 +685,7 @@ static void InsertSuffix(char* filename, int suffix)
 {
     char temp[MAX_PATH];
     char* ext = strrchr(filename, '.');
-    if (ext != NULL) // ".cvspass" is an extension in Windows
+    if (ext != NULL) // ".cvspass" is treated as a file extension on Windows
     {
         *ext++ = 0;
         sprintf(temp, "%s(%ld).%s", filename, suffix, ext);
@@ -954,7 +954,7 @@ static BOOL TestUUBlock(CParserOutput* pOutput, BOOL& bEnd)
     SkipWSP(line);
     if (!*line)
         return FALSE;
-    while (*line && *line != ' ' && *line != '\t') // is a sequence of octal digits following?
+    while (*line && *line != ' ' && *line != '\t') // does a sequence of octal digits follow?
         if ((BYTE)*line < (BYTE)'0' || (BYTE)*line > (BYTE)'7')
             return FALSE;
         else
@@ -965,9 +965,9 @@ static BOOL TestUUBlock(CParserOutput* pOutput, BOOL& bEnd)
     GetWord(line, filename, MAX_PATH, " \t"); // the file name also has to be present
     SkipWSP(line);
     if (*line)
-        return FALSE; // and nothing more
+        return FALSE; // nothing else must follow
 
-    // we found a UU header
+    // we found a uuencoded header
     SaveState(); // save the position in case we need to return
     int iLineStart = InputFile.iCurrentLine;
     int size = 0;
@@ -1354,8 +1354,8 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                     }
                     goback = TRUE;
                 }
-                else // Handling the case when the previous multipart
-                {    // was not properly terminated, yet we are at a boundary
+                else // Handling the previous multipart case
+                {    // the previous multipart was not properly terminated, but we are at a boundary
                     int i;
                     for (i = STACKTOP - 1; i >= 0; i--) // one of the previous ones.
                         if (IsBoundary(cBoundaries[i], &bEnd2))
@@ -1414,7 +1414,7 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                 while ((cNextLine[0] == ' ' || cNextLine[0] == '\t') && !IsWhiteLine(cNextLine))
                 {
                     if (strlen(cLine) + strlen(cNextLine + 1) >= LINE_MAX)
-                        break; // overflow test
+                        break; // overflow check
                     pDummyDecoder->DecodeLine(cNextLine, bLast);
                     strcat(cLine, cNextLine + 1);
                     bLast = bNextLast;
@@ -1430,7 +1430,7 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                         char cType[20], cSubType[20];
                         ParseContentType(cText, cType, sizeof(cType), cSubType, sizeof(cSubType));
                         if (iMultipart < MULTIPARTSTACK_MAX && !_stricmp(cType, "multipart"))
-                        { // if the message is multipart, we care about the string that separates the individual parts
+                        { // if the message is multipart, we care about the boundary string that separates the individual parts
                             char cBoundary[BOUNDARY_MAX];
                             if (GetParameter(cText, "boundary", cBoundary, BOUNDARY_MAX))
                             {
@@ -1489,7 +1489,7 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                             p = strrchr(cDisp, '/');
                             p = max(p, p2);
                             if (p && p[1])
-                            { // Do not take empty fname from from e.g. http://www.altap.cz/
+                            { // Do not take an empty file name from URLs such as http://www.altap.cz/
                                 iNameOrigin = 3;
                                 bNextBlockIsAttachment = TRUE;
                                 strcpy(cFileName, p + 1);
@@ -1504,10 +1504,10 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                         }
                         else if (!*p)
                         {
-                            // Hack: Handle .MHT files created by MSIE7 or Win7 problem report creation tool:
+                            // Hack: Handle .MHT files created by MSIE7 or the Windows 7 problem reporting tool:
                             // Content-Location: screenshot_0001.jpeg
-                            // But right now I cannot find any example with file: :-(((
-                            // Should we look for \ and / as well?
+                            // No example using file: has been found yet.
+                            // Should we also look for \\ and /?
                             iNameOrigin = 3;
                             bNextBlockIsAttachment = TRUE;
                             strcpy(cFileName, cDisp);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/parser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 13 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 113 comment units, 113 review results, 113 resolved results, and 113 apply results.
- Branch-target comment guard passed for `src/plugins/unmime/parser.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unmime/parser.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 21 provider calls, 440686 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 12 calls, 267317 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 9 calls, 173369 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
