### PR TITLE
[translation] Fix src/edtlbwnd.h comments

### DIFF
--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -114,7 +114,7 @@ public:
 
     BOOL SetCurSel(int index);
 
-    // returns index of the selected item - for a new item it is one more than
+    // returns index of the selected item - for a new item it is 1 more than
     // the number of items
     BOOL GetCurSel(int& index);
     // returns -1 for an empty item


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/edtlbwnd.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 34 comment units, 34 review results, 34 resolved results, and 34 apply results.
- Branch-target comment guard passed for `src/edtlbwnd.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/edtlbwnd.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 68449 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 48323 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20126 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
