### PR TITLE
[translation] Fix src/plugins/wmobile/wmobile.cpp comments

### DIFF
--- a/src/plugins/wmobile/wmobile.cpp
+++ b/src/plugins/wmobile/wmobile.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/wmobile.cpp
+++ b/src/plugins/wmobile/wmobile.cpp
@@ -8,7 +8,7 @@ CPluginInterface PluginInterface;
 // additional parts of the CPluginInterface interface
 CPluginInterfaceForFS InterfaceForFS;
 
-// ConfigVersion: 0 - no configuration was read from the Registry (plugin installation or a version without configuration - up to and including 2.5 beta 7),
+// ConfigVersion: 0 - no configuration was loaded from the Registry (plugin installation or a version without configuration - up to and including 2.5 beta 7),
 //                1 - first configuration version (since 2.5 beta 8; introduced to automatically disable the Alt+F1/F2 menu item when rapi.dll is not installed)
 
 int ConfigVersion = 0;           // version of the configuration loaded from the registry (see description above)
@@ -59,11 +59,11 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
         if (!InitCommonControlsEx(&initCtrls))
         {
             MessageBox(NULL, "InitCommonControlsEx failed!", "Error", MB_OK | MB_ICONERROR);
-            return FALSE; // DLL won't start
+            return FALSE; // DLL will not load
         }
     }
 
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 
 void OnAbout(HWND hParent)
@@ -209,7 +209,7 @@ CPluginInterface::LoadConfiguration(HWND parent, HKEY regKey, CSalamanderRegistr
 {
     CALL_STACK_MESSAGE1("CPluginInterface::LoadConfiguration(, ,)");
 
-    if (regKey != NULL) // load from the registry
+    if (regKey != NULL) // load from registry
     {
         registry->GetValue(regKey, CONFIG_VERSION, REG_DWORD, &ConfigVersion, sizeof(DWORD));
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/wmobile.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 47 comment units, 47 review results, 47 resolved results, and 47 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/wmobile.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/wmobile.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
