### PR TITLE
[translation] Fix src/plugins/zip/add.cpp comments

### DIFF
--- a/src/plugins/zip/add.cpp
+++ b/src/plugins/zip/add.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <winioctl.h>

--- a/src/plugins/zip/add.cpp
+++ b/src/plugins/zip/add.cpp
@@ -130,7 +130,7 @@ int CZipPack::PackNormal(SalEnumSelection2 next, void* param)
                                 ProgressTotalSize += CQuadWord().SetUI64(DelFiles[0]->LocHeaderOffs);
                         }
                         else if (Config.BackupZip)
-                            ProgressTotalSize = CQuadWord().SetUI64(CentrDirOffs); //size of backuped file
+                            ProgressTotalSize = CQuadWord().SetUI64(CentrDirOffs); // size of the backed-up file
                         else
                             ProgressTotalSize = CQuadWord(0, 0);
                         ProgressTotalSize += AddTotalSize + CQuadWord(addCount, 0);
@@ -141,7 +141,7 @@ int CZipPack::PackNormal(SalEnumSelection2 next, void* param)
                             if (ErrorID && !Config.BackupZip && !ZeroZip)
                                 Recover();
                         }
-                        else //backup zip
+                        else // back up ZIP
                             if (Config.BackupZip)
                                 ErrorID = BackupZip();
                         if (!ErrorID && !UserBreak)
@@ -651,14 +651,14 @@ int CZipPack::ExportLocalHeader(CFileInfo* fileInfo, char* buffer)
     else
     {
         localHeader->CompSize = 0xFFFFFFFF;
-        Zip64Size = 8 + 8; // In Local Header, both Size and CompSize must be present, if any
+        Zip64Size = 8 + 8; // In the local header, both Size and CompSize must be present if either is.
     }
     if (fileInfo->Size < 0xFFFFFFFF)
         localHeader->Size = (__UINT32)fileInfo->Size;
     else
     {
         localHeader->Size = 0xFFFFFFFF;
-        Zip64Size = 8 + 8; // In Local Header, both Size and CompSize must be present, if any
+        Zip64Size = 8 + 8; // In the local header, both Size and CompSize must be present, if either is present
     }
     localHeader->NameLen = ExportName(buffer + sizeof(CLocalFileHeader), fileInfo);
     localHeader->ExtraLen = 0;
@@ -1129,7 +1129,7 @@ int CZipPack::MatchFiles(int& count)
             }
             lstrcpy(destName, next->Name + SourceLen + 1);
             destLen = RootLen + next->NameLen - SourceLen - (RootLen ? 0 : 1);
-            if (next->Action == AF_NOADD && next->IsDir) // this may already apply to directories; files are skipped above
+            if (next->Action == AF_NOADD && next->IsDir) // this can already apply to directories; files are skipped above
                 if (Move)
                 {
                     if (inZipLen >= destLen &&
@@ -1342,9 +1342,9 @@ int WriteOutput(char* buffer, unsigned size, void* user)
     CZipPack* pack = (CZipPack*)user;
     int error = 0;
 
-    // Note: The compressed output slightly grows if buffer content is modified here anyhow (e.g. memset)
-    // I don't know why, looks like a bug in the compressor?
-    // NOTE: The file still gets successfully decompressed even then...
+    // Note: The compressed output grows slightly if the buffer content is modified here (e.g. by memset).
+    // The cause is unknown; this appears to be a compressor bug.
+    // NOTE: The file can still be decompressed successfully afterward.
     if (pack->Options.Encrypt)
         if (pack->AESContextValid)
             SalamanderCrypt->AESEncrypt(&pack->AESContext, buffer, size);
@@ -1521,7 +1521,7 @@ int CZipPack::PackFiles()
         {
             ret = CreateCFile(&SourFile, next->Name, GENERIC_READ, FILE_SHARE_READ,
                               OPEN_EXISTING, FILE_FLAG_SEQUENTIAL_SCAN, 0, &SkipAllIOErrors,
-                              // Do not allow files over 4GB in SFX files, the SFX module probably doesn't support them
+                              // Do not allow files over 4 GB in SFX files; the SFX module probably does not support them
                               (Options.Action & PA_SELFEXTRACT) ? false : true, false);
             if (ret)
             {
@@ -1571,9 +1571,9 @@ int CZipPack::PackFiles()
 
                     next->Flag |= GPF_ENCRYPTED | GPF_DATADESCR;
                     // NOTE: Patera 2008.12.03: This FAST/SLOW flag is normally set in CDeflate::lm_init()
-                    // in deflate.cpp. But in case of encrypted files LocalHeder is written before lm_init() gets called.
-                    // IMHO it would be cleaner to do the same as with non-encrypted files.
-                    // WinZIP 12.0 complains about different GPF flags in loc & central headers otherwise.
+                    // in deflate.cpp. But for encrypted files, the local header is written before lm_init() is called.
+                    // It would be cleaner to do the same as for non-encrypted files.
+                    // Otherwise WinZIP 12.0 complains about different GPF flags in the local and central headers.
                     if (Config.Level <= 2)
                     {
                         next->Flag |= FAST;
@@ -1960,7 +1960,7 @@ int CZipPack::IsDirectoryEmpty(const char* name)
     if (search == INVALID_HANDLE_VALUE)
     {
         ProcessError(IDS_ERRACCESDIR, GetLastError(), name, PE_NORETRY | PE_NOSKIP, NULL);
-        return 1; //like an empty directory
+        return 1; // treat as an empty directory
     }
     ret = TRUE;
     do


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/add.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 116 comment units, 116 review results, 116 resolved results, and 116 apply results.
- Branch-target comment guard passed for `src/plugins/zip/add.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/add.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
