### PR TITLE
[translation] Fix src/plugins/zip/extract.cpp comments

### DIFF
--- a/src/plugins/zip/extract.cpp
+++ b/src/plugins/zip/extract.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <tchar.h>

--- a/src/plugins/zip/extract.cpp
+++ b/src/plugins/zip/extract.cpp
@@ -1136,7 +1136,7 @@ int CZipUnpack::UnBZIP2File(CFileInfo* fileInfo, int* errorID)
         break;
     }
     case 3: // Out of memory
-    case 4: // Error uncompressing BZIP2 stream
+    case 4: // Error decompressing the BZIP2 stream
         switch (ProcessError(
             ret == 3 ? IDS_LOWMEM : IDS_ERRBZIP2,
             0, FileNameDisp,
@@ -1324,7 +1324,7 @@ int CZipUnpack::ExtractSingleFile(char* targetDir, int targetDirLen,
                                     WORD pwdVerFile;
                                     bool repeat;
 
-                                    // AES v2 doesn't store CRC, seems to be created by TC
+                                    // AES v2 does not store a CRC; it seems to be created by TC
                                     if (AES_VERSION_2 == aesExtraField.Version)
                                         bCheckCRC = false;
                                     ZipFile->FilePointer = fileInfo->DataOffset;
@@ -1440,7 +1440,7 @@ int CZipUnpack::ExtractSingleFile(char* targetDir, int targetDirLen,
                                             break;
                                         }
                                     //                    if (i >= Passwords.Count)// pwd not found in cache
-                                    if (!bFound) // pwd not found in cache
+                                    if (!bFound) // Password not found in cache
                                         do
                                         {
                                             repeat = false;
@@ -1920,7 +1920,7 @@ int CZipUnpack::SafeCreateCFile(CFile** file, const char* fileName, const char* 
                 {
                     if (q == CQuadWord(0, 0x80000000))
                     {
-                        // allocation failed and we will not attempt it again
+                        // allocation failed and we will not try again
                         AllocateWholeFile = false;
                         TestAllocateWholeFile = false;
                     }
@@ -2010,7 +2010,7 @@ LABEL_QuickSortHeaders2:
     {
         if (i < right)
         {
-            if (j - left < right - i) // both "halves" need sorting; recurse into the smaller one and handle the other via goto
+            if (j - left < right - i) // both "halves" need to be sorted, so recurse into the smaller one and process the other via "goto"
             {
                 QuickSortHeaders2(left, j, headers);
                 left = i;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/extract.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 49 comment units, 49 review results, 49 resolved results, and 49 apply results.
- Branch-target comment guard passed for `src/plugins/zip/extract.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/extract.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
