### PR TITLE
[translation] Fix src/plugins/zip/selfextr/selfextr.cpp comments

### DIFF
--- a/src/plugins/zip/selfextr/selfextr.cpp
+++ b/src/plugins/zip/selfextr/selfextr.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/plugins/zip/selfextr/selfextr.cpp
+++ b/src/plugins/zip/selfextr/selfextr.cpp
@@ -228,7 +228,7 @@ LONG SalRegQueryValueEx(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved,
             lpcbData != NULL &&
             (ret == ERROR_MORE_DATA || lpData == NULL && ret == ERROR_SUCCESS))
         {
-            (*lpcbData) += type == REG_MULTI_SZ ? 2 : 1; // request extra space for a possible null terminator
+            (*lpcbData) += type == REG_MULTI_SZ ? 2 : 1; // request extra space for a possible extra null terminator(s)
             return ret;
         }
         if (ret == ERROR_SUCCESS && lpData != NULL)
@@ -242,7 +242,7 @@ LONG SalRegQueryValueEx(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved,
                 }
                 else // not enough space for the null terminator in the buffer
                 {
-                    (*lpcbData) += type == REG_MULTI_SZ ? 2 : 1; // request the necessary null terminator
+                    (*lpcbData) += type == REG_MULTI_SZ ? 2 : 1; // account for the required null terminator(s)
                     return ERROR_MORE_DATA;
                 }
             }
@@ -255,7 +255,7 @@ LONG SalRegQueryValueEx(HKEY hKey, LPCSTR lpValueName, LPDWORD lpReserved,
                 }
                 else // not enough room for the second null terminator in the buffer
                 {
-                    (*lpcbData)++; // request the required null terminator
+                    (*lpcbData)++; // request space for the required null terminator
                     return ERROR_MORE_DATA;
                 }
             }
@@ -332,7 +332,7 @@ int InitExtraction(const char* name)
     direntries = *(unsigned long*)(ptr + 20 + 23 * 4); // number of dir entries
     for (section = *(unsigned short*)(ptr + 2) - 1; section >= 0; section--)
     {
-        offset += *(unsigned long*)(ptr + 20 + 24 * 4 + direntries * 8 + section * 10 * 4 + 4 * 4); // size of section
+        offset += *(unsigned long*)(ptr + 20 + 24 * 4 + direntries * 8 + section * 10 * 4 + 4 * 4); // section size
     }
     //test header consistence
     ArchiveStart = (CSelfExtrHeader*)(ArchiveBase + offset);
@@ -373,7 +373,7 @@ int InitExtraction(const char* name)
 #ifdef EXT_VER
         bool b = TargetPath[0] == 0;
 
-        if (b) //temp path specified on commandline
+        if (b) // temp path specified on the command line
 #endif         //EXT_VER
             if (GetTempPath(MAX_PATH, TargetPath) == 0)
                 return HandleError(STR_ERROR_TEMPPATH, GetLastError());
@@ -667,7 +667,7 @@ int MyWinMain()
   }
   */
 
-    // finally show the message box
+    // show the message box
     if (ArchiveStart->MBoxStyle != -1)
     {
         int r = (int)ArchiveStart->MBoxStyle < 0 ? DialogBox(HInstance, MAKEINTRESOURCE(IDD_LONGMESSAGE), NULL, LongMessageDlgProc) : MessageBox(NULL, (char*)ArchiveStart + ArchiveStart->MBoxTextOffs, (char*)ArchiveStart + ArchiveStart->MBoxTitleOffs, ArchiveStart->MBoxStyle);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/selfextr/selfextr.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 51 comment units, 51 review results, 51 resolved results, and 51 apply results.
- Branch-target comment guard passed for `src/plugins/zip/selfextr/selfextr.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/selfextr/selfextr.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 81 provider calls, 1377353 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 66 calls, 1124617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 252736 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
