### PR TITLE
[translation] Fix src/plugins/zip/bits.cpp comments

### DIFF
--- a/src/plugins/zip/bits.cpp
+++ b/src/plugins/zip/bits.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/bits.cpp
+++ b/src/plugins/zip/bits.cpp
@@ -146,8 +146,8 @@ void CDeflate::bi_init() /* output zip file, NULL for in-memory compression */
 void CDeflate::send_bits(int value,  /* value to send */
                          int length) /* number of bits */
 {
-    /* If not enough room in bi_buf, use (valid) bits from bi_buf and
-     * (16 - bi_valid) bits from value, leaving (width - (16-bi_valid))
+    /* If there is not enough room in bi_buf, use the valid bits in bi_buf and
+     * (16 - bi_valid) bits from value, leaving (length - (16 - bi_valid))
      * unused bits in value.
      */
     if (bi_valid > (int)Buf_size - length)
@@ -165,11 +165,11 @@ void CDeflate::send_bits(int value,  /* value to send */
 }
 
 /* ===========================================================================
- * Reverse the first len bits of a code, using straightforward code (a faster
- * method would use a table)
- * IN assertion: 1 <= len <= 15
+ * Reverse the first len bits of a code using straightforward code (a faster
+ * method would use a table).
+ * Assertion: 1 <= len <= 15
  */
-unsigned CDeflate::bi_reverse(unsigned code, /* the value to invert */
+unsigned CDeflate::bi_reverse(unsigned code, /* value to reverse */
                               int len)       /* its bit length */
 {
     unsigned res = 0;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/bits.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 43 comment units, 43 review results, 43 resolved results, and 43 apply results.
- Branch-target comment guard passed for `src/plugins/zip/bits.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/bits.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
