### PR TITLE
[translation] Fix src/pwdmngr.cpp comments

### DIFF
--- a/src/pwdmngr.cpp
+++ b/src/pwdmngr.cpp
@@ -158,7 +158,7 @@ BOOL UnscramblePassword(char* password)
     }
     if (!ok)
     {
-        password[0] = 0; // some error occured; clear the password
+        password[0] = 0; // some error occurred; clear the password
         TRACE_E("Unable to unscramble password! scrambled=" << backup);
     }
     memset(backup, 0, lstrlen(backup)); // wipe the memory that contained the password
@@ -618,7 +618,7 @@ BOOL CPasswordManager::DecryptPassword(const BYTE* encryptedPassword, int encryp
 
 TRY_DECRYPT_AGAIN:
 
-    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 for the terminator so we can call unscramble after AES 
+    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 for the terminator so we can call UnscramblePassword after AES
     memcpy(tmpBuff, encryptedPassword, encryptedPasswordSize);
     tmpBuff[encryptedPasswordSize] = 0; // terminator required by UnscramblePassword
 
@@ -641,10 +641,6 @@ TRY_DECRYPT_AGAIN:
 
             if (plainMasterPassword == OldPlainMasterPassword && UseMasterPassword && PlainMasterPassword != NULL)
             { // handle the case where the password is encrypted with the new master password
-              // (the password cannot be decrypted with the old master password, but can with the new one,
-              // therefore, the message that the password cannot be decrypted would be misleading,
-              // because when the user tries to decrypt it with the new master password, it succeeds
-              // meaning the user has no way to identify the undecryptable password)
                 plainMasterPassword = PlainMasterPassword;
                 goto TRY_DECRYPT_AGAIN;
             }
@@ -718,7 +714,7 @@ void CPasswordManager::SetMasterPassword(HWND hParent, const char* password)
         Plugins.PasswordManagerEvent(hParent, OldPlainMasterPassword == NULL ? PME_MASTERPASSWORDCREATED : PME_MASTERPASSWORDCHANGED);
     }
 
-    // the thread has returned from calling Plugins.PasswordManagerEvent(), so we can discard OldPlainMasterPassword
+    // the thread has returned from Plugins.PasswordManagerEvent(), so we can discard OldPlainMasterPassword
     if (OldPlainMasterPassword != NULL)
     {
         free(OldPlainMasterPassword);
@@ -840,7 +836,7 @@ BOOL CPasswordManager::Save(HKEY hKey)
 BOOL CPasswordManager::Load(HKEY hKey)
 {
     BOOL ret = TRUE;
-    // password manager configuration data
+    // password manager configuration
     if (ret)
         ret &= GetValue(hKey, SALAMANDER_PWDMNGR_USEMASTERPWD, REG_DWORD, &UseMasterPassword, sizeof(UseMasterPassword));
     if (UseMasterPassword)
@@ -855,7 +851,7 @@ BOOL CPasswordManager::Load(HKEY hKey)
 
 BOOL CPasswordManager::AskForMasterPassword(HWND hParent)
 {
-    // return FALSE if master password usage is disabled
+    // return FALSE if the master password is not used
     if (!UseMasterPassword)
         return FALSE;
 

--- a/src/pwdmngr.cpp
+++ b/src/pwdmngr.cpp
@@ -618,7 +618,7 @@ BOOL CPasswordManager::DecryptPassword(const BYTE* encryptedPassword, int encryp
 
 TRY_DECRYPT_AGAIN:
 
-    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 for the terminator so we can call UnscramblePassword after AES
+    BYTE* tmpBuff = (BYTE*)malloc(encryptedPasswordSize + 1); // +1 for the terminator so we can call unscramble after AES
     memcpy(tmpBuff, encryptedPassword, encryptedPasswordSize);
     tmpBuff[encryptedPasswordSize] = 0; // terminator required by UnscramblePassword
 
@@ -641,6 +641,10 @@ TRY_DECRYPT_AGAIN:
 
             if (plainMasterPassword == OldPlainMasterPassword && UseMasterPassword && PlainMasterPassword != NULL)
             { // handle the case where the password is encrypted with the new master password
+              // (the password cannot be decrypted with the old master password, but can with the new one,
+              // therefore, the message that the password cannot be decrypted would be misleading,
+              // because when the user tries to decrypt it with the new master password, it succeeds
+              // meaning the user has no way to identify the undecryptable password)
                 plainMasterPassword = PlainMasterPassword;
                 goto TRY_DECRYPT_AGAIN;
             }
@@ -714,7 +718,7 @@ void CPasswordManager::SetMasterPassword(HWND hParent, const char* password)
         Plugins.PasswordManagerEvent(hParent, OldPlainMasterPassword == NULL ? PME_MASTERPASSWORDCREATED : PME_MASTERPASSWORDCHANGED);
     }
 
-    // the thread has returned from Plugins.PasswordManagerEvent(), so we can discard OldPlainMasterPassword
+    // the thread has returned from calling Plugins.PasswordManagerEvent(), so we can discard OldPlainMasterPassword
     if (OldPlainMasterPassword != NULL)
     {
         free(OldPlainMasterPassword);
@@ -836,7 +840,7 @@ BOOL CPasswordManager::Save(HKEY hKey)
 BOOL CPasswordManager::Load(HKEY hKey)
 {
     BOOL ret = TRUE;
-    // password manager configuration
+    // password manager configuration data
     if (ret)
         ret &= GetValue(hKey, SALAMANDER_PWDMNGR_USEMASTERPWD, REG_DWORD, &UseMasterPassword, sizeof(UseMasterPassword));
     if (UseMasterPassword)
@@ -851,7 +855,7 @@ BOOL CPasswordManager::Load(HKEY hKey)
 
 BOOL CPasswordManager::AskForMasterPassword(HWND hParent)
 {
-    // return FALSE if the master password is not used
+    // return FALSE if master password usage is disabled
     if (!UseMasterPassword)
         return FALSE;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/pwdmngr.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 105 comment units, 105 review results, 105 resolved results, and 105 apply results.
- Branch-target comment guard passed for `src/pwdmngr.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/pwdmngr.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 222321 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 8 calls, 197450 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 24871 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
