### PR TITLE
[translation] Fix src/plugins/zip/deflate.cpp comments

### DIFF
--- a/src/plugins/zip/deflate.cpp
+++ b/src/plugins/zip/deflate.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/deflate.cpp
+++ b/src/plugins/zip/deflate.cpp
@@ -307,15 +307,15 @@ void CDeflate::fill_window()
          */
         if (more == (unsigned)EOF)
         {
-            /* Very unlikely, but possible on 16 bit machine if strstart == 0
-             * and lookahead == 1 (input done one byte at time)
-             */
+            /* Very unlikely, but possible on a 16-bit machine if strstart == 0
+                         * and lookahead == 1 (input done one byte at a time)
+                         */
             more--;
 
             /* For MMAP or BIG_MEM, the whole input file is already in memory
-         * so we must not perform sliding. We must however call file_read in
-         * order to compute the crc, update lookahead and possibly set eofile.
-         */
+             * so we must not perform sliding. We must, however, call ReadData to
+             * compute the CRC, update lookahead, and possibly set eofile.
+             */
         }
         else if (strstart >= WSIZE + MAX_DIST && sliding)
         {
@@ -382,8 +382,8 @@ void CDeflate::fill_window()
 }
 
 /* ===========================================================================
- * Processes a new input file and return its compressed length. This
- * function does not perform lazy evaluationof matches and inserts
+ * Processes a new input file and returns its compressed length. This
+ * function does not perform lazy evaluation of matches and inserts
  * new strings in the dictionary only for unmatched strings or for short
  * matches. It is used only for the fast compression options.
  */
@@ -407,9 +407,9 @@ ullg CDeflate::deflate_fast()
         if (hash_head != NIL && strstart - hash_head <= MAX_DIST)
         {
             /* To simplify the code, we prevent matches with the string
-             * of window index 0 (in particular we have to avoid a match
-             * of the string with itself at the start of the input file).
-             */
+                         * at window index 0 (in particular we have to avoid a match
+                         * of the string with itself at the start of the input file).
+                         */
 #ifndef HUFFMAN_ONLY
             match_length = longest_match(hash_head);
 #endif


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/deflate.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 86 comment units, 86 review results, 86 resolved results, and 86 apply results.
- Branch-target comment guard passed for `src/plugins/zip/deflate.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/deflate.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
