### PR TITLE
[translation] Fix src/edtlbwnd.cpp comments

### DIFF
--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -139,9 +139,9 @@ CEditListBox::CEditListBox(HWND hDlg, int ctrlID, DWORD flags, CObjectOrigin ori
     int itemHeight = max(tm.tmHeight + 4, IconSizes[ICONSIZE_16]);
     SendMessage(HWindow, LB_SETITEMHEIGHT, 0, MAKELPARAM(itemHeight, 0));
 
-    // MakeDragList subclasses the list box and we stop receiving basic messages
-    // such as WM_LBUTTONDOWN, WM_MOUSEMOVE, ect. That makes this function unusable,
-    // so we implement drag&drop support ourselves.
+    // MakeDragList subclasses the list box, and we stop receiving basic messages
+    // such as WM_LBUTTONDOWN, WM_MOUSEMOVE, etc. This makes this function unusable,
+    // so drag-and-drop support is implemented directly here.
     //  MakeDragList(HWindow);
     //  DragNotify = RegisterWindowMessage(DRAGLISTMSGSTRING);
 }
@@ -835,7 +835,7 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_KEYUP:
     {
-        if (Dragging) // We don't want the listbox processing this if we are dragging.
+        if (Dragging) // We do not want the list box to process this while dragging.
             return 0;
         break;
     }
@@ -1077,7 +1077,7 @@ CEditListBox::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         if (Dragging)
         {
             LRESULT ret = CWindow::WindowProc(uMsg, wParam, lParam);
-            return ret | DLGC_WANTMESSAGE; // we want Escape
+            return ret | DLGC_WANTMESSAGE; // handle Escape
         }
         break;
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/edtlbwnd.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 25 comment units, 25 review results, 25 resolved results, and 25 apply results.
- Branch-target comment guard passed for `src/edtlbwnd.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/edtlbwnd.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 94372 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 92131 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 2241 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
