### PR TITLE
[translation] Fix src/dialogs.h comments

### DIFF
--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -276,9 +276,9 @@ public:
     // in cycles (after the last one it returns to the first)
     HWND GetNextOpenedDlg(int* index);
 
-    // ensures that all open dialogs are closed;
-    // call only from the main thread (otherwise another dialog may open and will not
-    // know that it should terminate)
+    // ensures all open dialogs are closed
+    // call only from the main thread (otherwise another dialog might open and won't
+    // know it should terminate)
     void PostCancelToAllDlgs();
 
     // sends a message to all dialogs that the icon (color) has changed and needs 
@@ -316,7 +316,7 @@ public:
 protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    BOOL FlushCachedData(); // updates modified data in static controls and progress bars; returns TRUE if there was anything to update (something was dirty)
+    BOOL FlushCachedData(); // sends modified data to statics and progress bars; returns TRUE if there was something to update (something was dirty)
 
     void SetDlgTitle(BOOL minimized);
     void SetWindowIcon();
@@ -325,7 +325,7 @@ protected:
     BOOL RunningInOwnThread;                // TRUE/FALSE = dialog runs in its own thread ("background") / dialog runs in the main thread and is modal to its parent (usually one of the panels)
     CStartProgressDialogData* ProgrDlgData; // non-NULL only if the dialog runs in its own thread and the main thread hasn't been resumed yet (waiting for dialog opening and operation start)
 
-    HANDLE Worker;                // handle of the worker thread associated with this dialog (NULL if the thread does not exist yet or no longer exists)
+    HANDLE Worker;                // worker thread associated with this dialog (NULL if it doesn't exist yet/any more)
     HANDLE WContinue;             // multi-purpose event
     HANDLE WorkerNotSuspended;    // non-signaled == the worker should enter suspend mode
     BOOL CancelWorker;            // if TRUE, the worker thread will terminate
@@ -357,7 +357,7 @@ protected:
 
     BOOL TimerIsRunning; // if TRUE, a timer for text changes and the progress bar updates is running
 
-    BOOL FirstUserSetDialog; // TRUE = the WM_USER_SETDIALOG message has not been processed yet (for the first one, a repaint is forced so the user sees the dialog at least flash)
+    BOOL FirstUserSetDialog; // TRUE = WM_USER_SETDIALOG message isn't processed yet (the first call forces a repaint so the user sees the dialog at least flash)
 
     HWND NextForegroundWindow; // window that should be foreground after closing this dialog (on XP with service pack 1 and with a top-most window opened the activation may fail after closing the dialog - focus sometimes went to the top-most window instead of Salamander)
 

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -276,9 +276,9 @@ public:
     // in cycles (after the last one it returns to the first)
     HWND GetNextOpenedDlg(int* index);
 
-    // ensures all open dialogs are closed
-    // call only from the main thread (otherwise another dialog might open and it won't 
-    // know it should terminate)
+    // ensures that all open dialogs are closed;
+    // call only from the main thread (otherwise another dialog may open and will not
+    // know that it should terminate)
     void PostCancelToAllDlgs();
 
     // sends a message to all dialogs that the icon (color) has changed and needs 
@@ -316,7 +316,7 @@ public:
 protected:
     virtual INT_PTR DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
-    BOOL FlushCachedData(); // sends modified data to statics and progress bars; returns TRUE if there was something to update (something was dirty)
+    BOOL FlushCachedData(); // updates modified data in static controls and progress bars; returns TRUE if there was anything to update (something was dirty)
 
     void SetDlgTitle(BOOL minimized);
     void SetWindowIcon();
@@ -325,7 +325,7 @@ protected:
     BOOL RunningInOwnThread;                // TRUE/FALSE = dialog runs in its own thread ("background") / dialog runs in the main thread and is modal to its parent (usually one of the panels)
     CStartProgressDialogData* ProgrDlgData; // non-NULL only if the dialog runs in its own thread and the main thread hasn't been resumed yet (waiting for dialog opening and operation start)
 
