### PR TITLE
[translation] Fix src/plugins/wmobile/dialogs.cpp comments

### DIFF
--- a/src/plugins/wmobile/dialogs.cpp
+++ b/src/plugins/wmobile/dialogs.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/dialogs.cpp
+++ b/src/plugins/wmobile/dialogs.cpp
@@ -28,7 +28,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         // horizontal and vertical centering of the dialog relative to the parent
         if (Parent != NULL)
             SalamanderGeneral->MultiMonCenterWindow(HWindow, Parent, TRUE);
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
     }
     return CDialog::DialogProc(uMsg, wParam, lParam);
@@ -129,7 +129,7 @@ BOOL CProgressDlg::GetWantCancel()
     }
 
     MSG msg;
-    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) // give the user a moment ...
+    while (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE)) // briefly process pending UI messages...
     {
         if (!IsWindow(HWindow) || !IsDialogMessage(HWindow, &msg))
         {
@@ -183,13 +183,13 @@ CProgressDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (ProgressBar == NULL)
         {
             DestroyWindow(HWindow); // error -> do not open the dialog
-            return FALSE;           // end of processing
+            return FALSE;           // stop processing
         }
 
         ::SetWindowText(HWindow, Title);
         SetDlgItemText(HWindow, IDT_OPERATION, Operation);
 
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
 
     case WM_COMMAND:
@@ -279,7 +279,7 @@ CProgress2Dlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         SetDlgItemText(HWindow, IDT_OPERATION2, Operation2);
 
-        break; // request focus from DefDlgProc
+        break; // let DefDlgProc set the focus
     }
     }
     return CProgressDlg::DialogProc(uMsg, wParam, lParam);
@@ -372,11 +372,11 @@ void CChangeAttrDialog::Transfer(CTransferInfo& ti)
         DateTime_SetSystemtime(HModifiedDate, GDT_VALID, &TimeModified);
         DateTime_SetSystemtime(HCreatedDate, GDT_VALID, &TimeCreated);
         DateTime_SetSystemtime(HAccessedDate, GDT_VALID, &TimeAccessed);
-        // then set the state to disabled (cannot be done in a single operation)
+        // then disable it (cannot be done in a single operation)
         DateTime_SetSystemtime(HModifiedDate, GDT_NONE, &TimeModified);
         DateTime_SetSystemtime(HCreatedDate, GDT_NONE, &TimeCreated);
         DateTime_SetSystemtime(HAccessedDate, GDT_NONE, &TimeAccessed);
-        // populate the times
+        // populate the time fields
         DateTime_SetSystemtime(HModifiedTime, GDT_VALID, &TimeModified);
         DateTime_SetSystemtime(HCreatedTime, GDT_VALID, &TimeCreated);
         DateTime_SetSystemtime(HAccessedTime, GDT_VALID, &TimeAccessed);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 7 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 25 comment units, 25 review results, 25 resolved results, and 25 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/dialogs.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/dialogs.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
