### PR TITLE
[translation] Fix src/menu1.cpp comments

### DIFF
--- a/src/menu1.cpp
+++ b/src/menu1.cpp
@@ -284,7 +284,7 @@ void CMenuItem::DecodeSubTextLenghtsAndWidths(CMenuSharedResources* sharedRes, B
     ColumnL2 = NULL;
     ColumnR = NULL;
 
-    // set column pointers and character counts
+    // set pointers and character counts for each column
     while (inifiniteLoop)
     {
         if (*iterator == '\t' || *iterator == 0)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/menu1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 20 comment units, 20 review results, 20 resolved results, and 20 apply results.
- Branch-target comment guard passed for `src/menu1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/menu1.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 26743 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 24402 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 2341 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