-    HANDLE Worker;                // worker thread associated with this dialog (NULL if it doesn't exist yet/any more)
+    HANDLE Worker;                // handle of the worker thread associated with this dialog (NULL if the thread does not exist yet or no longer exists)
     HANDLE WContinue;             // multi-purpose event
     HANDLE WorkerNotSuspended;    // non-signaled == the worker should enter suspend mode
     BOOL CancelWorker;            // if TRUE, the worker thread will terminate
@@ -357,7 +357,7 @@ protected:
 
     BOOL TimerIsRunning; // if TRUE, a timer for text changes and the progress bar updates is running
 
-    BOOL FirstUserSetDialog; // TRUE = WM_USER_SETDIALOG message isn't processed yet (the first call forces a repaint so the user sees the dialog at least flash)
+    BOOL FirstUserSetDialog; // TRUE = the WM_USER_SETDIALOG message has not been processed yet (for the first one, a repaint is forced so the user sees the dialog at least flash)
 
     HWND NextForegroundWindow; // window that should be foreground after closing this dialog (on XP with service pack 1 and with a top-most window opened the activation may fail after closing the dialog - focus sometimes went to the top-most window instead of Salamander)
 
@@ -635,7 +635,7 @@ public:
     char Mask[MAX_PATH]; // which files will be converted?
     int Change;          // which conversion should be performed?
     BOOL SubDirs;        // include subdirectories?
-    int CodeType;        // selected encoding (0 = none)
+    int CodeType;        // which encoding is selected (0 = none)
     int EOFType;         // selected line endings (0 = none)
                          // 1 = CRLF
                          // 2 = LF
@@ -831,7 +831,7 @@ protected:
 
 protected:
     CBitmap* Bitmap;         // includes the text
-    CBitmap* OriginalBitmap; // graphics only, without text
+    CBitmap* OriginalBitmap; // bitmap only, without text
     HFONT HNormalFont;
     HFONT HBoldFont;
     RECT OpenSalR;
@@ -935,7 +935,7 @@ protected:
     char* IconFile;
     int* IconIndex;
     BOOL Dirty;
-    HICON* Icons;     // array of enumerated icon handles
+    HICON* Icons;     // array of icon handles
     DWORD IconsCount; // number of icons in the array
 
 public:
@@ -988,8 +988,8 @@ protected:
     void InitColumns();     // add columns to the listview
     void SetColumnWidths(); // set optimal column widths
     void RefreshListView(BOOL setOnly = TRUE, int selIndex = -1, const CPluginData* selectPlugin = NULL, BOOL setColumnWidths = FALSE);
-    void OnSelChanged();                                                    // selected item in the listview changed
-    CPluginData* GetSelectedPlugin(int* index = NULL, int* lvIndex = NULL); // returns NULL if no item is selected; index returns index to the Plugins array; lvIndex returns index within listview, can be NULL
+    void OnSelChanged();                                                    // the selected item in the list view changed
+    CPluginData* GetSelectedPlugin(int* index = NULL, int* lvIndex = NULL); // returns NULL if no item is selected; index returns the index into the Plugins array; lvIndex returns the index within the list view and can be NULL
     void EnableButtons(CPluginData* plugin);
     void OnContextMenu(int x, int y); // show the context menu for the selected item at coordinates x, y
     void OnMove(BOOL up);
@@ -1025,7 +1025,7 @@ protected:
     void RefreshListView(BOOL setOnly = TRUE);
 
     WORD GetHotKey(BYTE* virtKey = NULL, BYTE* mods = NULL);
-    CPluginMenuItem* GetSelectedItem(int* orgIndex); // orgIndex returns index to Plugin array->MenuItems; may be NULL
+    CPluginMenuItem* GetSelectedItem(int* orgIndex); // orgIndex receives the index into the Plugin->MenuItems array; it may be NULL
     CPluginMenuItem* GetItem(int index);
     void EnableButtons();
     void HandleConflictWarning();
