### PR TITLE
[translation] Fix src/jumplist.cpp comments

### DIFF
--- a/src/jumplist.cpp
+++ b/src/jumplist.cpp
@@ -21,8 +21,8 @@ http://msdn.microsoft.com/en-us/library/dd378460%28v=VS.85%29.aspx#custom_jump_l
 DEFINE_PROPERTYKEY(PKEY_Title, 0xF29F85E0, 0x4FF9, 0x1068, 0xAB, 0x91, 0x08, 0x00, 0x2B, 0x27, 0xB3, 0xD9, 2);
 DEFINE_PROPERTYKEY(PKEY_AppUserModel_IsDestListSeparator, 0x9F4C2855, 0x9F79, 0x4B39, 0xA8, 0xD0, 0xE1, 0xD4, 0x2D, 0xE1, 0xD5, 0xF3, 6);
 
-// We want to link the unique process ID with the configuration
-// (two different versions of Salamander may, for example, have different hot paths)
+// Associate the unique process ID with the configuration
+// (for example, two different versions of Salamander may have different hot paths)
 //const char *SALAMANDER_APP_ID = "OPENSAL.OpenSalamanderAppID." VERSINFO_xstr(VERSINFO_BUILDNUMBER);
 
 //typedef WINSHELLAPI HRESULT (WINAPI *FT_SetCurrentProcessExplicitAppUserModelID)(PCWSTR appID);
@@ -170,7 +170,7 @@ HRESULT CreateShellLink(const char* path, const char* name, IShellLink** psl)
             lstrcpyn(desc, path, _countof(desc));
             if (strlen(path) >= _countof(desc))
                 strcpy(desc + _countof(desc) - 4, "..."); // indicates the path has been truncated
-            ret->SetDescription(desc);                    // MAX_PATH+1 is the limit (at least on Windows 7 where I'm testing now); longer = the jump list won't show at all
+            ret->SetDescription(desc);                    // MAX_PATH+1 is the limit (at least on Windows 7, where this was tested); if it is longer, the jump list will not be shown
             ret->SetIconLocation("shell32.dll", -319);    // this icon exists from Windows XP onwards
 
             // To set the link title, we require the property store of the link.
@@ -284,7 +284,7 @@ void CreateJumpList()
         IID_PPV_ARGS(&pcdl));
     if (SUCCEEDED(hr))
     {
-        //important to setup App Id for the Jump List
+        // Important to set up the App ID for the Jump List
         //wchar_t appID[500];
         //ConvertA2U(SALAMANDER_APP_ID, -1, appID, _countof(appID));
         //hr = pcdl->SetAppID(appID);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/jumplist.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 19 comment units, 19 review results, 19 resolved results, and 19 apply results.
- Branch-target comment guard passed for `src/jumplist.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/jumplist.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 159718 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 45837 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 113881 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
