### PR TITLE
[translation] Fix src/filesmap.cpp comments

### DIFF
--- a/src/filesmap.cpp
+++ b/src/filesmap.cpp
@@ -119,7 +119,7 @@ BOOL CFilesMap::CreateMap()
                     AlterFileName(formatedFileName, f->Name, -1, Configuration.FileNameFormat, 0, isDir);
 
                     const char* s = formatedFileName;
-                    // skip the ".."
+                    // suppress ".."
                     if (*s == '.' && *(s + 1) == '.' && *(s + 2) == 0)
                         s = NULL;
 
@@ -418,7 +418,7 @@ void CFilesMap::SetPoint(int x, int y)
             }
             item = GetMapItem(col, row);
 
-            if (item == NULL) // there were several crashes in CFilesMap::SetPoint; cause unknown
+            if (item == NULL) // Several crashes occurred in CFilesMap::SetPoint; cause unknown
                 continue;     // this avoids a crash; at worst, selection will not work
 
             BOOL inOld = PointInRect(col, row, oldRect);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/filesmap.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 29 comment units, 29 review results, 29 resolved results, and 29 apply results.
- Branch-target comment guard passed for `src/filesmap.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/filesmap.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 50525 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 29118 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 21407 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
