### PR TITLE
[translation] Fix src/plugins/zip/crypt.cpp comments

### DIFF
--- a/src/plugins/zip/crypt.cpp
+++ b/src/plugins/zip/crypt.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/crypt.cpp
+++ b/src/plugins/zip/crypt.cpp
@@ -34,7 +34,7 @@ __forceinline int decrypt_byte(__UINT32* keys)
 extern CSalamanderGeneralAbstract* SalamanderGeneral;
 #define CRC32(c, b) (SalamanderGeneral->UpdateCrc32(&b, 1, c ^ 0xffffffffL) ^ 0xffffffffL)
 
-//Update the encryption keys with the next byte of plain text
+// Update the encryption keys with the next byte of plaintext
 __forceinline int update_keys(int c, __UINT32* keys)
 {
     CALL_STACK_MESSAGE_NONE
@@ -48,8 +48,8 @@ __forceinline int update_keys(int c, __UINT32* keys)
     return c;
 }
 
-//initialize the encryption keys and the random header according to
-//the given password.
+// Initialize the encryption keys from
+// the given password.
 void init_keys(const char* password, __UINT32* keys)
 {
     CALL_STACK_MESSAGE2("init_keys(%s, )", password);
@@ -69,7 +69,7 @@ int testkey(const char* password, const char* header, char check,
     CALL_STACK_MESSAGE4("testkey(%s, %s, %u, )", password, header, check);
     char buf[ENCRYPT_HEADER_SIZE]; //decrypted header
 
-    //set keys and save the encrypted header
+    //set keys and copy the encrypted header
     init_keys(password, keys);
     CopyMemory(buf, header, ENCRYPT_HEADER_SIZE);
     //decrypt header
@@ -78,10 +78,10 @@ int testkey(const char* password, const char* header, char check,
     if (buf[ENCRYPT_HEADER_SIZE - 1] == check)
         return 0;
     else
-        return -1; // bad
+        return -1; // check failed
 }
 
-//test password and set up keys
+// Test the password and set up the keys
 int InitKeys(const char* password, const char* header, char check,
              __UINT32* keys)
 {
@@ -103,7 +103,7 @@ int InitKeys(const char* password, const char* header, char check,
     return ret;
 }
 
-//decrypt buffer
+// decrypt the buffer
 void Decrypt(char* buffer, unsigned size, __UINT32* keys)
 {
     CALL_STACK_MESSAGE3("Decrypt(%p, %u, , )", buffer, size);
@@ -126,7 +126,7 @@ void FillBufferWithRandomData(char* buf, int len)
         *buf++ = (rand() >> 7) & 0xff;
 }
 
-//crypt encryption header
+// Encrypt the ZIP encryption header
 void CryptHeader(const char* password, char* header, unsigned short check,
                  __UINT32* keys)
 {
@@ -151,7 +151,7 @@ void CryptHeader(const char* password, char* header, unsigned short check,
     Encrypt(header, ENCRYPT_HEADER_SIZE, keys);
 }
 
-//encrypt buffer
+// encrypts buffer
 void Encrypt(char* buffer, unsigned size, __UINT32* keys)
 {
     CALL_STACK_MESSAGE3("Encrypt(%p, %u, , )", buffer, size);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/crypt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 8 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/zip/crypt.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/crypt.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
