### PR TITLE
[translation] Fix src/salamand.h comments

### DIFF
--- a/src/salamand.h
+++ b/src/salamand.h
@@ -111,8 +111,7 @@ public:
     // sorts the Dirs and Files lists so that Contains() can be called;
     void Sort();
 
-    // returns TRUE if the name specified through 'nameIsDir' and 'name' is present in one
-    // of the arrays; if 'foundOnIndex' is not NULL, it returns the index where the item was found
+    // returns TRUE if the name specified by 'nameIsDir' and 'name' is present in one of the arrays; if 'foundOnIndex' is not NULL, it receives the index at which the item was found
     BOOL Contains(BOOL nameIsDir, const char* name, int* foundOnIndex = NULL);
 
     // returns the total number of stored names
@@ -259,7 +258,7 @@ public:
 
     BOOL IsGood() { return FileName != NULL; }
 
-    // returns TRUE if the object was constructed from the specified data
+    // returns TRUE if the object matches the specified data
     BOOL Equal(CFileHistoryItemTypeEnum type, DWORD handlerID, const char* fileName);
 
     BOOL Execute();
@@ -406,7 +405,7 @@ public:
     void Set(DWORD index, const char* name, DWORD flags, BOOL leftSmartMode, BOOL rightSmartMode);
 
     BOOL SwapItems(int index1, int index2); // swaps two items in the array
-    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is ok
+    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is not empty
 
     int SaveColumns(CColumnConfig* columns, char* buffer);  // convert the array to a string
     void LoadColumns(CColumnConfig* columns, char* buffer); // and back again
@@ -449,9 +448,9 @@ public:
     // detaches the data from the object (so the buffer is not deallocated in the object's destructor)
     void DetachData();
 
-    // returns TRUE if the string 'str' of length 'len' was successfully appended; if 'len' is -1,
-    // 'len' is determined as "strlen(str)" (addition without the trailing zero); if 'len' is -2,
-    // 'len' is determined as "strlen(str)+1" (addition including the trailing zero)
+    // returns TRUE if the string 'str' of length 'len' was added successfully; if 'len' is -1,
+    // it is determined as "strlen(str)" (without the terminating null); if 'len' is -2,
+    // it is determined as "strlen(str)+1" (including the terminating null)
     virtual BOOL WINAPI Add(const char* str, int len = -1);
 };
 
@@ -523,7 +522,7 @@ class CShares
 {
 protected:
     CRITICAL_SECTION CS;                // section used to synchronize object data
-    TIndirectArray<CSharesItem> Data;   // list of shares
+    TIndirectArray<CSharesItem> Data;   // list of shared resources
     TIndirectArray<CSharesItem> Wanted; // list of references into Data interesting for searching
     BOOL SubsetOnly;
 
@@ -749,7 +748,7 @@ extern CSystemPolicies SystemPolicies;
 // ensures ArrangeHorizontalLines is called for all dialogs
 //
 // If 'HCenterAgains' is different from NULL, it is centered to it, otherwise to the parent.
-// sets the message box parent for plug-ins to this dialog (only while it exists)
+// sets the message box parent for plugins to this dialog (only while it exists)
 //
 
 class CCommonDialog : public CDialog
@@ -840,10 +839,9 @@ public:
     // returns the number of valid messages
     int GetCount() { return Count; }
 
-    // inserts the item according to 'index' into 'buffer' (pass buffer size in 'buffMax')
-    // 'index': for value 0 it will be the oldest item, for value Count
-    // it will be the last added message
-    // if the index is out of the array, it inserts the text "error"
+    // inserts the item selected by 'index' into 'buffer' (pass the buffer size in 'buffMax')
+    // 'index': value 0 is the oldest item; value Count - 1 is the last added message
+    // if 'index' is out of range, inserts the text "error"
     void Print(char* buffer, int buffMax, int index);
 };
 
@@ -866,7 +864,7 @@ extern CMessagesKeeper MessagesKeeper;
 struct CWayPoint
 {
     DWORD WayPoint;     // value defined in the code
-    WPARAM CustomData1; // user-defined value
+    WPARAM CustomData1; // user value
     LPARAM CustomData2; // user-defined value
     DWORD Time;         // insertion time
 };
@@ -900,10 +898,9 @@ public:
         return count;
     }
 
-    // inserts the item according to 'index' into 'buffer' (pass buffer size in 'buffMax')
-    // 'index': for value 0 it will be the oldest item, value Count
-    // it will be the last added waypoint
-    // if the index is out of the array, it inserts the text "error"
+    // inserts the item selected by 'index' into 'buffer' (pass the buffer size in 'buffMax')
+    // 'index': value 0 is the oldest item; value Count - 1 is the last added waypoint
+    // if 'index' is out of range, inserts the text "error"
     void Print(char* buffer, int buffMax, int index);
 };
 

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -111,7 +111,8 @@ public:
     // sorts the Dirs and Files lists so that Contains() can be called;
     void Sort();
 
