### PR TITLE
[translation] Fix src/olespy.h comments

### DIFF
--- a/src/olespy.h
+++ b/src/olespy.h
@@ -11,7 +11,7 @@
 // Details on finding OLE leaks are described in OLESPY.CPP.
 
 // Attaches our IMallocSpy to OLE; COM must be initialized first.
-// If it returns TRUE, the followed functions can be called.
+// If it returns TRUE, the following functions can be called.
 BOOL OleSpyRegister();
 
 // Detaches the Spy from OLE; OleSpyDump can still be called after this function.


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/olespy.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 7 comment units, 7 review results, 7 resolved results, and 7 apply results.
- Branch-target comment guard passed for `src/olespy.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/olespy.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 43746 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 20409 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 23337 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
