### PR TITLE
[translation] Fix src/plugins/zip/zip2sfx/zip2sfx2.cpp comments

### DIFF
--- a/src/plugins/zip/zip2sfx/zip2sfx2.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx2.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 //#include <windows.h>

--- a/src/plugins/zip/zip2sfx/zip2sfx2.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx2.cpp
@@ -109,7 +109,7 @@ BOOL WriteSFXHeader()
     offs += ++l;
     header.ArchiveNameOffs = offs;
     //l = lstrlen(archName);
-    //ArchiveDataOffs += l; // we accounted for this earlier
+    //ArchiveDataOffs += l; // we did not account for this before
     //offs += ++l;
     offs++;
     header.TargetDirSpecOffs = offs;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/zip2sfx/zip2sfx2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 14 comment units, 14 review results, 14 resolved results, and 14 apply results.
- Branch-target comment guard passed for `src/plugins/zip/zip2sfx/zip2sfx2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/zip2sfx/zip2sfx2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 55 provider calls, 1033894 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 47 calls, 890648 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 8 calls, 143246 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
