### PR TITLE
[translation] Fix src/msgbox.cpp comments

### DIFF
--- a/src/msgbox.cpp
+++ b/src/msgbox.cpp
@@ -191,9 +191,9 @@ BOOL CMessageBox::EscapeEnabled()
         return TRUE;
 }
 
-// returns a copy of 'src' into which 'n' characters are inserted so that the resulting maximum
-// width does not exceed 'maxWidth'. Assumes that the hDC has the correct font selected.
-// returns NULL in case of failure
+// returns a copy of 'src' with '\n' characters inserted so that the resulting maximum
+// width does not exceed 'maxWidth'. Assumes that 'hDC' has the appropriate font selected.
+// returns NULL on failure
 
 char* DuplicateStrAndInsertEOLs(const char* src, HDC hDC, int maxWidth)
 {
@@ -581,7 +581,7 @@ CMessageBox::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         // maximum width relative to the desktop where the dialog will appear
         int maxTextWidth = (int)((clipRect.right - clipRect.left) / 1.8);
-        if (maxTextWidth > fontCharWidth * 90) // since Windows Vista dialogs are narrower again - wrap at 90 average characters
+        if (maxTextWidth > fontCharWidth * 90) // Since Windows Vista, dialogs are narrower again, so wrap at 90 average-width characters.
             maxTextWidth = fontCharWidth * 90;
 
         tR.right = maxTextWidth;
@@ -589,8 +589,8 @@ CMessageBox::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (tR.right > maxTextWidth)
         {
-            // text width exceeds maxTextWidth limit, so we create a new one
-            // text into which we will insert hard line breaks
+            // text width exceeds the maxTextWidth limit, so we create new text
+            // with hard line breaks inserted
             const char* newText = DuplicateStrAndInsertEOLs(Text.Get(), hDC, maxTextWidth);
             if (newText != NULL)
             {
@@ -790,7 +790,7 @@ CMessageBox::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
                 // assign text
                 BOOL btnTextWasSet = FALSE;
-                if (AliasBtnNames != NULL) // alias button names
+                if (AliasBtnNames != NULL) // button name aliases
                 {
                     char tmpBuff[1000];
                     char seps[] = "\t";


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/msgbox.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 78 comment units, 78 review results, 78 resolved results, and 78 apply results.
- Branch-target comment guard passed for `src/msgbox.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/msgbox.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 165646 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 6 calls, 126919 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 38727 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
