### PR TITLE
[translation] Fix src/pack2.cpp comments

### DIFF
--- a/src/pack2.cpp
+++ b/src/pack2.cpp
@@ -189,12 +189,12 @@ BOOL PackCompress(HWND parent, CFilesWindow* panel, const char* archiveFileName,
     if (archiveRoot != NULL && *archiveRoot != '\0')
     {
         strcpy(archiveRootPath, archiveRoot);
-        if (!modifyTable->CanPackToDir) // the archiver program does not support it
+        if (!modifyTable->CanPackToDir) // the archiver does not support it
         {
             if ((*PackErrorHandlerPtr)(parent, IDS_PACKQRY_ARCPATH))
                 strcpy(archiveRootPath, "\\"); // the user wants to ignore it
             else
-                return FALSE; // the user will mind
+                return FALSE; // the user objects
         }
     }
     else
@@ -355,7 +355,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
             return (*PackErrorHandlerPtr)(parent, IDS_PACKERR_PATH, buffer);
         }
 
-        // and put it into the list
+        // and add it to the list file
         if (!isDir)
         {
             if (fprintf(listFile, "%s\n", namecnv) <= 0)
@@ -524,7 +524,7 @@ BOOL PackUniversalCompress(HWND parent, const char* command, TPackErrorTable* co
                         {
                             HANDLES(FindClose(find)); // this name already exists with some extension, searching further
                             (*PackErrorHandlerPtr)(parent, IDS_PACKERR_UNABLETOREN, src, dst);
-                            return TRUE; // succeeded, only the resulting archive names differ slightly (even multivolume)
+                            return TRUE; // Succeeded; only the names of the resulting archive differ slightly (including multivolume archives)
                         }
                     }
                     else
@@ -658,7 +658,7 @@ BOOL PackDelFromArc(HWND parent, CFilesWindow* panel, const char* archiveFileNam
             CharToOem(name, namecnv);
         else
             strcpy(namecnv, name);
-        // and put it into the list
+        // and add it to the list file
         if (!isDir)
         {
             if (fprintf(listFile, "%s%s\n", rootPath, namecnv) <= 0)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/pack2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 93 comment units, 93 review results, 93 resolved results, and 93 apply results.
- Branch-target comment guard passed for `src/pack2.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/pack2.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 22 provider calls, 409056 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 12 calls, 216919 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 10 calls, 192137 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
