### PR TITLE
[translation] Fix src/plugins/unole/unole2.cpp comments

### DIFF
--- a/src/plugins/unole/unole2.cpp
+++ b/src/plugins/unole/unole2.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unole/unole2.cpp
+++ b/src/plugins/unole/unole2.cpp
@@ -54,7 +54,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         break;
     }
     }
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 char* LoadStr(int resID)
@@ -269,7 +269,7 @@ BOOL ParseStorage(CSalamanderDirectoryAbstract* Dir, LPSTORAGE CF, LPMALLOC pIMa
         {
             LPSTORAGE pSubStorage;
 
-            // concatenate path
+            // append to path
             if (path != oldPath)
             {
                 strcpy(oldPath, "\\");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unole/unole2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 49 comment units, 49 review results, 49 resolved results, and 49 apply results.
- Branch-target comment guard passed for `src/plugins/unole/unole2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unole/unole2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 101577 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 81131 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20446 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
