### PR TITLE
[translation] Fix src/logo.cpp comments

### DIFF
--- a/src/logo.cpp
+++ b/src/logo.cpp
@@ -166,7 +166,7 @@ BOOL CSplashScreen::PrepareBitmap()
     svgGrad.AlphaBlend(hDC, 0, GradientY, gradSize.cx, Height - GradientY, SVGSTATE_ORIGINAL);
     svgHand.AlphaBlend(hDC, Width - handSize.cx, 0, handSize.cx, handSize.cy, SVGSTATE_ORIGINAL);
 
-    // fixed texts
+    // static text
     PaintText(SALAMANDER_TEXT_VERSION,
               VersionR.left,
               VersionR.top,
@@ -457,7 +457,7 @@ CAboutDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (WindowsVistaAndLater)
                 return (BOOL)(UINT_PTR)HGradientBkBrush;
             else
-                return (BOOL)(UINT_PTR)GetStockObject(NULL_BRUSH); // under XP this still worked fine
+                return (BOOL)(UINT_PTR)GetStockObject(NULL_BRUSH); // this still worked correctly on XP
         }
         break;
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/logo.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 19 comment units, 19 review results, 19 resolved results, and 19 apply results.
- Branch-target comment guard passed for `src/logo.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/logo.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 49468 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 23572 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 25896 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
