### PR TITLE
[translation] Fix src/color.cpp comments

### DIFF
--- a/src/color.cpp
+++ b/src/color.cpp
@@ -36,7 +36,7 @@ void ColorRGBToHLS(COLORREF clrRGB, WORD* pwHue, WORD* pwLuminance, WORD* pwSatu
     int h, l, s;     // output HLS values
     WORD cMax, cMin; // max and min RGB values
     WORD cSum, cDif;
-    int rDelta, gDelta, bDelta; // intermediate value: % of spread from max
+    int rDelta, gDelta, bDelta; // intermediate value: % of the spread from the maximum
 
     // get R, G, and B out of DWORD
     r = GetRValue(clrRGB);
@@ -95,7 +95,7 @@ WORD HueToRGB(WORD n1, WORD n2, WORD hue)
     if (hue > HLSMAX)
         hue -= HLSMAX;
 
-    // return r,g, or b value from this tridrant
+    // return the r, g, or b value for this hue segment
     if (hue < (HLSMAX / 6))
         return (n1 + (((n2 - n1) * hue + (HLSMAX / 12)) / (HLSMAX / 6)));
     if (hue < (HLSMAX / 2))
@@ -109,7 +109,7 @@ WORD HueToRGB(WORD n1, WORD n2, WORD hue)
 COLORREF ColorHLSToRGB(WORD wHue, WORD wLuminance, WORD wSaturation)
 {
     WORD r, g, b;        // RGB component values
-    WORD magic1, magic2; // calculated magic numbers (really!)
+    WORD magic1, magic2; // computed magic numbers
 
     if (wSaturation == 0)
     { // achromatic case


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/color.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 27 comment units, 27 review results, 27 resolved results, and 27 apply results.
- Branch-target comment guard passed for `src/color.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/color.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 83986 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 83986 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
