### PR TITLE
[translation] Fix src/plugins/zip/selfextr/extract.cpp comments

### DIFF
--- a/src/plugins/zip/selfextr/extract.cpp
+++ b/src/plugins/zip/selfextr/extract.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/plugins/zip/selfextr/extract.cpp
+++ b/src/plugins/zip/selfextr/extract.cpp
@@ -211,7 +211,7 @@ BOOL PathMerge(char* fullPath, const char* relativePath)
     const char* sour = relativePath;
 
     PathAddBackslash(fullPath);
-    if (relativePath[0] == '\\') //UNC or relative to root dir
+    if (relativePath[0] == '\\') // UNC or relative to the root directory
     {
         if (relativePath[1] == '\\')
             *fullPath = 0; //UNC
@@ -280,8 +280,8 @@ void i64toa(__int64 val, char* buf)
         *p++ = (char)(digval + '0'); /* a digit */
     } while (val > 0);
 
-    /* We now have the digit of the number in the buffer, but in reverse
-     order.  Thus we reverse them now. */
+    /* The digits of the number are now in the buffer, but in reverse order.
+         Thus we reverse them now. */
 
     *p-- = '\0'; /* terminate string; p points to last digit */
 
@@ -383,7 +383,7 @@ int GetName(CFileHeader* header, char* name)
         else
             *dest++ = *sour++;
     }
-    if (*(dest - 1) == '\\') //remove last slash if name specifies a directory
+    if (*(dest - 1) == '\\') // Remove the trailing slash if the name specifies a directory
         dest--;
     *dest = 0;
     if (header->Version >> 8 == HS_FAT ||
@@ -532,7 +532,7 @@ DWORD SalGetFileAttributes(const char* fileName)
         fileNameCopy[fileNameLen + 1] = 0;
         return GetFileAttributes(fileNameCopy);
     }
-    else // ordinary path, nothing special here, just call the Windows GetFileAttributes
+    else // regular path; nothing special to handle, just call Windows GetFileAttributes
     {
         return GetFileAttributes(fileName);
     }
@@ -647,7 +647,7 @@ HANDLE SafeCreateFile(char* name, DWORD attr, FILETIME* time, unsigned size)
 
 int SafeWrite(HANDLE file, const unsigned char* buffer, unsigned size)
 {
-    unsigned long bytesWritten; //number of butes read by ReadFile()
+    unsigned long bytesWritten; // number of bytes written by WriteFile()
     bool retry;
     unsigned filePos;
     LONG dummy;
@@ -698,15 +698,15 @@ void MakeCrcTable()
     const __UINT32 poly = 0xedb88320L; //polynomial exclusive-or pattern
 
     /*
-  //generate crc polonomial, using precomputed poly should be faster
-  // terms of polynomial defining this crc (except x^32):
-  static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
+      // generate CRC polynomial; using a precomputed poly should be faster
+      // terms of the polynomial defining this CRC (except x^32):
+      static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
 
-  // make exclusive-or pattern from polynomial (0xedb88320L)
-  poly = 0L;
-  for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
-    poly |= 1L << (31 - p[n]);
-*/
+      // make exclusive-or pattern from polynomial (0xedb88320L)
+      poly = 0L;
+      for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
+        poly |= 1L << (31 - p[n]);
+    */
     for (n = 0; n < 256; n++)
     {
         c = (__UINT32)n;
@@ -988,7 +988,7 @@ int Extract()
         {
             //ExtractedFiles++; should we count directories as files in the result as well?
             OutFile = INVALID_HANDLE_VALUE;
-            ok = true; //don't erase the file
+            ok = true; // do not delete the file
             goto next;
         }
         if (OutFile == INVALID_HANDLE_VALUE)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/selfextr/extract.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 7 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 62 comment units, 62 review results, 62 resolved results, and 62 apply results.
- Branch-target comment guard passed for `src/plugins/zip/selfextr/extract.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/selfextr/extract.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 81 provider calls, 1377353 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 66 calls, 1124617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 252736 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
