### PR TITLE
[translation] Fix src/mapi.cpp comments

### DIFF
--- a/src/mapi.cpp
+++ b/src/mapi.cpp
@@ -28,9 +28,9 @@ BOOL CSimpleMAPI::Init(HWND hParent)
         HLibrary = HANDLES_Q(LoadLibrary("mapi32.dll"));
         if (HLibrary == NULL)
         {
-            // under NT4.0 US + IE 4.01 US, mapi32.dll is not installed
-            // but I found msoemapi.dll there which has the necessary export and more importantly, it works,
-            // so why not try it...
+            // Under NT 4.0 US + IE 4.01 US, mapi32.dll is not installed,
+            // but I found msoemapi.dll there. It has the required export and,
+            // more importantly, it works, so it is worth trying.
             HLibrary = HANDLES_Q(LoadLibrary("msoemapi.dll"));
             if (HLibrary == NULL)
             {
@@ -144,7 +144,7 @@ BOOL CSimpleMAPI::SendMail()
     message.nFileCount = FileNames.Count;
     message.lpFiles = fileDesc;
 
-    char* subject = (char*)malloc(subjectSize + strlen(LoadStr(IDS_EMAILFILES_SUBJECT)) + 2); // space for "emailing" and the terminating NULL
+    char* subject = (char*)malloc(subjectSize + strlen(LoadStr(IDS_EMAILFILES_SUBJECT)) + 2); // space for the email subject and the terminating NULL
     if (subject == NULL)
     {
         TRACE_E(LOW_MEMORY);
@@ -183,8 +183,8 @@ BOOL CSimpleMAPI::SendMail()
 
     free(subject);
     free(fileDesc);
-    // report nothing because various clients return different values
-    // for example Outlook 6 on XP returned 1 when cancelling a message or 3
+    // do not report anything, because different clients return different values
+    // for example, Outlook 6 on XP returned 1 when cancelling a message or 3
     // when cancelling the connection wizard (if it was not configured)
     /*
   if (ret != 0)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/mapi.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 20 comment units, 20 review results, 20 resolved results, and 20 apply results.
- Branch-target comment guard passed for `src/mapi.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/mapi.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 70416 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 70416 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
