### PR TITLE
[translation] Fix src/plugins/zip/explode.cpp comments

### DIFF
--- a/src/plugins/zip/explode.cpp
+++ b/src/plugins/zip/explode.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/explode.cpp
+++ b/src/plugins/zip/explode.cpp
@@ -317,10 +317,10 @@ int explode_lit(CDecompressionObject* decompress,
     mdl = mask_bits[bdl];
     s = (ulg)decompress->ucsize;
 
-    while (s > 0) /* do until ucsize bytes uncompressed */
+    while (s > 0) /* repeat until ucsize bytes have been uncompressed */
     {
         NEEDBITS(decompress, 1)
-        if (b & 1) /* then literal--decode it */
+        if (b & 1) /* then decode the literal */
         {
             DUMPBITS(1)
             s--;
@@ -383,7 +383,7 @@ int explode_lit(CDecompressionObject* decompress,
                     w += e;
                     d += e;
                 }
-                else /* do it slow to avoid memcpy() overlap */
+                else /* copy byte by byte to avoid overlap */
 #endif               /* !NOMEMCPY */
                     do
                     {
@@ -408,7 +408,7 @@ int explode_lit(CDecompressionObject* decompress,
         TRACE_E("flush returned error");
         return 5;
     }
-    // this exposes the CRC
+    // this detects the CRC
     //
     // if (G.csize + G.incnt + (k >> 3))   /* should have read csize bytes, but */
     // {                        /* sometimes read one too many:  k>>3 compensates */
@@ -437,7 +437,7 @@ int explode_nolit(CDecompressionObject* decompress,
     ulg b;           /* bit buffer */
     unsigned k;      /* number of bits in bit buffer */
     unsigned u;      /* true if unflushed */
-    int retval = 0;  /* error code returned: initialized to "no error" */
+    int retval = 0;  /* returned error code, initialized to "no error" */
 
     uch* redirSlide;
     unsigned wsize;
@@ -453,7 +453,7 @@ int explode_nolit(CDecompressionObject* decompress,
     mdl = mask_bits[bdl];
     s = (ulg)decompress->ucsize;
 
-    while (s > 0) /* do until ucsize bytes uncompressed */
+    while (s > 0) /* continue until ucsize bytes have been uncompressed */
     {
         NEEDBITS(decompress, 1)
         if (b & 1) /* then literal--get eight bits */
@@ -480,7 +480,7 @@ int explode_nolit(CDecompressionObject* decompress,
             d = (unsigned)b & mdl;
             DUMPBITS(bdl)
             DECODEHUFT(decompress, td, bd, md) /* get coded distance high bits */
-            d = w - d - t->v.n;                /* construct offset */
+            d = w - d - t->v.n;                /* compute offset */
             DECODEHUFT(decompress, tl, bl, ml) /* get coded length */
             n = t->v.n;
             if (e) /* get length extra bits */
@@ -520,7 +520,7 @@ int explode_nolit(CDecompressionObject* decompress,
                     w += e;
                     d += e;
                 }
-                else /* do it slow to avoid memcpy() overlap */
+                else /* copy slowly to avoid memcpy() overlap */
 #endif               /* !NOMEMCPY */
                     do
                     {
@@ -545,7 +545,7 @@ int explode_nolit(CDecompressionObject* decompress,
         TRACE_E("flush returned error");
         return 5;
     }
-    // this catches the CRC
+    // The CRC check catches this
     // if (G.csize + G.incnt + (k >> 3))   /* should have read csize bytes, but */
     // {                        /* sometimes read one too many:  k>>3 compensates */
     //   G.used_csize = G.lrec.csize - G.csize - G.incnt - (k >> 3);
@@ -632,7 +632,7 @@ int Explode(CDecompressionObject* decompress)
             huft_free(decompress, tb);
         return (int)r;
     }
-    if (decompress->Flag & 2) /* true if 8K */
+    if (decompress->Flag & 2) /* TRUE for 8K */
     {
         bdl = 7;
         r = huft_build(decompress, l, 64, 0, cpdist8, extra, &td, &bd);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/explode.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 10 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 112 comment units, 112 review results, 112 resolved results, and 112 apply results.
- Branch-target comment guard passed for `src/plugins/zip/explode.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/explode.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
