### PR TITLE
[translation] Fix src/geticon.cpp comments

### DIFF
--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -66,7 +66,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
 {
     BOOL ret = FALSE;
 
-    IExtractIconA* pxi = NULL; // if 'isIExtractIconW' is TRUE, this pointer is actually IExtractIconW
+    IExtractIconA* pxi = NULL; // if 'isIExtractIconW' is TRUE, this pointer is of type IExtractIconW
     BOOL isIExtractIconW = FALSE;
     HICON hIconSmall = NULL;
     HICON hIconLarge = NULL;
@@ -227,7 +227,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
             else
                 hres = pxi->Extract(iconFile, iconIndex, &hIconLarge, &hIconSmall, MAKELONG(IconSizes[largeIconSize], IconSizes[ICONSIZE_16]));
             //TRACE_I("  SalGetIconFromPIDL() pxi->Extract() hIconLarge="<<hIconLarge<<" hIconSmall="<<hIconSmall<<" isIExtractIconW="<<isIExtractIconW);
-            // WARNING: for *.ai files iconFile==0 and iconIndex==0 yet Extract() still returns an icon (Adobe Illustrator shell extension)
+            // WARNING: for *.ai files, iconFile==0 and iconIndex==0, yet Extract() still returns an icon (apparently due to the Adobe Illustrator shell extension)
             // WARNING: D:\Store\Salamand\ICO_SONY\SonyF707_Day_Flash.icc returns hIconLarge==hIconSmall, both 32x32
         }
 
@@ -288,7 +288,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         // use hIconSmall for the small icon because IExtractIcon::Extract() ignores the pixel size and always returns 16 and 32
         if (iconSize == ICONSIZE_16)
         {
-            // if the small icon is missing or we were given the handle of the large one, create it
+            // if the small icon is missing or we were given the large icon handle, create it
             if (hIconSmall == NULL || hIconSmall == hIconLarge)
             {
                 hIconSmall = (HICON)CopyImage(hIconLarge, IMAGE_ICON, IconSizes[ICONSIZE_16], IconSizes[ICONSIZE_16], LR_COPYFROMRESOURCE);
@@ -303,7 +303,7 @@ BOOL SalGetIconFromPIDL(IShellFolder* psf, const char* path, LPCITEMIDLIST pidl,
         }
         else // ICONSIZE_32 || ICONSIZE_48
         {
-            // if the large icon is missing or we were given the handle of the small one, create it
+            // if the large icon is missing or we were given the small icon handle, create it
             if (hIconLarge == NULL || hIconSmall == hIconLarge)
             {
                 hIconLarge = (HICON)CopyImage(hIconSmall, IMAGE_ICON, IconSizes[largeIconSize], IconSizes[largeIconSize], LR_COPYFROMRESOURCE);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/geticon.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 54 comment units, 54 review results, 54 resolved results, and 54 apply results.
- Branch-target comment guard passed for `src/geticon.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/geticon.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 157545 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 93285 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 64260 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
