### PR TITLE
[translation] Fix src/filesbx2.cpp comments

### DIFF
--- a/src/filesbx2.cpp
+++ b/src/filesbx2.cpp
@@ -348,8 +348,8 @@ void CHeaderLine::SetMinWidths()
         if (column->SupportSorting == 1)
             column->MinWidth += 2 * SORT_BITMAP_W;
 
-        // when measuring the "Name" column and the next column isn't "Ext"
-        // and integration of "Ext" into "Name" is allowed, add the width of "Ext"
+        // when measuring the "Name" column and integration of "Ext" into "Name" is enabled,
+        // add the width of "Ext"
         if (i == 0 && !Parent->Parent->IsExtensionInSeparateColumn() &&
             (Parent->Parent->ValidFileData & VALID_DATA_EXTENSION))
         {
@@ -380,7 +380,7 @@ CHeaderLine::HitTest(int xPos, int yPos, int& index, BOOL& extInName)
         right = left + column->Width;
         if (xPos >= left && xPos < right)
         {
-            // test the separators
+            // check the dividers
             if (xPos < left + 2 && i > 0 && Columns->At(i - 1).FixedWidth == 1)
             {
                 index = i - 1;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/filesbx2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 44 comment units, 44 review results, 44 resolved results, and 44 apply results.
- Branch-target comment guard passed for `src/filesbx2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/filesbx2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 99199 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 73666 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 25533 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
