### PR TITLE
[translation] Fix src/cache.cpp comments

### DIFF
--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -56,7 +56,7 @@ CCacheData::CCacheData(const char* name, const char* tmpName, BOOL ownDelete,
 
 CCacheData::~CCacheData()
 {
-    if (TmpName != NULL && LockObject.Count == 0) // tmp-file is no longer needed
+    if (TmpName != NULL && LockObject.Count == 0) // temporary file is no longer needed
     {
         if (!CleanFromDisk())
         {
@@ -127,8 +127,7 @@ BOOL CCacheData::CleanFromDisk()
         else // deletion should be handled by the plugin
         {
             if (OwnDeletePlugin != NULL) // we can start deleting (the plugin cannot be unloaded); otherwise the file will not be deleted
-            {                            // won't be  deleted (it's either already deleted or it's just
-                                         // disconnected - the plugin decides this during its unload
+            {                            // will not be deleted (it is either already deleted or only disconnected; the plugin chooses that during unload)
                 DeleteManager.AddFile(TmpName, OwnDeletePlugin);
                 OwnDeletePlugin = NULL; // no more deleting will be done
             }
@@ -148,7 +147,7 @@ CCacheData::GetName(CDiskCache* monitor, BOOL* exists, BOOL canBlock, BOOL onlyA
     DWORD res;
     if (canBlock && !onlyAdd)
     {
-        // release the monitor for other threads for the duration of waiting for the readiness of the tmp-file
+        // release the monitor for other threads while waiting for the tmp-file to become ready
         monitor->Leave();
         res = WaitForSingleObject(Preparing, INFINITE);
         monitor->Enter();
@@ -202,7 +201,7 @@ CCacheData::GetName(CDiskCache* monitor, BOOL* exists, BOOL canBlock, BOOL onlyA
                     *exists = FALSE;
                     if (errorCode != NULL)
                         *errorCode = DCGNE_ALREADYEXISTS;
-                    return NULL; // returning the "file already exists" error
+                    return NULL; // return the "file already exists" error
                 }
                 else
                 {
@@ -486,7 +485,7 @@ BOOL CCacheDirData::GetName(CDiskCache* monitor, const char* name, BOOL* exists,
     if (GetNameIndex(name, i)) // 'name' found at index 'i'
     {
         *tmpPath = Names[i]->GetName(monitor, exists, canBlock, onlyAdd, errorCode);
-        if (*tmpPath != NULL) // neither a fatal error nor an unprepared tmp file
+        if (*tmpPath != NULL) // not a fatal error and not a temporary file that is still being prepared
         {                     // not a "file already exists" error either (only if 'onlyAdd' is TRUE)
             CheckAndCreateDirectory(Path, NULL, TRUE);
         }
@@ -582,7 +581,7 @@ BOOL CCacheDirData::ReleaseName(const char* name, BOOL* ret, BOOL* lastCached, B
         BOOL last;
         *ret = Names[i]->ReleaseName(&last, storeInCache);
         *lastCached = FALSE;
-        if (last) // this was also the last link to this tmp-file
+        if (last) // this was also the last reference to this tmp file
         {
             if (Names[i]->IsCached())
                 *lastCached = TRUE;
@@ -647,7 +646,7 @@ void CCacheDirData::AddVictimsToArray(TDirectArray<CCacheData*>& victArr)
 
 BOOL CCacheDirData::DetachTmpFile(const char* tmpName)
 {
-    if (StrNICmp(tmpName, Path, PathLength) == 0) // if there's a chance that this is our tmp-file
+    if (StrNICmp(tmpName, Path, PathLength) == 0) // if there is a chance that this is our tmp file
     {
         int i;
         for (i = 0; i < Names.Count; i++)
@@ -687,7 +686,7 @@ void CCacheDirData::FlushCache(const char* name)
             }
         }
         else
-            break; // there cannot be any more, stop here
+            break; // there can be no more; stop here
     }
 }
 
@@ -866,7 +865,7 @@ CCacheHandles::CCacheHandles() : Handles(100, 50), Owners(100, 50)
 void CCacheHandles::Destroy()
 {
     CALL_STACK_MESSAGE1("CCacheHandles::Destroy()");
-    if (Thread != NULL) // thread termination is required
+    if (Thread != NULL) // the thread needs to be terminated
     {
         SetEvent(Terminate);                                   // "you should end now"
         if (WaitForSingleObject(Thread, 1000) == WAIT_TIMEOUT) // let's give it 1 second
@@ -1044,7 +1043,7 @@ void CCacheHandles::WaitForIdle()
 {
     CALL_STACK_MESSAGE1("CCacheHandles::WaitForIdle()");
     TRACE_I("CCacheHandles::WaitForIdle begin");
-    Idle = 1;                              // we are asking
+    Idle = 1;                              // asking whether we're idle
     SetEvent(TestIdle);                    // if the watching thread is waiting, we will stop the wait (we will run the idle-state test)
     WaitForSingleObject(IsIdle, INFINITE); // we are waiting for idle
     TRACE_I("CCacheHandles::WaitForIdle end");
@@ -1270,7 +1269,7 @@ BOOL CDiskCache::ReleaseName(const char* name, BOOL storeInCache)
         if (Dirs[i]->ReleaseName(name, &ret, &lastCached, storeInCache)) // 'name' found
         {
             if (lastCached) // The tmp-file is orphaned and cached; we will see whether it already needs to be released.
-            {               // to release it, or if we need to release space on disk
+            {               // Check whether we need to free up disk space.
                 CheckCachedFiles();
             }
             Leave();
@@ -1325,7 +1324,7 @@ void CDiskCache::CheckCachedFiles()
             Dirs[i]->AddVictimsToArray(victArr);
         }
         if (!victArr.IsGood())
-            return; // low memory, we won't perform optimization
+            return; // low memory, optimization will not be performed
         if (victArr.Count > 1)
             SortVictims(victArr, 0, victArr.Count - 1);
         int actVict = 0;
@@ -1343,9 +1342,9 @@ void CDiskCache::CheckCachedFiles()
                 }
             }
             else
-                break; // at least one cached file must remain in cache, it will be
-                       // the one which was released last, it prevents discarding
-                       // of the file which the user is currently looking at
+                break; // at least one cached file must remain in the cache;
+                       // it will be the one most recently released,
+                       // preventing the file the user is currently viewing from being discarded
         }
     }
 }
@@ -1357,13 +1356,13 @@ void CDiskCache::WaitSatisfied(HANDLE lock, CCacheData* owner)
     BOOL last;
     if (owner->WaitSatisfied(lock, &last))
     {
-        if (last) // the tmp-file has no more links; we can cancel it
+        if (last) // the tmp file is orphaned; we can delete it
         {
             if (owner->IsCached()) // see if we already need to free some space
-            {                      // and free up disk space if needed
+            {                      // free up disk space if needed
                 CheckCachedFiles();
             }
-            else // we should delete the file directly
+            else // delete the file directly
             {
                 int i;
                 for (i = 0; i < Dirs.Count; i++)
@@ -1602,7 +1601,7 @@ void CDeleteManager::ProcessData()
     if (BlockDataProcessing)
         return;
 
-    // we will lower the priority of the thread - we are going to delete a file to a plugin
+    // lower the thread priority; we are going to delete the file via the plugin
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 
     if (MainWindow != NULL)
@@ -1673,10 +1672,10 @@ void CDeleteManager::PluginMayBeUnloaded(HWND parent, CPluginData* plugin)
             WaitingForProcessing = TRUE; // Block sending WM_USER_PROCESSDELETEMAN: it is undesirable and unnecessary; data will be processed at the end of the method
         HANDLES(LeaveCriticalSection(&CS));
 
-        BlockDataProcessing = TRUE; // in case we missed a WM_TIMER posted to the main window (we block it because it can be delivered by the first displayed message box and its message loop)
+        BlockDataProcessing = TRUE; // in case a WM_TIMER posted to the main window would otherwise be missed (we block it because it can be delivered by the first displayed message box and its message loop)
 
         int copiesCount = DiskCache.CountNamesDeletedByPlugin(plugin->GetPluginInterface()->GetInterface());
-        if (copiesCount > 0) // plugin still has some tmp-files opened (and it should ensure their deletion)
+        if (copiesCount > 0) // The plugin still has some temporary files open (and should ensure they are deleted)
         {
             if (plugin->PrematureDeleteTmpCopy(parent, copiesCount))
             { // user wants to delete tmp-files, even if they are still opened (they are in viewers, etc.)

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -56,7 +56,7 @@ CCacheData::CCacheData(const char* name, const char* tmpName, BOOL ownDelete,
 
 CCacheData::~CCacheData()
 {
-    if (TmpName != NULL && LockObject.Count == 0) // temporary file is no longer needed
+    if (TmpName != NULL && LockObject.Count == 0) // tmp-file is no longer needed
     {
         if (!CleanFromDisk())
         {
@@ -127,7 +127,7 @@ BOOL CCacheData::CleanFromDisk()
         else // deletion should be handled by the plugin
         {
             if (OwnDeletePlugin != NULL) // we can start deleting (the plugin cannot be unloaded); otherwise the file will not be deleted
-            {                            // will not be deleted (it is either already deleted or only disconnected; the plugin chooses that during unload)
+            {                            // won't be deleted (it is either already deleted or just disconnected; the plugin decides this during unload)
                 DeleteManager.AddFile(TmpName, OwnDeletePlugin);
                 OwnDeletePlugin = NULL; // no more deleting will be done
             }
@@ -147,7 +147,7 @@ CCacheData::GetName(CDiskCache* monitor, BOOL* exists, BOOL canBlock, BOOL onlyA
     DWORD res;
     if (canBlock && !onlyAdd)
     {
-        // release the monitor for other threads while waiting for the tmp-file to become ready
+        // release the monitor for other threads for the duration of waiting for the readiness of the tmp-file
         monitor->Leave();
         res = WaitForSingleObject(Preparing, INFINITE);
         monitor->Enter();
@@ -201,7 +201,7 @@ CCacheData::GetName(CDiskCache* monitor, BOOL* exists, BOOL canBlock, BOOL onlyA
                     *exists = FALSE;
                     if (errorCode != NULL)
                         *errorCode = DCGNE_ALREADYEXISTS;
-                    return NULL; // return the "file already exists" error
+                    return NULL; // returning the "file already exists" error
                 }
                 else
                 {
@@ -485,7 +485,7 @@ BOOL CCacheDirData::GetName(CDiskCache* monitor, const char* name, BOOL* exists,
     if (GetNameIndex(name, i)) // 'name' found at index 'i'
     {
         *tmpPath = Names[i]->GetName(monitor, exists, canBlock, onlyAdd, errorCode);
-        if (*tmpPath != NULL) // not a fatal error and not a temporary file that is still being prepared
+        if (*tmpPath != NULL) // neither a fatal error nor an unprepared tmp file
         {                     // not a "file already exists" error either (only if 'onlyAdd' is TRUE)
             CheckAndCreateDirectory(Path, NULL, TRUE);
         }
@@ -581,7 +581,7 @@ BOOL CCacheDirData::ReleaseName(const char* name, BOOL* ret, BOOL* lastCached, B
         BOOL last;
         *ret = Names[i]->ReleaseName(&last, storeInCache);
         *lastCached = FALSE;
-        if (last) // this was also the last reference to this tmp file
+        if (last) // this was also the last link to this tmp-file
         {
             if (Names[i]->IsCached())
                 *lastCached = TRUE;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/cache.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 19 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 185 comment units, 185 review results, 185 resolved results, and 185 apply results.
- Branch-target comment guard passed for `src/cache.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/cache.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 29 provider calls, 622474 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 42093 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 27 calls, 580381 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
