### PR TITLE
[translation] Fix src/dialogs3.cpp comments

### DIFF
--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -226,7 +226,7 @@ CConvertFilesDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
           SetMenuItemBitmaps(hMenu, mi.wID, MF_BYCOMMAND, NULL, HMenuCheckDot);
         }
 
-        // insert a separator after none
+        // insert a separator after 'None'
         mi.fMask = MIIM_TYPE;
         mi.fType = MFT_SEPARATOR;
         InsertMenuItem(hMenu, 1, TRUE, &mi);
@@ -519,8 +519,8 @@ CEditNewFileDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if (LOWORD(wParam) == IDB_BROWSE)
         {
-            /* used by the export_mnu.py script which generates salmenu.mnu for the Translator
-   keep synchronized with the InsertMenu() call below...
+            /* Used by the export_mnu.py script that generates salmenu.mnu for Translator.
+   Keep synchronized with the InsertMenu() call below.
 MENU_TEMPLATE_ITEM EditNewFileDialogMenu[] = 
 {
   {MNTT_PB, 0
@@ -687,7 +687,7 @@ void CCopyMoveMoreDialog::TransferCriteriaControls(CTransferInfo& ti)
     {
         Criteria->Masks.SetMasksString(masks);
         int errpos = 0;
-        // masks must go out in the Prepared state
+        // masks must be passed out in the Prepared state
         if (!Criteria->Masks.PrepareMasks(errpos)) // invalid mask, this shouldn't happen thanks to validation
             Criteria->UseMasks = FALSE;
         char dummy[200];
@@ -723,7 +723,7 @@ void CCopyMoveMoreDialog::TransferCriteriaControls(CTransferInfo& ti)
             {
                 speedLimNum /= 1024;
                 speedLimUnits++;
-                if (speedLimNum == 0 || speedLimUnits > 3) // cannot happen, just for peace of mind
+                if (speedLimNum == 0 || speedLimUnits > 3) // cannot happen; defensive check
                 {
                     TRACE_E("CCopyMoveMoreDialog::TransferCriteriaControls(): unexpected situation!");
                     speedLimNum = 4;
@@ -1644,7 +1644,7 @@ CDriveInfo::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         HDC hdc = HANDLES(GetDC(HWindow));
         int devCaps = GetDeviceCaps(hdc, NUMCOLORS);
         HANDLES(ReleaseDC(HWindow, hdc));
-        if (devCaps == -1) // more than 256 colors
+        if (devCaps == -1) // more than 256 colors available
         {
             FreeLight = RGB(35, 245, 156);
             FreeDark = RGB(9, 159, 96);
@@ -1667,7 +1667,7 @@ CDriveInfo::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (cr != NULL)
             cr->SetColor(UsedLight);
 
-        Graph = new CColorGraph(HWindow, IDB_GRAPH); // JRYFIXME - rewrite to W10 look; see disk properties, it won't be comfortable to use GDI+ maybe our SVG?
+        Graph = new CColorGraph(HWindow, IDB_GRAPH); // JRYFIXME - rewrite to match the Windows 10 look; see disk properties. Would it be better to use GDI+ or our SVGs?
         if (Graph != NULL)
             Graph->SetColor(FreeLight, FreeDark, UsedLight, UsedDark);
 
@@ -1826,7 +1826,7 @@ void CPackDialog::Transfer(CTransferInfo& ti)
             char* s = strrchr(Path, '.');
             char* s2 = strrchr(Path, '\\');
             int nameLen = (int)strlen(Path);
-            if ((s == NULL || s2 != NULL && s2 > s) && // '.cvspass' in Windows is considered an extension ...
+            if ((s == NULL || s2 != NULL && s2 > s) && // '.cvspass' is treated as an extension in Windows ...
                 (s2 == NULL || (s2 - Path + 1) < nameLen) &&
                 nameLen > 0 &&
                 nameLen + 1 + 1 + strlen(ext) < MAX_PATH)
@@ -1862,7 +1862,7 @@ BOOL CPackDialog::ChangeExtension(char* name, const char* ext)
 {
     char* s = strrchr(name, '.');
     char* s2 = strrchr(name, '\\');
-    if (s != NULL && // '.cvspass' in Windows is considered an extension ...
+    if (s != NULL && // '.cvspass' is treated as an extension in Windows ...
                      //if (s != NULL && s > name &&
         (s2 == NULL || s > s2) &&
         strlen(ext) + 1 + ((s + 1) - name) < MAX_PATH)
@@ -2589,7 +2589,7 @@ void CWaitWindow::PaintText(HDC hDC)
         HFONT hOldFont = (HFONT)SelectObject(hDestDC, EnvFont);
         int prevBkMode = SetBkMode(hDestDC, TRANSPARENT);
         SetTextColor(hDestDC, GetSysColor(COLOR_BTNTEXT));
-        // we won't clip so that we survive minor text extension
+        // do not clip, to tolerate minor text extension
         // that may occur during a SetText call
         DrawText(hDestDC, Text, (int)strlen(Text), &r, DT_LEFT | DT_NOPREFIX | DT_NOCLIP | (NeedWrap ? DT_WORDBREAK : 0));
         SetBkMode(hDestDC, prevBkMode);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/dialogs3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 140 comment units, 140 review results, 140 resolved results, and 140 apply results.
- Branch-target comment guard passed for `src/dialogs3.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/dialogs3.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 153774 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43715 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 110059 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