@@ -1167,9 +1167,9 @@ struct CImportOldKey
 class CImportConfigDialog : public CCommonDialog
 {
 public:
-    // array corresponding to SalamanderConfigurationRoots array; TRUE:the configuration exists, FALSE:it doesn't
+    // array corresponding to the SalamanderConfigurationRoots array; TRUE: configuration exists, FALSE: does not exist
     BOOL ConfigurationExist[SALCFG_ROOTS_COUNT];
-    // pointer to the same sized array where the dialog stores TRUE for configurations to delete
+    // pointer to an array of the same size where the dialog stores TRUE for configurations to be deleted
     BOOL* DeleteConfigurations;
     // dialog returns here which configuration the user wants to import; -1 -> none
     // index points into the SalamanderConfigurationRoots array
@@ -1213,7 +1213,7 @@ public:
     BOOL Initialize(const char* slgSearchPath = NULL, HINSTANCE pluginDLL = NULL);
 
     int GetLanguagesCount() { return Items.Count; }
-    BOOL GetSLGName(char* path, int index = 0); // returns xxxx.slg of the item at index 'index'
+    BOOL GetSLGName(char* path, int index = 0); // returns the xxxx.slg for the item at index 'index'
     BOOL SLGNameExists(const char* slgName);    // checks whether 'slgName' exists in 'Items'
 
     void FillControls();
@@ -1286,8 +1286,8 @@ protected:
 public:
     CSharesDialog(HWND hParent);
 
-    const char* GetFocusedPath(); // returns the path of the selected share; call only after the dialog returns
-                                  // returns NULL if "Focus" wasn't clicked and the dialog returned IDOK
+    const char* GetFocusedPath(); // returns the path of the selected share; call only after Execute() returns
+                                  // returns NULL if the "Focus" button was not pressed and the dialog returned IDOK
                                   // from Execute()
 
 protected:
@@ -1299,7 +1299,7 @@ protected:
     void Refresh();     // loads shared folders and adds them to the listview
     static int CALLBACK SortFunc(LPARAM lParam1, LPARAM lParam2, LPARAM lParamSort);
     void SortItems();                        // sorts items based on the SortBy variable
-    int GetFocusedIndex();                   // returns index to SharetDirs array or -1 if no item is selected
+    int GetFocusedIndex();                   // returns the index into the SharetDirs array, or -1 if no item is selected
     void DeleteShare(const char* shareName); // request the system to remove the share
     void OnContextMenu(int x, int y);        // shows the context menu for the selected item at coordinates x, y
     void EnableControls();                   // button enabler
@@ -1349,9 +1349,9 @@ public:
     CDisconnectDialog(CFilesWindow* panel);
     ~CDisconnectDialog();
 
-    const char* GetFocusedPath();                 // returns the path of the selected share; call only after the dialog returns
-                                                  // returns NULL if "Focus" wasn't clicked and the dialog returned IDOK
-                                                  // from Execute()
+    const char* GetFocusedPath();                 // returns the path of the selected share; call only after Execute() returns
+                                  // returns NULL if the "Focus" button was not pressed and the dialog returned IDOK
+                                  // from Execute()
     BOOL NoConnection() { return NoConncection; } // returns TRUE if the dialog wasn't opened because there was no connection
 
 protected:
@@ -1446,7 +1446,7 @@ protected:
     int OriginalHeight;   // full dialog height
     int OriginalButtonsY; // Y position of the buttons in client coordinates
     int SpacerHeight;     // spacer used when shrinking/expanding the dialog
-    BOOL Expanded;        // are we currently expanded?
+    BOOL Expanded;        // is the dialog currently expanded?
 
 public:
     CCompareDirsDialog(HWND hParent, BOOL enableByDateAndTime, BOOL enableBySize,
@@ -1499,7 +1499,7 @@ protected:
     CITaskBarList3* TaskBarList3; // pointer to the interface owned by the Salamander main window
 
 public:
-    CCmpDirProgressDialog(HWND hParent, BOOL hasProgress, CITaskBarList3* taskBarList3); // if 'hasProgress' is TRUE, the dialog shows a progress bar
+    CCmpDirProgressDialog(HWND hParent, BOOL hasProgress, CITaskBarList3* taskBarList3); // if 'hasProgress' is TRUE, the dialog with a progress bar is used
 
     // text setup
     void SetSource(const char* text);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/dialogs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 18 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 220 comment units, 220 review results, 220 resolved results, and 220 apply results.
- Branch-target comment guard passed for `src/dialogs.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/dialogs.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 110548 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 21560 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 88988 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
