### PR TITLE
[translation] Fix src/execute.h comments

### DIFF
--- a/src/execute.h
+++ b/src/execute.h
@@ -101,8 +101,8 @@ struct CUserMenuValidationData // additional data used to validate User Menu: ar
     BOOL MustHandleItemsAsGroup;     // TRUE = items must be processed as a group: ListOfSelectedNames, ListOfSelectedFullNames, FileToCompareXXX, DirToCompareXXX
     BOOL MustHandleItemsOneByOne;    // TRUE = items must be processed individually: FullName, Name, NamePart, ExtPart, DOSFullName, DOSName, DOSNamePart, DOSExtPart
     int UsedCompareType;             // 0 = none yet, 1 = file-left-right, 2 = file-active-inactive, 3 = dir-left-right, 4 = dir-active-inactive, 5 = multiple types (invalid), 6 = file-or-dir-left-right, 7 = file-or-dir-active-inactive
-    BOOL UsedCompareLeftOrActive;    // TRUE = at least one variable compare-left or compare-active is used (we're testing if both parameters are used; otherwise it's nonsense)
-    BOOL UsedCompareRightOrInactive; // TRUE = at least one variable compare-right or compare-inactive is used (we're testing if both parameters are used; otherwise it's nonsense)
+    BOOL UsedCompareLeftOrActive;    // TRUE = at least one compare-left or compare-active variable is used (we test whether both parameters are used; otherwise it makes no sense)
+    BOOL UsedCompareRightOrInactive; // TRUE = at least one compare-right or compare-inactive variable is used (we test whether both parameters are used; otherwise it makes no sense)
 };
 
 struct CUserMenuAdvancedData // additional data used only for the User Menu: array Arguments


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/execute.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 63 comment units, 63 review results, 63 resolved results, and 63 apply results.
- Branch-target comment guard passed for `src/execute.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/execute.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 119759 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 6 calls, 99604 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20155 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
