### PR TITLE
[translation] Fix src/plugins/wmobile/dialogs.h comments

### DIFF
--- a/src/plugins/wmobile/dialogs.h
+++ b/src/plugins/wmobile/dialogs.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/wmobile/dialogs.h
+++ b/src/plugins/wmobile/dialogs.h
@@ -51,7 +51,7 @@ public:
     void Set(const char* fileName, DWORD progressTotal, BOOL dalayedPaint);
     void SetProgress(DWORD progressTotal, DWORD progress, BOOL dalayedPaint);
 
-    // empties the message queue (call often enough) and allows repainting, pressing Cancel...
+    // processes the message queue (call often enough) and allows repainting, pressing Cancel, ...
     // returns TRUE if the user wants to interrupt the operation
     BOOL GetWantCancel();
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/dialogs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 11 comment units, 11 review results, 11 resolved results, and 11 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/dialogs.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/dialogs.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
