### PR TITLE
[translation] Fix src/plugins/zip/unshrink.cpp comments

### DIFF
--- a/src/plugins/zip/unshrink.cpp
+++ b/src/plugins/zip/unshrink.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/unshrink.cpp
+++ b/src/plugins/zip/unshrink.cpp
@@ -268,7 +268,7 @@ int Unshrink(CDecompressionObject* decompress)
 
         /* search for freecode */
         freecode = (short)(lastfreecode + 1);
-        /* add if-test before loop for speed? */
+        /* Add an if-test before the loop for speed? */
         while (parent[freecode] != FREE_CODE)
             ++freecode;
         lastfreecode = freecode;
@@ -303,7 +303,7 @@ void partial_clear(short* parent)
 
     /* clear all nodes which have no children (i.e., leaf nodes only) */
 
-    /* first loop:  mark each parent as such */
+    /* first loop: mark each parent as having a child */
     for (code = BOGUSCODE + 1; code < HSIZE; ++code)
     {
         short cparent = (short)(parent[code] & CODE_MASK);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/unshrink.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 37 comment units, 37 review results, 37 resolved results, and 37 apply results.
- Branch-target comment guard passed for `src/plugins/zip/unshrink.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/unshrink.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 322 provider calls, 5341015 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 234 calls, 4005067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 88 calls, 1335948 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
