### PR TITLE
[translation] Fix src/plugins/zip/prevsfx.cpp comments

### DIFF
--- a/src/plugins/zip/prevsfx.cpp
+++ b/src/plugins/zip/prevsfx.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/prevsfx.cpp
+++ b/src/plugins/zip/prevsfx.cpp
@@ -145,12 +145,12 @@ INT_PTR WINAPI SfxPreviewDlgProc(HWND dlg, UINT uMsg, WPARAM wParam, LPARAM lPar
         dlgWinAboutHeigth = r.bottom - r.top;
         RECT r2;
         GetWindowRect(GetDlgItem(dlg, IDC_SEPARATOR), &r2);
-        // an application built with a newer platform toolset handles dialog sizes differently; see
+        // an application built with a newer Platform Toolset handles window sizes differently; see
         // https://social.msdn.microsoft.com/Forums/vstudio/en-US/7ca548b5-8931-41dc-ac1d-ed9aed223d7a/different-dialog-box-position-and-size-with-visual-c-2012
         // https://connect.microsoft.com/VisualStudio/feedback/details/768135/different-dialog-box-size-and-position-when-compiled-in-visual-c-2012-vs-2010-2008
-        // therefore the original logic no longer works (in VC2012+ the window is shorter than in VC2010-): dlgWinHeigth = r2.top - r.top + 1;
-        // fix: dlgWinHeigth = full window height minus the difference between the client area height and the separator position
-        //         within the dialog's client area
+        // therefore the original solution does not work (in VC2012+ the window is shorter than in VC2010-): dlgWinHeigth = r2.top - r.top + 1;
+        // solution: dlgWinHeigth = full window height minus the difference between the dialog client area height and the separator position
+        //           within the dialog client area
         POINT p;
         p.x = r2.left;
         p.y = r2.top;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/prevsfx.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 5 comment units, 5 review results, 5 resolved results, and 5 apply results.
- Branch-target comment guard passed for `src/plugins/zip/prevsfx.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/prevsfx.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
