### PR TITLE
[translation] Fix src/mainwnd1.cpp comments

### DIFF
--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -198,8 +198,8 @@ BOOL CHotPathItems::Save(HKEY hKey)
 
             if (*name == 0 && *path == 0 && visible == TRUE)
             {
-                // optimization: don't clutter the registry unless needed
-                // not ready for configuration merging, but neither is the rest of our configuration
+                // Optimization: do not write to the registry unless necessary
+                // Not ready for configuration merging, but neither is the rest of the configuration
                 ClearKey(actKey);
                 CloseKey(actKey);
                 DeleteKey(hKey, keyName);
@@ -238,7 +238,7 @@ BOOL CHotPathItems::Load(HKEY hKey)
             CleanName(name);
             if (GetValue(actKey, SALAMANDER_HOTPATHS_PATH, REG_SZ, path, HOTPATHITEM_MAXPATH))
             {
-                if (Configuration.ConfigVersion < 47)            // the old path limit was MAX_PATH, so it fits with expansion
+                if (Configuration.ConfigVersion < 47)            // the old path was limited to MAX_PATH, so it still fits after expansion
                     DuplicateDollars(path, HOTPATHITEM_MAXPATH); // if the path is long and contains '$', the end might be truncated; we ignore it
             }
             GetValue(actKey, SALAMANDER_HOTPATHS_VISIBLE, REG_DWORD, &visible, sizeof(DWORD));
@@ -267,7 +267,7 @@ BOOL CHotPathItems::Load1_52(HKEY hKey)
         itoa(i, keyName, 10);
         if (GetValue(hKey, keyName, REG_SZ, path, MAX_PATH))
         {
-            DuplicateDollars(path, MAX_PATH); // if the path is long and contains '$', the end might be truncated; ignore it
+            DuplicateDollars(path, MAX_PATH); // if the path is long and contains '$', the end may be truncated; this is not addressed
             strcpy(name, path);
         }
 
@@ -352,7 +352,7 @@ CMainWindow::CMainWindow() : ChangeNotifArray(3, 5)
     item = new CViewerMasksItem();
     if (ViewerMasks != NULL && item != NULL)
     {
-        ViewerMasks->Add(item); // no critical section needed, we're in the constructor
+        ViewerMasks->Add(item); // no critical section needed; this is the constructor
         item->Set("*.htm;*.html;*.xml;*.mht", "", "", "");
         item->ViewerType = -4; // IE viewer (4th plugin in the default configuration)
     }
@@ -360,7 +360,7 @@ CMainWindow::CMainWindow() : ChangeNotifArray(3, 5)
     item = new CViewerMasksItem();
     if (ViewerMasks != NULL && item != NULL)
     {
-        ViewerMasks->Add(item); // no critical section needed, we're in the constructor
+        ViewerMasks->Add(item); // no critical section is needed; this is the constructor
         item->Set("*.rpm", "", "", "");
         item->ViewerType = -2; // TAR (2nd plugin in the default configuration)
     }
@@ -368,7 +368,7 @@ CMainWindow::CMainWindow() : ChangeNotifArray(3, 5)
     item = new CViewerMasksItem();
     if (ViewerMasks != NULL && item != NULL)
     {
-        ViewerMasks->Add(item); // no critical section needed, we're in the constructor
+        ViewerMasks->Add(item); // no critical section is needed; this is the constructor
         item->Set("*.*", "", "", "");
         item->ViewerType = VIEWER_INTERNAL; // internal viewer
     }
@@ -558,7 +558,7 @@ BOOL CMainWindow::TogglePluginsBar(BOOL storePos)
         if (!PluginsBar->CreateWnd(HTopRebar))
             return FALSE;
         //    IdleForceRefresh = TRUE;   // force an update
-        //    IdleRefreshStates = TRUE;  // on next Idle, enforce a check on status variables
+        //    IdleRefreshStates = TRUE;  // on the next Idle, force a check of the state variables
         PluginsBar->CreatePluginButtons();
         InsertPluginsBarBand();
         ShowWindow(PluginsBar->HWindow, SW_SHOW);
@@ -1182,7 +1182,7 @@ void CMainWindow::EditWindowSetDirectory()
         EditWindow->Enable(TRUE); // cached in EditWindow
         EditWindow->SetDirectory(dir);
     }
-    else // disable/hide edit-line
+    else // disable/hide the edit line
     {
         if (EditMode && panel != NULL) // release focus from command line before disabling it
             FocusPanel(panel, TRUE);
@@ -1241,7 +1241,7 @@ void CMainWindow::SetUnescapedHotPath(int index, const char* path)
         lstrcpyn(HotPathSetBufferName, path, MAX_PATH);
         lstrcpyn(HotPathSetBufferPath, path, HOTPATHITEM_MAXPATH);
         DuplicateDollars(HotPathSetBufferPath, HOTPATHITEM_MAXPATH);
-        // open the HotPaths page and edit item index
+        // open the HotPaths page and start editing item index
         PostMessage(HWindow, WM_USER_CONFIGURATION, 1, index);
     }
     else
@@ -1760,7 +1760,7 @@ void CMainWindow::GetFormatedPathForTitle(char* path)
                                 if (chars < pathLen)
                                     lastChars = chars;
                                 else
-                                    break; // end of path isn't a point of division;bug in GetNextDirectoryLineHotPath implementation
+                                    break; // end of path is not a split point; bug in GetNextDirectoryLineHotPath implementation
                             }
                             trimEnd = path + lastChars;
                         }
@@ -1813,7 +1813,7 @@ void CMainWindow::GetFormatedPathForTitle(char* path)
                             if (chars < pathLen)
                                 lastChars = chars;
                             else
-                                break; // end of path isn't a point of division; bug in GetNextDirectoryLineHotPath implementation
+                                break; // end of path is not a split point; bug in GetNextDirectoryLineHotPath implementation
                         }
                         if (lastChars > 0)
                         {
@@ -3053,7 +3053,7 @@ void CMainWindow_RefreshCommandStates(CMainWindow* obj)
 
 void CMainWindow::RefreshCommandStates()
 {
-    CMainWindow_RefreshCommandStates(this); // this hack exists because we can't obtain the object's method address (as a plain function we can)
+    CMainWindow_RefreshCommandStates(this); // this workaround exists because the address of an object method cannot be obtained here (unlike for a plain function)
 }
 
 void CMainWindow::OnEnterIdle()


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/mainwnd1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 12 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 215 comment units, 215 review results, 215 resolved results, and 215 apply results.
- Branch-target comment guard passed for `src/mainwnd1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/mainwnd1.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 25 provider calls, 504310 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 18 calls, 352863 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 151447 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
