### PR TITLE
[translation] Fix src/plugins/zip/common.h comments

### DIFF
--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -163,7 +163,7 @@ public:
     int RootLen; //length of ZipRoot
     bool ZeroZip;
     QWORD EOCentrDirOffs;           //offset of end of central directory record
-    QWORD Zip64EOCentrDirOffs;      //offset of zip 64 end of central directory record
+    QWORD Zip64EOCentrDirOffs;      //offset of Zip64 end of central directory record
     CEOCentrDirRecordEx EOCentrDir; //end of central directory record
     QWORD CentrDirSize;
     QWORD CentrDirOffs;
@@ -173,7 +173,7 @@ public:
     QWORD ExtraBytes;
     CSalamanderForOperationsAbstract* Salamander;
     int ErrorID;
-    CQuadWord MatchedTotalSize; //total uncopressed size of all files
+    CQuadWord MatchedTotalSize; //total uncompressed size of all files
                                 //that are about to be extracted
     CQuadWord ProgressTotalSize;
     bool Fatal;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/common.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 59 comment units, 59 review results, 59 resolved results, and 59 apply results.
- Branch-target comment guard passed for `src/plugins/zip/common.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/common.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