-    // returns TRUE if the name specified by 'nameIsDir' and 'name' is present in one of the arrays; if 'foundOnIndex' is not NULL, it receives the index at which the item was found
+    // returns TRUE if the name specified through 'nameIsDir' and 'name' is present in one
+    // of the arrays; if 'foundOnIndex' is not NULL, it returns the index where the item was found
     BOOL Contains(BOOL nameIsDir, const char* name, int* foundOnIndex = NULL);
 
     // returns the total number of stored names
@@ -258,7 +259,7 @@ public:
 
     BOOL IsGood() { return FileName != NULL; }
 
-    // returns TRUE if the object matches the specified data
+    // returns TRUE if the object was constructed from the specified data
     BOOL Equal(CFileHistoryItemTypeEnum type, DWORD handlerID, const char* fileName);
 
     BOOL Execute();
@@ -405,7 +406,7 @@ public:
     void Set(DWORD index, const char* name, DWORD flags, BOOL leftSmartMode, BOOL rightSmartMode);
 
     BOOL SwapItems(int index1, int index2); // swaps two items in the array
-    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is not empty
+    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is ok
 
     int SaveColumns(CColumnConfig* columns, char* buffer);  // convert the array to a string
     void LoadColumns(CColumnConfig* columns, char* buffer); // and back again
@@ -448,9 +449,9 @@ public:
     // detaches the data from the object (so the buffer is not deallocated in the object's destructor)
     void DetachData();
 
-    // returns TRUE if the string 'str' of length 'len' was added successfully; if 'len' is -1,
-    // it is determined as "strlen(str)" (without the terminating null); if 'len' is -2,
-    // it is determined as "strlen(str)+1" (including the terminating null)
+    // returns TRUE if the string 'str' of length 'len' was successfully appended; if 'len' is -1,
+    // 'len' is determined as "strlen(str)" (addition without the trailing zero); if 'len' is -2,
+    // 'len' is determined as "strlen(str)+1" (addition including the trailing zero)
     virtual BOOL WINAPI Add(const char* str, int len = -1);
 };
 
@@ -522,7 +523,7 @@ class CShares
 {
 protected:
     CRITICAL_SECTION CS;                // section used to synchronize object data
-    TIndirectArray<CSharesItem> Data;   // list of shared resources
+    TIndirectArray<CSharesItem> Data;   // list of shares
     TIndirectArray<CSharesItem> Wanted; // list of references into Data interesting for searching
     BOOL SubsetOnly;
 

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -111,8 +111,7 @@ public:
     // sorts the Dirs and Files lists so that Contains() can be called;
     void Sort();
 
-    // returns TRUE if the name specified through 'nameIsDir' and 'name' is present in one
-    // of the arrays; if 'foundOnIndex' is not NULL, it returns the index where the item was found
+    // returns TRUE if the name specified by 'nameIsDir' and 'name' is present in one of the arrays; if 'foundOnIndex' is not NULL, it receives the index at which the item was found
     BOOL Contains(BOOL nameIsDir, const char* name, int* foundOnIndex = NULL);
 
     // returns the total number of stored names
@@ -259,7 +258,7 @@ public:
 
     BOOL IsGood() { return FileName != NULL; }
 
-    // returns TRUE if the object was constructed from the specified data
+    // returns TRUE if the object matches the specified data
     BOOL Equal(CFileHistoryItemTypeEnum type, DWORD handlerID, const char* fileName);
 
     BOOL Execute();
@@ -406,7 +405,7 @@ public:
     void Set(DWORD index, const char* name, DWORD flags, BOOL leftSmartMode, BOOL rightSmartMode);
 
     BOOL SwapItems(int index1, int index2); // swaps two items in the array
-    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is ok
+    BOOL CleanName(char* name);             // trims spaces and returns TRUE if name is not empty
 
     int SaveColumns(CColumnConfig* columns, char* buffer);  // convert the array to a string
     void LoadColumns(CColumnConfig* columns, char* buffer); // and back again
@@ -449,9 +448,9 @@ public:
     // detaches the data from the object (so the buffer is not deallocated in the object's destructor)
     void DetachData();
 
-    // returns TRUE if the string 'str' of length 'len' was successfully appended; if 'len' is -1,
-    // 'len' is determined as "strlen(str)" (addition without the trailing zero); if 'len' is -2,
-    // 'len' is determined as "strlen(str)+1" (addition including the trailing zero)
+    // returns TRUE if the string 'str' of length 'len' was added successfully; if 'len' is -1,
+    // it is determined as "strlen(str)" (without the terminating null); if 'len' is -2,
+    // it is determined as "strlen(str)+1" (including the terminating null)
     virtual BOOL WINAPI Add(const char* str, int len = -1);
 };
 
@@ -523,7 +522,7 @@ class CShares
 {
 protected:
     CRITICAL_SECTION CS;                // section used to synchronize object data
-    TIndirectArray<CSharesItem> Data;   // list of shares
+    TIndirectArray<CSharesItem> Data;   // list of shared resources
     TIndirectArray<CSharesItem> Wanted; // list of references into Data interesting for searching
     BOOL SubsetOnly;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salamand.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 201 comment units, 201 review results, 201 resolved results, and 201 apply results.
- Branch-target comment guard passed for `src/salamand.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/salamand.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 18 provider calls, 324986 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 15 calls, 263176 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 61810 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
