### PR TITLE
[translation] Fix src/regwork.h comments

### DIFF
--- a/src/regwork.h
+++ b/src/regwork.h
@@ -88,7 +88,7 @@ public:
     BOOL CreateKey(HKEY key, const char* name, HKEY& createdKey);
 
     // opens the existing subkey 'name' of key 'key'; returns the handle in 'openedKey'
-    // and TRUE on success. The returned key ('createdKey') must be closed by calling the CloseKey.
+    // and TRUE on success. The returned key ('openedKey') must be closed by calling CloseKey.
     BOOL OpenKey(HKEY key, const char* name, HKEY& openedKey);
 
     // closes a key previously opened via OpenKey or CreateKey
@@ -121,7 +121,7 @@ protected:
     // thread body - all work takes place here
     unsigned Body();
 
-    static DWORD WINAPI ThreadBody(void* param); // helper function for the thread body
+    static DWORD WINAPI ThreadBody(void* param); // thread entry function
     static unsigned ThreadBodyFEH(void* param);  // helper function for the thread body
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/regwork.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 26 comment units, 26 review results, 26 resolved results, and 26 apply results.
- Branch-target comment guard passed for `src/regwork.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/regwork.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 112927 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 92427 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20500 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
