### PR TITLE
[translation] Fix src/plugins/zip/zip2sfx/zip2sfx.cpp comments

### DIFF
--- a/src/plugins/zip/zip2sfx/zip2sfx.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 //#include <windows.h>

--- a/src/plugins/zip/zip2sfx/zip2sfx.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx.cpp
@@ -188,10 +188,11 @@ DWORD SalGetFileAttributes(const char* fileName)
 {
     int fileNameLen = (int)strlen(fileName);
     char fileNameCopy[3 * MAX_PATH];
-    // if the path ends with a trailing space or dot we must append '\\'; otherwise
-    // GetFileAttributes trims that character and works with a different path.
-    // The workaround still beats returning attributes of another file or directory
-    // (for "c:\\file.txt   " it ends up working with "c:\\file.txt").
+    // If the path ends with a space or dot, we must append '\\'; otherwise
+    // GetFileAttributes trims trailing spaces/dots and works with a different path.
+    // This does not work for files, but it is still better than getting attributes
+    // for a different file or directory (for "c:\\file.txt   " it works with
+    // the name "c:\\file.txt").
     if (fileNameLen > 0 && (fileName[fileNameLen - 1] <= ' ' || fileName[fileNameLen - 1] == '.') &&
         fileNameLen + 1 < _countof(fileNameCopy))
     {
@@ -200,7 +201,7 @@ DWORD SalGetFileAttributes(const char* fileName)
         fileNameCopy[fileNameLen + 1] = 0;
         return GetFileAttributes(fileNameCopy);
     }
-    else // ordinary path, nothing special here, just call the Windows GetFileAttributes
+    else // ordinary path, nothing special to handle, just call Windows GetFileAttributes
     {
         return GetFileAttributes(fileName);
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/zip2sfx/zip2sfx.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 23 comment units, 23 review results, 23 resolved results, and 23 apply results.
- Branch-target comment guard passed for `src/plugins/zip/zip2sfx/zip2sfx.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/zip2sfx/zip2sfx.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 55 provider calls, 1033894 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 47 calls, 890648 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 8 calls, 143246 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
