### PR TITLE
[translation] Fix src/menubar.cpp comments

### DIFF
--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -396,7 +396,7 @@ void CMenuBar::EnterMenuInternal(int index, BOOL openWidthSelect, BOOL byMouse)
             case WM_KEYDOWN:
             {
                 BOOL shiftPressed = (GetKeyState(VK_SHIFT) & 0x8000) != 0;
-                if (msg.wParam == VK_MENU && (msg.lParam & 0x40000000) == 0 || // Alt down, but not an autorepeat
+                if (msg.wParam == VK_MENU && (msg.lParam & 0x40000000) == 0 || // Alt down, but not auto-repeat
                     (!shiftPressed && msg.wParam == VK_F10))
                 {
                     leaveLoop = TRUE;
@@ -556,7 +556,7 @@ void CMenuBar::EnterMenuInternal(int index, BOOL openWidthSelect, BOOL byMouse)
 
     // remove ourselves from monitoring closing messages
     MenuWindowQueue.Remove(HWindow);
-    // if we hooked, we will also unhook
+    // if we hooked the thread, we will also unhook it
     if (hOldHookProc != NULL)
         OldMenuHookTlsAllocator.UnhookThread(hOldHookProc);
 
@@ -715,7 +715,7 @@ BOOL CMenuBar::IsMenuBarMessage(CONST MSG* lpMsg)
         }
         else
         {
-            WheelDuringMenu = FALSE; // if the user scrolled the wheel and then typed a number (Alt+numXXX), we will ignore the scrolling
+            WheelDuringMenu = FALSE; // if the user scrolled the wheel and then typed a number (Alt+numXXX), scrolling is ignored
             HandlingVK_MENU = FALSE;
         }
         if (wParam == VK_F10)
@@ -754,7 +754,7 @@ BOOL CMenuBar::IsMenuBarMessage(CONST MSG* lpMsg)
             if (WheelDuringMenu)
             {
                 WheelDuringMenu = FALSE;
-                return TRUE; // suppress releasing Alt after Alt+Wheel, otherwise the window menu opens (without being shown)
+                return TRUE; // suppress Alt release after Alt+Wheel; otherwise the window menu is entered without being shown
             }
             // if the user did not use the wheel, we must not process the message
             // Alt+num064 (etc.) is used for inserting characters
@@ -826,7 +826,7 @@ CMenuBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
-        if (WindowsVistaAndLater) // under Vista the rebar flickers
+        if (WindowsVistaAndLater) // On Vista, the rebar flickers
             return TRUE;
         RECT r;
         GetClientRect(HWindow, &r);
@@ -908,7 +908,7 @@ CMenuBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             int newHotIndex = HotIndex;
             if (hitItem)
             {
-                if (!HelpMode2 && !MenuLoop && !MouseIsTracked) // capture is needed only in the track mode
+                if (!HelpMode2 && !MenuLoop && !MouseIsTracked) // mouse leave tracking is needed only in track mode
                 {
                     TRACKMOUSEEVENT tme;
                     tme.cbSize = sizeof(tme);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/menubar.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 67 comment units, 67 review results, 67 resolved results, and 67 apply results.
- Branch-target comment guard passed for `src/menubar.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/menubar.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 13 provider calls, 231179 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 126931 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 104248 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
