### PR TITLE
[translation] Fix src/plugins/wmobile/rapi.cpp comments

### DIFF
--- a/src/plugins/wmobile/rapi.cpp
+++ b/src/plugins/wmobile/rapi.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/rapi.cpp
+++ b/src/plugins/wmobile/rapi.cpp
@@ -112,7 +112,7 @@ public:
         RAPI_FUNCTIONS
 #undef Func_Operator
 
-        if (!IsGood()) // And verify everything
+        if (!IsGood()) // Verify everything
         {
             Unload();
             return FALSE;
@@ -589,7 +589,7 @@ BOOL CRAPI::FindAllFilesInTree(LPCTSTR rootPath, char (&path)[MAX_PATH], LPCTSTR
         // JR Some storage implementations return ERROR_FILE_NOT_FOUND instead of ERROR_NO_MORE_FILES
         int nError = CDynRapi::CeGetLastError();
         if (nError == ERROR_NO_MORE_FILES || nError == ERROR_FILE_NOT_FOUND)
-            return TRUE; // JR empty directory, stop
+            return TRUE; // JR: empty directory, returning
 
         char buf[2 * MAX_PATH + 100];
         DWORD err = GetLastError();
@@ -664,7 +664,7 @@ BOOL CRAPI::FindAllFilesInTree(LPCTSTR rootPath, char (&path)[MAX_PATH], LPCTSTR
         if (!FindNextFile(find, &data))
         {
             if (CDynRapi::CeGetLastError() == ERROR_NO_MORE_FILES)
-                break; // JR Everything is fine, stop
+                break; // JR everything is fine, stopping
 
             DWORD err = GetLastError();
             SalamanderGeneral->ShowMessageBox(SalamanderGeneral->GetErrorText(err), TitleWMobileError, MSGBOX_ERROR);
@@ -702,7 +702,7 @@ CRAPI::CopyFileToPC(LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName, BOOL bFai
     if (srcHandle == INVALID_HANDLE_VALUE)
         goto ONERROR_SRC;
 
-    size = GetFileSize(srcHandle, NULL); // JR REVIEW: Files larger than 4 GB likely won't exist on Windows Mobile
+    size = GetFileSize(srcHandle, NULL); //JR REVIEW: Files larger than 4 GB probably do not exist on Windows Mobile
     if (size == 0xFFFFFFFF)
         goto ONERROR_SRC;
 
@@ -748,7 +748,7 @@ CRAPI::CopyFileToPC(LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName, BOOL bFai
         }
     } while (read >= sizeof(buffer));
 
-    ::SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: should we ignore potential errors?
+    ::SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: ignore potential errors?
     ::SetFileAttributes(lpNewFileName, attr);
 
 RETURN:
@@ -839,7 +839,7 @@ CRAPI::CopyFileToCE(LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName, BOOL bFai
         }
     } while (read >= sizeof(buffer));
 
-    SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: should we ignore potential errors?
+    SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: ignore potential errors?
     SetFileAttributes(lpNewFileName, attr);
 
 RETURN:
@@ -933,7 +933,7 @@ CRAPI::CopyFile(LPCTSTR lpExistingFileName, LPCTSTR lpNewFileName, BOOL bFailIfE
         }
     } while (read >= sizeof(buffer));
 
-    SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: should we ignore potential errors?
+    SetFileTime(dstHandle, &creationTime, &accessedTime, &writeTime); // JR REVIEW: ignore potential errors?
     SetFileAttributes(lpNewFileName, attr);
 
 RETURN:
@@ -1088,7 +1088,7 @@ BOOL CRAPI::CheckAndCreateDirectory(const char* dir, HWND parent, BOOL quiet, ch
                 if (attrs != 0xFFFFFFFF) // the name exists
                 {
                     if (attrs & FILE_ATTRIBUTE_DIRECTORY)
-                        break; // we will build from this directory
+                        break; // we will create directories starting from this directory
                     else       // it is a file, that would not work...
                     {
                         sprintf(buf, LoadStr(IDS_ERR_DIRNAMEISFILE), name);
@@ -1154,7 +1154,7 @@ BOOL CRAPI::CheckAndCreateDirectory(const char* dir, HWND parent, BOOL quiet, ch
     }
     if (attrs & FILE_ATTRIBUTE_DIRECTORY)
         return TRUE;
-    else // file, that would not work...
+    else // a file; a directory cannot be created here
     {
         sprintf(buf, LoadStr(IDS_ERR_DIRNAMEISFILE), dir);
         if (errBuf != NULL)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/rapi.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 46 comment units, 46 review results, 46 resolved results, and 46 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/rapi.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/rapi.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
