### PR TITLE
[translation] Fix src/plugins4.cpp comments

### DIFF
--- a/src/plugins4.cpp
+++ b/src/plugins4.cpp
@@ -99,7 +99,7 @@ void CPlugins::UpdatePluginsOrder(BOOL sortByName)
             }
         }
         DWORD flags = 1;
-        if (foundIndex == -1) // this plugin has no record in the Order array => append it to the end
+        if (foundIndex == -1) // this plugin has no entry in the Order array => append it to the end
         {
             foundIndex = AddPluginToOrder(pluginData->DLLName, TRUE);
             if (firstAdded)
@@ -254,7 +254,7 @@ int CPlugins::FindIndexForNewPluginFSTimer(DWORD timeoutAbs)
         if (actTimeoutAbs == timeoutAbs)
         {
             while (++m < PluginFSTimers.Count && PluginFSTimers[m]->AbsTimeout - timeoutAbsBase == timeoutAbs)
-                ;     // return the index after the last identical timer
+                ;     // return the index after the last timer with the same timeout
             return m; // found
         }
         else if (actTimeoutAbs > timeoutAbs)
@@ -327,12 +327,12 @@ int CPlugins::KillPluginFSTimer(CPluginFSInterfaceAbstract* timerOwner, BOOL all
             ret++;
         }
     }
-    if (setTimer) // the timer with the nearest timeout was cancelled, the timeout must be reset
+    if (setTimer) // the timer with the nearest timeout was canceled; the timeout must be reset
     {
         if (PluginFSTimers.Count > 0)
         {
             DWORD ti = PluginFSTimers[0]->AbsTimeout - GetTickCount();
-            if ((int)ti > 0) // if the new timer hasn't already timed out (the difference can even be negative), adjust or start the Windows timer
+            if ((int)ti > 0) // if the new timer has not already expired (the time difference can even be negative), adjust or start the Windows timer
             {
                 SetTimer(MainWindow->HWindow, IDT_PLUGINFSTIMERS, ti, NULL);
             }
@@ -411,7 +411,7 @@ void CPlugins::HandlePluginFSTimers()
         if (PluginFSTimers.Count > 0)
         {
             DWORD ti = PluginFSTimers[0]->AbsTimeout - GetTickCount();
-            if ((int)ti > 0) // if the new timer hasn't already timed out (the difference can even be negative), adjust or start the Windows timer
+            if ((int)ti > 0) // if the new timer has not already expired (the time difference can even be negative), adjust or start the Windows timer
                 SetTimer(MainWindow->HWindow, IDT_PLUGINFSTIMERS, ti, NULL);
             else
                 PostMessage(MainWindow->HWindow, WM_TIMER, IDT_PLUGINFSTIMERS, 0); // process the next timeout as soon as possible


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 34 comment units, 34 review results, 34 resolved results, and 34 apply results.
- Branch-target comment guard passed for `src/plugins4.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins4.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 136856 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 94331 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 42525 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
