### PR TITLE
[translation] Fix src/plugins/zip/del.cpp comments

### DIFF
--- a/src/plugins/zip/del.cpp
+++ b/src/plugins/zip/del.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/del.cpp
+++ b/src/plugins/zip/del.cpp
@@ -311,7 +311,7 @@ void CZipPack::UpdateCentrDir(CFileInfo* curFile, CFileInfo* nextFile, QWORD del
             }
             else
             {
-                // We leave Zip64 record here even when no longer needed, it is not a violation
+                // We leave the Zip64 record here even when it is no longer needed; this is not a violation
                 *(QWORD*)locHeaderOffsOffs = locHeaderOffs;
             }
         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/del.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 18 comment units, 18 review results, 18 resolved results, and 18 apply results.
- Branch-target comment guard passed for `src/plugins/zip/del.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/del.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
