### PR TITLE
[translation] Fix src/plugins/zip/selfextr/comdefs.h comments

### DIFF
--- a/src/plugins/zip/selfextr/comdefs.h
+++ b/src/plugins/zip/selfextr/comdefs.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 // WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
 #ifndef __COMDEFS_H

--- a/src/plugins/zip/selfextr/comdefs.h
+++ b/src/plugins/zip/selfextr/comdefs.h
@@ -17,7 +17,7 @@ typedef struct
     unsigned Flags;
     unsigned EOCentrDirOffs;
     unsigned ArchiveSize; //size of zip archive following this header
-    short CommandOffs;    // length of the command line string following this structure, including the terminating '\0'
+    short CommandOffs;    // offset of the command line string following this structure, including the terminating '\0'
     short TextOffs;
     short TitleOffs;
     short SubDirOffs;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/selfextr/comdefs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 28 comment units, 28 review results, 28 resolved results, and 28 apply results.
- Branch-target comment guard passed for `src/plugins/zip/selfextr/comdefs.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/selfextr/comdefs.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 81 provider calls, 1377353 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 66 calls, 1124617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 252736 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
