### PR TITLE
[translation] Fix src/regwork.cpp comments

### DIFF
--- a/src/regwork.cpp
+++ b/src/regwork.cpp
@@ -733,7 +733,7 @@ BOOL CRegistryWorkerThread::CInUseHandler::CanUseThread(CRegistryWorkerThread* t
             t->InUse = TRUE;
             T = t; // destructor will set T->InUse = FALSE
         }
-        // otherwise // this is a recursive call (due to the message loop and thus message distribution) = we reject running the work there
+        // otherwise this is a recursive call (due to the message loop and thus message dispatch), so we reject running the work in the thread
         return ret;
     }
     return FALSE;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/regwork.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 33 comment units, 33 review results, 33 resolved results, and 33 apply results.
- Branch-target comment guard passed for `src/regwork.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/regwork.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 90105 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 90105 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
