### PR TITLE
[translation] Fix src/plugins/zip/iosfxset.cpp comments

### DIFF
--- a/src/plugins/zip/iosfxset.cpp
+++ b/src/plugins/zip/iosfxset.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/iosfxset.cpp
+++ b/src/plugins/zip/iosfxset.cpp
@@ -311,18 +311,18 @@ void HandlePathRelativeToZip2Sfx(char* path, const char* zip2sfxDir)
     }
 }
 
-// return values
+// Return values
 //
 // 0 OK
-// invalid target_dir specified:
-//   1 bad temp
+// Invalid target_dir specified:
+//   1 invalid temp
 //   2 missing right parenthesis
 //   3 unknown keyword in $()
-//   4 bad key name
+//   4 invalid key name
 // 5 missing settings version
-// 6 incorrect settings version
-// 7 incorrect data format
-// 8 agree disagree buttons used for classical message box
+// 6 invalid settings version
+// 7 invalid data format
+// 8 Agree/Disagree buttons used for a standard message box
 
 int ImportSFXSettings(const char* textData, CSfxSettings* settings, const char* zip2sfxDir)
 {
@@ -621,7 +621,7 @@ int ImportSFXSettings(const char* textData, CSfxSettings* settings, const char* 
 // 3 unknown keyword in $()
 // 4 bad key name
 //
-// higher word contains index of where the syntax error occured in the target dir string
+// higher word contains the index of where the syntax error occurred in the target dir string
 
 DWORD
 ParseTargetDir(const char* path, unsigned* targetDir, const char** subDir,
@@ -682,7 +682,7 @@ ParseTargetDir(const char* path, unsigned* targetDir, const char** subDir,
             // also check that the string inside the brackets is valid
             if (iterator - path + 2 <= 0)
             {
-                return 3 + (2 << 16); // empty brackets
+                return 3 + (2 << 16); // empty parentheses
             }
             if (path[1] == '(')
             {
@@ -690,7 +690,7 @@ ParseTargetDir(const char* path, unsigned* targetDir, const char** subDir,
                 {
                     if (iterator[1] != 0)
                     {
-                        return 1 + (DWORD)(((iterator - path) + 1) << 16); // nothing may follow after $(Temp)
+                        return 1 + (DWORD)(((iterator - path) + 1) << 16); // nothing may follow $(Temp)
                     }
                     if (targetDir)
                         *targetDir = SE_TEMPDIREX;
@@ -723,7 +723,7 @@ ParseTargetDir(const char* path, unsigned* targetDir, const char** subDir,
 
                 return 3 + (2 << 16); // invalid keyword
             }
-            else // otherwise fill dirSpec
+            else // optionally fill dirSpec
             {
                 if (path[1] == '[')
                 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/iosfxset.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 33 comment units, 33 review results, 33 resolved results, and 33 apply results.
- Branch-target comment guard passed for `src/plugins/zip/iosfxset.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/iosfxset.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
