### PR TITLE
[translation] Fix src/plugins/zip/sfxmake/sfxmake.cpp comments

### DIFF
--- a/src/plugins/zip/sfxmake/sfxmake.cpp
+++ b/src/plugins/zip/sfxmake/sfxmake.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <windows.h>

--- a/src/plugins/zip/sfxmake/sfxmake.cpp
+++ b/src/plugins/zip/sfxmake/sfxmake.cpp
@@ -70,26 +70,26 @@ BOOL GetChar(HANDLE file, char& c)
         return FALSE;
     }
     /*
-    switch (c)
-    {
-      case '\r': break; //dump all CRLF sequences
-      case '\n':
-        if (prev == '\r') break;
-        else return TRUE;
+        switch (c)
+        {
+          case '\r': break; //skip all CRLF sequences
+          case '\n':
+            if (prev == '\r') break;
+            else return TRUE;
 
-      case '\\': break; // read next (control) character
+          case '\\': break; //read the next control character
 
-      case 'n':  //process all \n ad  sequences
-        if (prev == '\\') c = '\n';
-        return TRUE;
+          case 'n':  //process all \n sequences
+            if (prev == '\\') c = '\n';
+            return TRUE;
 
-      case 'r': //process all \r ad  sequences
-        if (prev == '\\') c = '\r';
-        return TRUE;
+          case 'r': //process all \r sequences
+            if (prev == '\\') c = '\r';
+            return TRUE;
 
-      default: return TRUE;
-    }
-    */
+          default: return TRUE;
+        }
+        */
     return TRUE;
     // prev = c;
     //  }
@@ -265,7 +265,7 @@ int main(int argc, char* argv[])
     if (SfxFile == INVALID_HANDLE_VALUE)
         return Error("Unable to create SFX package file.");
 
-    //open file with default texts
+    // open file with default text
     HANDLE textFile = CreateFile(argv[2], GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
     if (textFile == INVALID_HANDLE_VALUE)
         return Error("Unable to open text file.");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/sfxmake/sfxmake.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 29 comment units, 29 review results, 29 resolved results, and 29 apply results.
- Branch-target comment guard passed for `src/plugins/zip/sfxmake/sfxmake.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/sfxmake/sfxmake.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 184652 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 164080 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20572 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
