### PR TITLE
[translation] Fix src/pack.h comments

### DIFF
--- a/src/pack.h
+++ b/src/pack.h
@@ -587,7 +587,7 @@ class CPackerFormatConfigData
 {
 public:
     char* Ext;         // list of extensions the archive can have
-    BOOL UsePacker;    // true if PackerIndex is valid (we can also pack)
+    BOOL UsePacker;    // true if PackerIndex is valid (packing is also supported)
     int PackerIndex;   // reference to the packer table
     int UnpackerIndex; // reference to the unpacker table
 
@@ -662,7 +662,7 @@ public:
     int GetFormatsCount() { return Formats.Count; } // returns the number of items in the array
 
     //    BOOL SwapFormats(int index1, int index2);         // swaps two items in the array
-    BOOL MoveFormat(int srcIndex, int dstIndex); // moves the item
+    BOOL MoveFormat(int srcIndex, int dstIndex); // moves the format
     void DeleteFormat(int index);
 
     int GetUnpackerIndex(int index) { return Formats[index]->UnpackerIndex; }
@@ -757,7 +757,7 @@ void PackAutoconfig(HWND parent);
 // runs the external program cmdLine and interprets the return code according to errorTable
 BOOL PackExecute(HWND parent, char* cmdLine, const char* currentDir, TPackErrorTable* const errorTable);
 
-// callback for enumeration by mask (used to extract all files matching the mask)
+// callback for enumeration by mask (used to unpack all files matching the mask)
 const char* WINAPI PackEnumMask(HWND parent, int enumFiles, BOOL* isDir, CQuadWord* size,
                                 const CFileData** fileData, void* param, int* errorOccured);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/pack.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 159 comment units, 159 review results, 159 resolved results, and 159 apply results.
- Branch-target comment guard passed for `src/pack.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/pack.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 14 provider calls, 274968 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 11 calls, 246635 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 28333 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
