### PR TITLE
[translation] Fix src/dialogs2.cpp comments

### DIFF
--- a/src/dialogs2.cpp
+++ b/src/dialogs2.cpp
@@ -269,7 +269,7 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         else
             CallEndStopRefresh = FALSE;
 
-        // when opening the dialog set the plug-ins' msgbox parent to this dialog (main thread only)
+        // when opening the dialog, set the message-box parent for plugins to this dialog (main thread only)
         if (Modal && MainThreadID == GetCurrentThreadId())
         {
             HOldPluginMsgBoxParent = PluginMsgBoxParent;
@@ -301,15 +301,15 @@ CCommonDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_DESTROY:
     {
-        if (GetKeyState(VK_ESCAPE) & 0x8000) // measure to avoid interrupting panel listing after each ESC
+        if (GetKeyState(VK_ESCAPE) & 0x8000) // safeguard against interrupting panel listing on each Esc
             WaitForESCReleaseBeforeTestingESC = TRUE;
 
-        // the dialog is closing - the user might have changed the clipboard
-        // (for example pasted text from an editline), so we'll verify it
+        // the dialog is closing; the user might have changed the clipboard
+        // (for example by putting text into an edit line), so we will check it
         IdleRefreshStates = TRUE;  // force the state variables check during the next Idle
         IdleCheckClipboard = TRUE; // also let the clipboard be checked
 
-        // when closing the dialog restore the msgbox parent for plug-ins
+        // when closing the dialog restore the msgbox parent for plugins
         if (HOldPluginMsgBoxParent != NULL)
             PluginMsgBoxParent = HOldPluginMsgBoxParent;
 
@@ -875,7 +875,7 @@ void CLanguageSelectorDialog::LoadListView()
 
 void CLanguageSelectorDialog::Transfer(CTransferInfo& ti)
 {
-    if (PluginName != NULL) // show this checkbox only when selecting an alternative language for a plug-in
+    if (PluginName != NULL) // show this checkbox only when selecting an alternative language for a plugin
         ti.CheckBox(IDC_USESAMESLGINOTHERPLUGINS, Configuration.UseAsAltSLGInOtherPlugins);
 
     if (ti.Type == ttDataToWindow)
@@ -894,7 +894,7 @@ void CLanguageSelectorDialog::Transfer(CTransferInfo& ti)
         if (index != -1)
         {
             lstrcpy(SLGName, Items[index].FileName);
-            if (PluginName != NULL) // store the alternative language name only when selecting an alternative language for a plug-in
+            if (PluginName != NULL) // store the alternative language name only when selecting an alternative language for a plugin
             {
                 if (Configuration.UseAsAltSLGInOtherPlugins)
                     lstrcpy(Configuration.AltPluginSLGName, SLGName);
@@ -923,7 +923,7 @@ BOOL CLanguageSelectorDialog::Initialize(const char* slgSearchPath, HINSTANCE pl
         do
         {
             char* point = strrchr(file.cFileName, '.');
-            if (point != NULL && stricmp(point + 1, "slg") == 0) // it was returning *.slg*
+            if (point != NULL && stricmp(point + 1, "slg") == 0) // FindFirstFile was returning *.slg* too
             {
                 CLanguage lang;
                 if (lang.Init(file.cFileName, pluginDLL))
@@ -950,7 +950,7 @@ int CLanguageSelectorDialog::GetPreferredLanguageIndex(const char* selectSLGName
     WORD primaryID = PRIMARYLANGID(langID);
     int localeIndex = -1;        // index corresponding to the user's locale
     int primarylocaleIndex = -1; // index corresponding to the user's primary language locale
-    int englishIndex = -1;       // index of the file "english.slg"
+    int englishIndex = -1;       // index of the "english.slg" file
     int i;
     for (i = 0; i < Items.Count; i++)
     {
@@ -1014,18 +1014,18 @@ CLanguageSelectorDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
             if (PluginName != NULL)
             {
-                // put the plug-in name in the title so the user knows which plug-in the language is for
+                // put the plugin name in the title so the user knows which plugin the language is for
                 char buf[200];
                 _snprintf_s(buf, _TRUNCATE, "%s: ", PluginName);
-                buf[99] = 0; // use only 100 characters for the plug-in name so some space remains for the original title dialog
+                buf[99] = 0; // use only 100 characters for the plugin name so some space remains for the original title dialog
                 int len = (int)strlen(buf);
                 if (GetWindowText(HWindow, buf + len, 200 - len))
                     SetWindowText(HWindow, buf);
             }
         }
-        if (!OpenedFromConfiguration && PluginName == NULL) // turn the Cancel button into Exit
+        if (!OpenedFromConfiguration && PluginName == NULL) // change the Cancel button to Exit
             SetDlgItemText(HWindow, IDCANCEL, ExitButtonLabel);
-        if (PluginName != NULL) // disable closing
+        if (PluginName != NULL) // disable the Close command
             EnableMenuItem(GetSystemMenu(HWindow, FALSE), SC_CLOSE, MF_BYCOMMAND | MF_GRAYED);
 
         Web = new CHyperLink(HWindow, IDC_SLG_WEB, STF_HYPERLINK_COLOR);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/dialogs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 12 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 71 comment units, 71 review results, 71 resolved results, and 71 apply results.
- Branch-target comment guard passed for `src/dialogs2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/dialogs2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 127554 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 127554 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
