### PR TITLE
[translation] Fix src/plugins/zip/chicon.cpp comments

### DIFF
--- a/src/plugins/zip/chicon.cpp
+++ b/src/plugins/zip/chicon.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/chicon.cpp
+++ b/src/plugins/zip/chicon.cpp
@@ -93,7 +93,7 @@ BOOL HasExtension(const char* filename, const char* extension)
 {
     CALL_STACK_MESSAGE_NONE
     const char* dot = strrchr(filename, '.');
-    if (dot != NULL) // ".cvspass" is extension in Windows
+    if (dot != NULL) // ".cvspass" is an extension in Windows
     {
         if (lstrcmpi(++dot, extension) == 0)
             return TRUE;
@@ -189,7 +189,7 @@ CIcon* LoadIconsFromDirectory(HINSTANCE module, LPICONDIR directory, BOOL isIco)
         if (isIco)
             icons[i].lpData = LoadIconDataFromICO((HANDLE)module, directory->idEntries[i].dwImageOffset, directory->idEntries[i].dwBytesInRes);
         else
-            icons[i].lpData = LoadIconDataFromEXE(module, directory->idEntries[i].dwImageOffset /*it is ID*/);
+            icons[i].lpData = LoadIconDataFromEXE(module, directory->idEntries[i].dwImageOffset /* ID */);
         if (!icons[i].lpData)
         {
             DestroyIcons(icons, i);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/chicon.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 17 comment units, 17 review results, 17 resolved results, and 17 apply results.
- Branch-target comment guard passed for `src/plugins/zip/chicon.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/chicon.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
