### PR TITLE
[translation] Fix src/plugins/zip/unreduce.cpp comments

### DIFF
--- a/src/plugins/zip/unreduce.cpp
+++ b/src/plugins/zip/unreduce.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/unreduce.cpp
+++ b/src/plugins/zip/unreduce.cpp
@@ -128,7 +128,7 @@ int Unreduce(CDecompressionObject* decompress) /* expand probabilistically reduc
     short Len = 0;
     unsigned __int64 s = decompress->ucsize; /* number of bytes left to decompress */
     unsigned w = 0;                          /* position in output window slide[] */
-    unsigned u = 1;                          /* true if slide[] unflushed */
+    unsigned u = 1;                          /* true if slide[] has not been flushed */
     uch Slen[256];
     uch* slide = decompress->Output->SlideWin;
 
@@ -159,7 +159,7 @@ int Unreduce(CDecompressionObject* decompress) /* expand probabilistically reduc
                 nchar = followers[lchar][follower];
             }
         }
-        /* expand the resulting byte */
+        /* decode the resulting byte */
         switch (ExState)
         {
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/unreduce.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 36 comment units, 36 review results, 36 resolved results, and 36 apply results.
- Branch-target comment guard passed for `src/plugins/zip/unreduce.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/unreduce.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
