### PR TITLE
[translation] Fix src/filesbox.h comments

### DIFF
--- a/src/filesbox.h
+++ b/src/filesbox.h
@@ -193,8 +193,8 @@ public:
     // returns the new TopIndex that EnsureItemVisible would set for scroll == FALSE
     int PredictTopIndex(int index);
 
-    // special version: scrolls only the part of the screen that doesn't contain
-    // the item index, then repaints the remaining items
+    // special version of the function: scrolls only the part of the screen that does not contain
+    // item index; then repaints the remaining items
     void EnsureItemVisible2(int newTopIndex, int index);
 
     // returns TRUE if item 'index' is at least partially visible; if 'isFullyVisible' is not NULL,
@@ -222,7 +222,7 @@ protected:
     void SetupScrollBars(DWORD flags = UPDATE_VERT_SCROLL | UPDATE_HORZ_SCROLL); // updates scrollbar information
     BOOL ShowHideChilds();                                                       // shows or hides children based on Mode; returns TRUE when a change occurs otherwise returns FALSE
     void UpdateInternalData();
-    void CheckAndCorrectBoundaries(); // ensures scrollbars are in valid ranges, adjusting them if needed
+    void CheckAndCorrectBoundaries(); // ensures the scrollbars are in valid positions, adjusting them if needed
 
     void OnHScroll(int scrollCode, int pos);
     void OnVScroll(int scrollCode, int pos);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/filesbox.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 64 comment units, 64 review results, 64 resolved results, and 64 apply results.
- Branch-target comment guard passed for `src/filesbox.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/filesbox.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 186873 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 166655 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20218 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
