### PR TITLE
[translation] Fix src/plugins/zip/common.cpp comments

### DIFF
--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -41,13 +41,13 @@ const CConfiguration DefConfig =
     {
         6,                            // Compression level
         EM_ZIP20,                     // Encryption Method
-        false,                        //don't add empty directories to zip
+        false,                        // Do not add empty directories to the ZIP archive.
         true,                         //create temporary backup of zip
         true,                         //display exteded pack options dialog
         false,                        //set zip file time to the newest file time
         {"1423", {0}, {0}, {0}, {0}}, //volume sizes
         {0, 0, 0, 0, 0},              //volume size units
-        true,                         //automatic volume size last used
+        true,                         // whether automatic volume size was used last time
         false,                        //automatically expand multi-volume archives on non-removable disks
         0,                            //config version (0 - default; 1 - beta 3; 2 - beta 4)
         "english.sfx",                //default sfx package
@@ -57,8 +57,8 @@ const CConfiguration DefConfig =
         TRUE,                         // winzip compatible multi-volume archive names
         // Custom columns:
         TRUE, // Show custom column Packed Size
-        0,    // LO/HI-WORD: left/right panel: Width for Packed Size column
-        0     // LO/HI-WORD: left/right panel: FixedWidth for Packed Size column
+        0,    // LOWORD/HIWORD: left/right panel width for the Packed Size column
+        0     // LO/HI-WORD: fixed width of the Packed Size column in the left/right panel
 };
 
 const CExtendedOptions DefOptions;
@@ -76,7 +76,7 @@ BOOL WINAPI DllMain(HINSTANCE hinstDLL, DWORD fdwReason, LPVOID lpvReserved)
     {
         DLLInstance = hinstDLL;
     }
-    return TRUE; // DLL can be loaded
+    return TRUE; // Allow the DLL to load
 }
 #endif //SSZIP
 
