### PR TITLE
[translation] Fix src/plugins/unmime/unmime.cpp comments

### DIFF
--- a/src/plugins/unmime/unmime.cpp
+++ b/src/plugins/unmime/unmime.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unmime/unmime.cpp
+++ b/src/plugins/unmime/unmime.cpp
@@ -40,10 +40,10 @@ LPCTSTR KEY_APPENDCHARSET = _T("Append Charset");
 LPCTSTR KEY_LISTATTACHMENTS = _T("List Attachments");
 LPCTSTR KEY_DONTSHOWANYMORE = _T("DontShowAnymore");
 
-// ConfigVersion: 0 - default (before any configuration is loaded),
-//                1 - version with configuration in the registry (used before, only without a configuration number)
+// ConfigVersion: 0 - default (without loading configuration),
+//                1 - version with configuration in the registry (already used, but without a configuration number)
 //                2 - version after introducing the configuration number + yEnc
-//                3 - Added support for CNM (Mercury + Pegasus Mail (PMail))
+//                3 - added support for CNM (Mercury + Pegasus Mail (PMail))
 
 int ConfigVersion = 0;
 #define CURRENT_CONFIG_VERSION 3
@@ -55,7 +55,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
 {
     if (fdwReason == DLL_PROCESS_ATTACH)
         DLLInstance = hinstDLL;
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 char* LoadStr(int resID)
@@ -79,17 +79,17 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
 
     CALL_STACK_MESSAGE1("SalamanderPluginEntry()");
 
-    // this plugin is built for the current version of Salamander and newer - perform a check
+    // this plugin is built for the current version of Salamander and later - check it
     if (salamander->GetVersion() < LAST_VERSION_OF_SALAMANDER)
     { // reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
-                   "UnMIME" /* neprekladat! */, MB_OK | MB_ICONERROR);
+                   "UnMIME" /* DO NOT TRANSLATE */, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
     // load the language module (.slg)
-    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "UnMIME" /* neprekladat! */);
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "UnMIME" /* do not translate */);
     if (HLanguage == NULL)
         return NULL;
 
@@ -105,7 +105,7 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
                                    VERSINFO_VERSION_NO_PLATFORM,
                                    VERSINFO_COPYRIGHT,
                                    LoadStr(IDS_PLUGIN_DESCRIPTION),
-                                   "UnMIME" /* neprekladat! */, "eml;b64;uue;xxe;hqx;ntx;cnm");
+                                   "UnMIME" /* DO NOT TRANSLATE */, "eml;b64;uue;xxe;hqx;ntx;cnm");
 
     salamander->SetPluginHomePageURL("www.altap.cz");
 
@@ -213,11 +213,11 @@ void CPluginInterface::Connect(HWND parent, CSalamanderConnectAbstract* salamand
     salamander->AddPanelArchiver("eml;b64;uue;xxe;hqx;ntx;cnm", FALSE, FALSE);
 
     // upgrade section:
-    if (ConfigVersion < 2) // version after introducing the configuration number + yEnc
+    if (ConfigVersion < 2) // version after adding the configuration number + yEnc
     {
         salamander->AddPanelArchiver("ntx", FALSE, TRUE); // add the "ntx" extension
     }
-    if (ConfigVersion < 3) // cnm: file format used by Mercury & PMail emailing system
+    if (ConfigVersion < 3) // cnm: file format used by the Mercury & PMail email system
     {
         salamander->AddPanelArchiver("cnm", FALSE, TRUE); // add the "cnm" extension
     }
@@ -254,7 +254,7 @@ BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* 
     CALL_STACK_MESSAGE2("CPluginInterfaceForArchiver::ListArchive(, %s, ,)", fileName);
     pluginData = &PluginDataInterface;
 
-    // allocate ArchiveData - it will hold data about the contents of the "archive"
+    // Allocate ArchiveData; it will hold data about the contents of the "archive"
     CArchiveData* ArchiveData = new CArchiveData;
     ArchiveData->RefCount = 0;
 
@@ -266,7 +266,7 @@ BOOL CPluginInterfaceForArchiver::ListArchive(CSalamanderForOperationsAbstract* 
         CloseHandle(hFile);
     }
 
-    // analyze the file
+    // file analysis
     if (!ParseMailFile(fileName, &ArchiveData->ParserOutput, G.bAppendCharset))
     {
         delete ArchiveData;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/unmime.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 10 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 56 comment units, 56 review results, 56 resolved results, and 56 apply results.
- Branch-target comment guard passed for `src/plugins/unmime/unmime.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unmime/unmime.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 146441 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 78794 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 5 calls, 67647 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
