### PR TITLE
[translation] Fix src/plugins/zip/inflate.h comments

### DIFF
--- a/src/plugins/zip/inflate.h
+++ b/src/plugins/zip/inflate.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/inflate.h
+++ b/src/plugins/zip/inflate.h
@@ -72,7 +72,7 @@ typedef struct
 //decopmression object
 
 typedef int (*FProgressMonitor)(CDecompressionObject*);
-//if return zero value decompression is aborted
+// If zero is returned, decompression is aborted.
 
 struct tagCDecompressionObject
 {
@@ -99,7 +99,7 @@ struct tagCDecompressionObject
     unsigned Flag;          //general purpose bit flag
 
     //unshrink + unreduce
-    unsigned __int64 CompBytesLeft; //bytes left to decompress
+    unsigned __int64 CompBytesLeft; //compressed bytes left to decompress
 
     //unreduce
     int Method;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/inflate.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 56 comment units, 56 review results, 56 resolved results, and 56 apply results.
- Branch-target comment guard passed for `src/plugins/zip/inflate.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/inflate.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
