### PR TITLE
[translation] Fix src/plugins/wmobile/wmobile.h comments

### DIFF
--- a/src/plugins/wmobile/wmobile.h
+++ b/src/plugins/wmobile/wmobile.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/wmobile/wmobile.h
+++ b/src/plugins/wmobile/wmobile.h
@@ -149,8 +149,8 @@ public:
         Path[0] = 0;
         TopIndexesCount = 0;
     } // clear the memory
-    void Push(const char* path, int topIndex);        // store the top index for the given path
-    BOOL FindAndPop(const char* path, int& topIndex); // find the top index for the given path, FALSE -> not found
+    void Push(const char* path, int topIndex);        // stores the top index for the given path
+    BOOL FindAndPop(const char* path, int& topIndex); // finds the top index for the given path; returns FALSE if not found
 };
 
 //


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/wmobile.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 38 comment units, 38 review results, 38 resolved results, and 38 apply results.
- Branch-target comment guard passed for `src/plugins/wmobile/wmobile.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/wmobile/wmobile.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 128 provider calls, 2471147 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 88 calls, 1797040 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 40 calls, 674107 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
