### PR TITLE
[translation] Fix src/plugins/wmobile/fs1.cpp comments

### DIFF
--- a/src/plugins/wmobile/fs1.cpp
+++ b/src/plugins/wmobile/fs1.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/fs1.cpp
+++ b/src/plugins/wmobile/fs1.cpp
@@ -97,15 +97,15 @@ CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* plugin
         char newPath[MAX_PATH];
         strcpy(newPath, fs->Path);
 
-        if (isDir == 2) // up-dir
+        if (isDir == 2) // parent directory
         {
             char* cutDir = NULL;
-            if (SalamanderGeneral->CutDirectory(newPath, &cutDir)) // shorten the path by the last component
+            if (SalamanderGeneral->CutDirectory(newPath, &cutDir)) // remove the last component from the path
             {
                 int topIndex; // next top index, -1 -> invalid
                 if (!fs->TopIndexMem.FindAndPop(newPath, topIndex))
                     topIndex = -1;
-                // change the path in the panel
+                // change the panel path
                 SalamanderGeneral->ChangePanelPathToPluginFS(panel, pluginFSName, newPath, NULL,
                                                              topIndex, cutDir);
             }
@@ -119,9 +119,9 @@ CPluginInterfaceForFS::ExecuteOnFS(int panel, CPluginFSInterfaceAbstract* plugin
 
             if (CRAPI::PathAppend(newPath, file.Name, MAX_PATH))
             {
-                // change the path in the panel
+                // change the panel path
                 if (SalamanderGeneral->ChangePanelPathToPluginFS(panel, pluginFSName, newPath))
-                    fs->TopIndexMem.Push(backupPath, topIndex); // remember the top index for the return
+                    fs->TopIndexMem.Push(backupPath, topIndex); // remember the top index for returning
             }
         }
     }
@@ -226,7 +226,7 @@ void CTopIndexMem::Push(const char* path, int topIndex)
 
     if (ok) // matches -> remember the next top index
     {
-        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // need to discard the first top index from memory
+        if (TopIndexesCount == TOP_INDEX_MEM_SIZE) // need to discard the oldest top index
         {
             int i;
             for (i = 0; i < TOP_INDEX_MEM_SIZE - 1; i++)
@@ -236,7 +236,7 @@ void CTopIndexMem::Push(const char* path, int topIndex)
         strcpy(Path, path);
         TopIndexes[TopIndexesCount++] = topIndex;
     }
-    else // does not match -> first top index in the sequence
+    else // path does not match -> first top index in the sequence
     {
         strcpy(Path, path);
         TopIndexesCount = 1;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/fs1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 7 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 26 comment units, 26 review results, 26 resolved results, and 26 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/fs1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/fs1.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