@@ -322,12 +322,12 @@ int CZipCommon::CheckZip()
 int CZipCommon::Read(CFile* file, void* buffer, unsigned bytesToRead,
                      unsigned* bytesRead, bool* skipAll)
 {
-    CALL_STACK_MESSAGE_NONE // time-critical method
+    CALL_STACK_MESSAGE_NONE // performance-critical method
                             //  CALL_STACK_MESSAGE3("CZipCommon::Read(, , 0x%X, , ) file: %s", bytesToRead, file->FileName);
         unsigned long read; //number of butes read by ReadFile()
     unsigned long toRead;   //number of butes read by ReadFile()
     int result;             //temp variable
-    int errorID;            //error string identifier
+    int errorID;            // error message identifier
     int lastError;          //value returned by GetLastError()
 
     if (file->Size > file->FilePointer)
@@ -351,7 +351,7 @@ int CZipCommon::Read(CFile* file, void* buffer, unsigned bytesToRead,
                 file->FilePointer + toRead <= file->RealFilePointer + file->BufferPosition)
             {
                 int offset = int(file->FilePointer - file->RealFilePointer);
-                // if the requested data are entirely in the buffer, just copy them
+                // if the requested data are fully in the buffer, just copy them
                 memcpy(buffer, file->InputBuffer + offset, toRead);
                 file->FilePointer += toRead;
                 if (bytesRead)
@@ -667,7 +667,7 @@ int CZipCommon::ProcessError(int errorID, int lastError, const char* fileName,
     if (skipAll && *skipAll)
         exitCode = ERR_SKIP;
     else
-    { //process error and display proper dialog
+    { // Process the error and display the appropriate dialog
         if (lastError)
         {
             char lastErrorBuf[1024]; //temp variable
@@ -692,7 +692,7 @@ int CZipCommon::ProcessError(int errorID, int lastError, const char* fileName,
 
         if (flags & PE_QUIET)
             result = DIALOG_CANCEL;
-        else //display dialog
+        else // display the dialog
             if (flags & PE_NORETRY)
                 if (flags & PE_NOSKIP)
                 {
@@ -862,7 +862,7 @@ int CZipCommon::FindEOCentrDirSig(BOOL* success)
                         break;
                     }
             }
-            position -= bufSize - 3; //tree overlapping bytes
+            position -= bufSize - 3; //three overlapping bytes
             i--;
         }
         if (!error && !found && position + 64 * 1024 + 22 >= ZipFile->Size)
@@ -908,8 +908,8 @@ int CZipCommon::FindEOCentrDirSig(BOOL* success)
                                     break;
                                 }
                                 ZipFile->FilePointer = EOCentrDirOffs + sizeof(CEOCentrDirRecord);
-                                // skipAll=true prevents Read showing EOF error. We show a better
-                                // error ourselves immediatelly
+                                // skipAll=true prevents Read from showing an EOF error. We show a better
+                                // error ourselves immediately
                                 bool skipAll = true;
                                 if (Read(ZipFile, Comment, EOCentrDir.CommentLen, NULL, &skipAll))
                                 {
@@ -1078,11 +1078,11 @@ int CZipCommon::FindZip64EOCentrDirLocator()
     Zip64 = true;
     if (zip64Record.DiskNum < 0xFFFF)
     {
-        // we keep this value unfixed so we can later recognize a weird ZIP file
-        // and refuse its modification, so far we have encountered a single file
-        // like this and we had trouble with deleting files inside the archive,
-        // which ended with the corrupted archive data)
-        // TODO save manison.zip to some repository for the weird ZIPs and put a correct reference here
+        // we keep this value unchanged so we can later recognize a weird ZIP file
+        // and refuse to modify it; so far we have encountered only one file
+        // like this, and deleting files inside the archive caused
+        // the archive data to become corrupted
+        // TODO: save manison.zip in a repository of weird ZIPs and add a correct reference here
         //EOCentrDir.DiskNum = __UINT16(zip64Record.DiskNum);
     }
     if (EOCentrDir.StartDisk == 0xFFFF)
@@ -1130,7 +1130,7 @@ int CZipCommon::CheckForExtraBytes()
 
     ExtraBytes = 0;
 
-    // do not check for extra bytes - too much work for little benefit
+    // extra bytes are not checked: too much work for little benefit
     if (MultiVol)
         return 0;
 
@@ -1473,7 +1473,7 @@ int CZipCommon::ProcessName(CFileHeader* fileHeader, char* outputName)
             *dest++ = *sour++;
         }
     }
-    if (dest > outputName && *(dest - 1) == '\\') //skip last slash if name specifies a directory
+    if (dest > outputName && *(dest - 1) == '\\') // Skip the trailing slash if the name specifies a directory
     {
         dest--;
         // set the directory attribute; some archivers do not set attributes
@@ -1492,7 +1492,7 @@ int CZipCommon::ProcessName(CFileHeader* fileHeader, char* outputName)
     if (!(fileHeader->Flag & GPF_UTF8) && ((fileHeader->Version >> 8 == HS_FAT /*0*/) ||
                                            (fileHeader->Version >> 8 == HS_HPFS /*6*/) ||
                                            //       ((fileHeader->Version >> 8 == HS_NTFS/*11*/) && ((fileHeader->Version & 0x0F) == 0x50)) // Patera 2010.03.30: This doesn't make sense -> disabled
-                                           // The following line got inspiration in MultiArc plugin of FAR
+                                           // The following line was inspired by the MultiArc plugin for FAR
                                            ((fileHeader->Version >> 8 == HS_NTFS /*11*/) && (((fileHeader->Version & 0xFF) <= 20) || ((fileHeader->Version & 0xFF) >= 25)))))
         // ZIP built-in to WinXP writes Version 0x0b14 and uses OEM
         // AS writes version 0x0016 and uses OEM
@@ -1746,7 +1746,7 @@ LABEL_QuickSortNames:
         }
     } while (i <= j); // do they have to match?
 
-    // the following "nice" code was replaced with code that saves a lot of stack (max. log(N) recursion depth)
+    // the following "nice" code was replaced with code that uses significantly less stack space (max. log(N) recursion depth)
     //  if (left < j) QuickSortNames(left, j, names, unix);
     //  if (i < right) QuickSortNames(i, right, names, unix);
 
@@ -1792,7 +1792,7 @@ bool BSearchName(LPCTSTR name, int ItemNumber, int left, int right, TIndirectArr
     {
         mid = (left + right) >> 1;
         c = respectCase ? _tcscmp(name, names[mid]->Name) : SalamanderGeneral->StrICmp(name, names[mid]->Name);
-        // Files are matched only when the ItemNumber also matches
+        // Files match only when ItemNumber matches or either ItemNumber is -1
         if (c == 0)
         {
             if ((ItemNumber == names[mid]->ItemNumber) || (-1 == names[mid]->ItemNumber) || (-1 == ItemNumber))
@@ -1849,7 +1849,7 @@ int CZipCommon::MatchFiles(TIndirectArray2<CFileInfo>& files, TIndirectArray2<CE
     for (cnt = 0; readSize < CentrDirSize && !errorID; cnt++)
     {
         unsigned int s;
-        if (centrDir) //for files deletion
+        if (centrDir) // for deleting files
         {
             centralHeader = (CFileHeader*)(centrDir + readSize);
             if (readSize + sizeof(CFileHeader) > CentrDirSize ||
@@ -1930,7 +1930,7 @@ int CZipCommon::MatchFiles(TIndirectArray2<CFileInfo>& files, TIndirectArray2<CE
         }
         if (!errorID)
         {
-            if (centrDir) //for files deletion
+            if (centrDir) // when deleting files
                 MatchedTotalSize += CQuadWord().SetUI64(fileInfo->CompSize);
             else
                 MatchedTotalSize += CQuadWord().SetUI64(fileInfo->Size);
@@ -2537,7 +2537,7 @@ BOOL PathAppend(LPTSTR  pPath, LPCTSTR pMore)
     return TRUE;
   }
   int len = lstrlen(pPath);
-  // trim the trailing backslash before appending
+  // add a backslash before appending
   if (len > 1 && pPath[len - 1] != '\\' && pMore[0] != '\\')
   {
     pPath[len] = '\\';


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/common.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 21 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 181 comment units, 181 review results, 181 resolved results, and 181 apply results.
- Branch-target comment guard passed for `src/plugins/zip/common.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/common.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
