### PR TITLE
[translation] Fix src/pwdmngr.h comments

### DIFF
--- a/src/pwdmngr.h
+++ b/src/pwdmngr.h
@@ -96,7 +96,7 @@ class CPasswordManager
 private:
     BOOL UseMasterPassword;                          // the user has (at some point) provided the master password used for data encryption; the plaintext value may later be NULL and must be requested again
     char* PlainMasterPassword;                       // allocated password (in plaintext) terminated by a null character; NULL if the user has not entered it during this session; not stored into the registry
-    char* OldPlainMasterPassword;                    // temporarily holds the previous PlainMasterPassword during the call to Plugins.PasswordManagerEvent(), allowing the plug-in to request decryption of its passwords
+    char* OldPlainMasterPassword;                    // temporarily holds the previous PlainMasterPassword during the call to Plugins.PasswordManagerEvent(), allowing the plugin to request decryption of its passwords
     CMasterPasswordVerifier* MasterPasswordVerifier; // used to verify the correctness of the master password; stored in the registry; may be NULL
 
     CSalamanderCryptAbstract* SalamanderCrypt; // interface for the work with cryptographic library


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/pwdmngr.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 28 comment units, 28 review results, 28 resolved results, and 28 apply results.
- Branch-target comment guard passed for `src/pwdmngr.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/pwdmngr.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 68748 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 68748 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
