### PR TITLE
[translation] Fix src/fileswn4.cpp comments

### DIFF
--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -238,17 +238,17 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                         }
                     }
                 }
-                else // it's a file
+                else // file
                 {
                     int index;
                     BOOL exceptions = *(DWORD*)lowerExtension == *(DWORD*)"scr" || // icons in the file,
-                                      *(DWORD*)lowerExtension == *(DWORD*)"pif" || // even though it isn't visible
+                                      *(DWORD*)lowerExtension == *(DWORD*)"pif" || // even though it is not visible in the Registry
                                       *(DWORD*)lowerExtension == *(DWORD*)"lnk";   // in the Registry
 
-                    if (exceptions || Associations.GetIndex(lowerExtension, index)) // the extension has an icon (association)
+                    if (exceptions || Associations.GetIndex(lowerExtension, index)) // the extension has an associated icon
                     {
                         if (!exceptions)
-                            TransferAssocIndex = index;                               // remember the valid index in Associations
+                            TransferAssocIndex = index;                               // store the valid index in Associations
                         if (exceptions || Associations[index].GetIndex(iconSize) < 0) // dynamic icon (from the file) or a loaded static icon
                         {                                                             // icon in the file
                             int icon;
@@ -316,7 +316,7 @@ void CFilesWindow::DrawIcon(HDC hDC, CFileData* f, BOOL isDir, BOOL isItemUpDir,
                 if (!IconCache->GetIndex(NULL /*fileName*/, icon, &PluginData, f) ||                // the icon-thread isn't loading it
                     IconCache->At(icon).GetFlag() != 1 && IconCache->At(icon).GetFlag() != 2 ||     // neither new nor old icon is loaded
                     !IconCache->GetIcon(IconCache->At(icon).GetIndex(), &iconList, &iconListIndex)) // failed to obtain its icon
-                {                                                                                   // we will display a simple symbol from the plug-in
+                {                                                                                   // we will display a simple symbol from the plugin
                     // the simple icon index will be obtained via the GetPluginIconIndex callback
                     TransferFileData = f;
                     TransferIsDir = isDir ? (isItemUpDir ? 2 : 1) : 0;
@@ -495,9 +495,9 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
     //  TRACE_I("DrawingSmall itemIndex="<<dec<<itemIndex<<" y="<<itemRect->top);
 
     BOOL isItemFocusedOrEditMode = FALSE;
-    if (FocusedIndex == itemIndex) // drawing the cursor
+    if (FocusedIndex == itemIndex) // Draw the cursor.
     {
-        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched in the command-line
+        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched to the command line
             isItemFocusedOrEditMode = TRUE;
     }
     if (drawFlags & DRAWFLAG_NO_FRAME)
@@ -522,7 +522,7 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
         // if it is only the cursor position change, skip visibility tests
         drawFlags |= DRAWFLAG_SKIP_VISTEST;
 
-        // we are drawing only a small area and have plenty of time - so using the cache is fine
+        // only a small area is being drawn and there is enough time, so we will use the cache
         hDC = ItemBitmap.HMemDC;
 
         // the bitmap is empty for now
@@ -560,7 +560,7 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
         innerRect.bottom = innerRect.top + IconSizes[ICONSIZE_16];
 
         // clear the area around the icon
-        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), the background color must not be painted
+        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), the background color must not be filled
             FillIntersectionRegion(hDC, &iconRect, &innerRect);
 
         /*
@@ -634,9 +634,9 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
         // text drawing
         //
         // !!! Warning !!!
-        // For smooth rendering of the whole line the GdiBatchLimit is used
-        // Ensure text drawing does not interrupt buffering
-        // (GDI functions do not return BOOL they call GdiFlush())
+        // GdiBatchLimit is used for smooth rendering of the whole line
+        // It is necessary to ensure that buffering is not interrupted during text drawing
+        // (GDI functions that do not return BOOL call GdiFlush())
         //
         //    GdiFlush();
 
@@ -834,7 +834,7 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
                     else
                     {
                         // extension is an exception - it always follows Name and we handle it explicitly
-                        if (isDir && !Configuration.SortDirsByExt || f->Ext[0] == 0 || f->Ext <= f->Name + 1) // empty value in the Ext column (exception for names like ".htaccess", they appear in the Name column even though they are extensions)
+                        if (isDir && !Configuration.SortDirsByExt || f->Ext[0] == 0 || f->Ext <= f->Name + 1) // empty value in the Ext column (exception for names like ".htaccess", which are shown in the Name column even though they look like extensions)
                             TransferLen = 0;
                         else
                         {
@@ -850,7 +850,7 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
                         ExtTextOut(hDC, r.left, y, ETO_OPAQUE, &adjR, "", 0, NULL); // just clearing
                     else
                     {
-                        if (column->FixedWidth == 1) // NarrowedNameColumn does not apply here (not Name column)
+                        if (column->FixedWidth == 1) // NarrowedNameColumn does not apply here (this is not the Name column)
                         {
                             int fitChars;
                             // for fixed-width columns we must check whether the entire text fits
@@ -954,7 +954,7 @@ void CFilesWindow::DrawBriefDetailedItem(HDC hTgtDC, int itemIndex, RECT* itemRe
 
             DrawFocusRect(hDC, &r, (f->Selected == 1), Parent->EditMode);
             /*
-      // for debugging the dual cursor issue we need to distinguish normal focus and drop target
+      // to debug the two-cursor bug, we need to distinguish normal focus from the drop target
       if (itemIndex == DropTargetIndex)
       {
         MoveToEx(hDC, r.left, r.top + 3, NULL);
@@ -1002,7 +1002,7 @@ void SplitText(HDC hDC, const char* text, int textLen, int* maxWidth,
                char* out2, int* out2Len, int* out2Width)
 {
     SIZE sz;
-    // measure the width of every character
+    // measure the widths of all characters
     GetTextExtentExPoint(hDC, text, textLen, 0, NULL, DrawItemAlpDx, &sz);
 
     if (sz.cx > *maxWidth)
@@ -1017,7 +1017,7 @@ void SplitText(HDC hDC, const char* text, int textLen, int* maxWidth,
         int maxW = *maxWidth;
         int w = 0;
         int index = 0;
-        while (index < maxW) // this condition should not be applied
+        while (index < maxW) // this condition should not apply
         {
             if (text[index] == ' ')
                 lastSpaceIndex = index;
@@ -1061,7 +1061,7 @@ void SplitText(HDC hDC, const char* text, int textLen, int* maxWidth,
             if (*out1Len >= 3)
                 memmove(out1 + *out1Len - 3, "...", 3);
 
-            // look for a space where we can continue to the next line
+            // look for a space where we can break to the next line
             while (index < textLen)
             {
                 if (text[index++] == ' ')
@@ -1180,7 +1180,7 @@ void CFilesWindow::DrawIconThumbnailItem(HDC hTgtDC, int itemIndex, RECT* itemRe
     BOOL isItemFocusedOrEditMode = FALSE;
     if (FocusedIndex == itemIndex) // drawing the cursor
     {
-        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched in the command-line
+        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched to the command line
             isItemFocusedOrEditMode = TRUE;
     }
 
@@ -1295,7 +1295,7 @@ void CFilesWindow::DrawIconThumbnailItem(HDC hTgtDC, int itemIndex, RECT* itemRe
         // outer rectangle from which we clear towards the inner one
         RECT outerRect = rect;
 
-        // rectangle we will clear to
+        // rectangle towards which we will clear
         RECT innerRect;
         BOOL thickFrame = FALSE; // for Thumbnails only -- should the frame be doubled?
         if (GetViewMode() == vmThumbnails)
@@ -1485,7 +1485,7 @@ void CFilesWindow::DrawIconThumbnailItem(HDC hTgtDC, int itemIndex, RECT* itemRe
             y = outerRect.top + 4;
         }
 
-        // inner rectangle we clear towards
+        // inner rectangle towards which we clear
         RECT r;
         r.left = rect.left + (itemWidth - maxWidth) / 2 - 2;
         r.top = y - 2;
@@ -1495,10 +1495,10 @@ void CFilesWindow::DrawIconThumbnailItem(HDC hTgtDC, int itemIndex, RECT* itemRe
             r.bottom += FontCharHeight;
 
         // clear the background around the text
-        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), the background color must not be painted
+        if ((drawFlags & DRAWFLAG_MASK) == 0) // When drawing the mask (B&W), do not draw the background color
             FillIntersectionRegion(hDC, &outerRect, &r);
 
-        if (drawFocusFrame) // if there won't be a frame displayed, reduce the area by it
+        if (drawFocusFrame) // if the focus frame will be drawn, shrink the area for it
             InflateRect(&r, -1, -1);
 
         int oldRTop = r.top;
@@ -1556,7 +1556,7 @@ void TruncateSringToFitWidth(HDC hDC, char* buffer, int* bufferLen, int maxTextW
         // search from the end for the character after which we can copy "..." and it fits in the column
         while (fitChars > 0 && DrawItemAlpDx[fitChars - 1] + TextEllipsisWidth > maxTextWidth)
             fitChars--;
-        // copy part of the original string to another buffer
+        // copy part of the original string within the buffer
         if (fitChars > 0)
         {
             // and append "..."
@@ -1739,9 +1739,9 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
     //  TRACE_I("DrawTileItem itemIndex="<<dec<<itemIndex<<" y="<<itemRect->top);
 
     BOOL isItemFocusedOrEditMode = FALSE;
-    if (FocusedIndex == itemIndex) // drawing the cursor
+    if (FocusedIndex == itemIndex) // draw the cursor
     {
-        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched in the command-line
+        if (FocusVisible || Parent->EditMode && Parent->GetActivePanel() == this) // switched to the command line
             isItemFocusedOrEditMode = TRUE;
     }
 
@@ -1784,7 +1784,7 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
         innerRect.bottom = iconY + iconH;
 
         // clear the background around the icon or frame (for Thumbnails)
-        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), the background color must not be painted
+        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), do not draw the background color
             FillIntersectionRegion(hDC, &outerRect, &innerRect);
         // no thumbnail available -> draw the icon
         DrawIcon(hDC, f, isDir, isItemUpDir, isItemFocusedOrEditMode,
@@ -1878,7 +1878,7 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
         textY += 2;
 
         // clear the background around the text
-        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), the background color must not be painted
+        if ((drawFlags & DRAWFLAG_MASK) == 0) // when drawing the mask (b&w), do not draw the background color
             FillIntersectionRegion(hDC, &outerRect, &r);
 
         //    if (drawFocusFrame) // if there won't be a frame displayed, reduce the area by it
@@ -1984,7 +1984,7 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
     int iconW = IconSizes[iconSize];
     int iconH = IconSizes[iconSize];
 
-    // for a thumbnail overlayRect != NULL and we move the overlay to its lower left corner
+    // For thumbnails, overlayRect != NULL and we move the overlay to its bottom-left corner
     if (overlayRect != NULL)
     {
         xOverlayDst = overlayRect->left;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 27 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 269 comment units, 269 review results, 269 resolved results, and 269 apply results.
- Branch-target comment guard passed for `src/fileswn4.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/fileswn4.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 37 provider calls, 531665 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 24 calls, 377067 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 13 calls, 154598 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
