### PR TITLE
[translation] Fix src/plugins/zip/selfextr/extended.cpp comments

### DIFF
--- a/src/plugins/zip/selfextr/extended.cpp
+++ b/src/plugins/zip/selfextr/extended.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <Tlhelp32.h>

--- a/src/plugins/zip/selfextr/extended.cpp
+++ b/src/plugins/zip/selfextr/extended.cpp
@@ -462,7 +462,7 @@ int decrypt_byte()
 
 #define CRC32(c, b) (CrcTab[((int)(c) ^ (b)) & 0xff] ^ ((c) >> 8))
 
-//Update the encryption keys with the next byte of plain text
+// Update the encryption keys with the next byte of plaintext
 int update_keys(int c)
 {
     Keys[0] = CRC32(Keys[0], c);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/selfextr/extended.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 22 comment units, 22 review results, 22 resolved results, and 22 apply results.
- Branch-target comment guard passed for `src/plugins/zip/selfextr/extended.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/selfextr/extended.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 81 provider calls, 1377353 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 66 calls, 1124617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 252736 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
