### PR TITLE
[translation] Fix src/codetbl.h comments

### DIFF
--- a/src/codetbl.h
+++ b/src/codetbl.h
@@ -70,16 +70,16 @@ public:
     // otherwise it returns FALSE
     BOOL GetPreloadedIndex(const char* dirName, int* index);
 
-    // selects the best matching item from the Preloaded array
+    // Selects the best matching item from the Preloaded array
     // cfgDirName points to the recommended directory name (from the configuration)
-    // dirName must point to a buffer of MAX_PATH characters where the directory name is returned;
-    // if none exists, an empty string is returned
-    // criteria:
+    // dirName must point to a buffer of size MAX_PATH where the directory name is returned;
+    // if no such item exists, an empty string is returned
+    // Criteria:
     //  1. cfgDirName
-    //  2. item matching the OS code page
+    //  2. Item matching the OS code page
     //  3. westeuro
-    //  4. first in the list
-    //  5. if there is no item in the list, we will return an empty string
+    //  4. First item in the list
+    //  5. If the list is empty, an empty string is returned
     void GetBestPreloadedConversion(const char* cfgDirName, char* dirName);
 
     // prepares the object for use (loads 'convert.cfg' script), hWindow is the parent window for message boxes


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/codetbl.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 35 comment units, 35 review results, 35 resolved results, and 35 apply results.
- Branch-target comment guard passed for `src/codetbl.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/codetbl.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
