### PR TITLE
[translation] Fix src/salinflt.cpp comments

### DIFF
--- a/src/salinflt.cpp
+++ b/src/salinflt.cpp
@@ -141,7 +141,7 @@ int huft_build(CDecompressionObject* decompress,
    circular buffer.  The index is updated simply by incrementing and then
    and'ing with 0x7fff (32K-1) (window size - 1). */
 // sliding window is defined in CDecompressionObject and could be
-// any size greater or equal 32K
+// any size greater than or equal to 32K
 
 /* Tables for deflate from PKZIP's appnote.txt. */
 /* Order of the bit length code lengths */
@@ -186,7 +186,7 @@ static const uch cpdext32[] = {
 #define MAXDISTS 30
 #endif
 
-/* And'ing with mask_bits[n] masks the lower n bits */
+/* ANDing with mask_bits[n] masks the lower n bits */
 const ush mask_bits[] = {
     0x0000,
     0x0001, 0x0003, 0x0007, 0x000f, 0x001f, 0x003f, 0x007f, 0x00ff,
@@ -200,16 +200,16 @@ const ush mask_bits[] = {
         DUMPBITS(j)
 
    where NEEDBITS makes sure that b has at least j bits in it, and
-   DUMPBITS removes the bits from b.  The macros use the variable k
-   for the number of bits in b.  Normally, b and k are register
-   variables for speed and are initialized at the begining of a
+   DUMPBITS removes the bits from b. The macros use the variable k
+   for the number of bits in b. Normally, b and k are register
+   variables for speed and are initialized at the beginning of a
    routine that uses these macros from a global bit buffer and count.
 
-   In order to not ask for more bits than there are in the compressed
-   stream, the Huffman tables are constructed to only ask for just
-   enough bits to make up the end-of-block code (value 256).  Then no
-   bytes need to be "returned" to the buffer at the end of the last
-   block.  See the huft_build() routine.
+   In order not to ask for more bits than there are in the compressed
+   stream, the Huffman tables are constructed to ask for just enough
+   bits to make up the end-of-block code (value 256). Then no bytes
+   need to be "returned" to the buffer at the end of the last block.
+   See the huft_build() routine.
  */
 
 //this function should replace NEXTBYTE macro
@@ -270,7 +270,7 @@ uch NextByte(CDecompressionObject* decompress)
    the longer codes.  The time it costs to decode the longer codes is
    then traded against the time it takes to make longer tables.
 
-   This results of this trade are in the variables lbits and dbits
+   The results of this tradeoff are reflected in the variables lbits and dbits
    below.  lbits is the number of bits the first level table for literal/
    length codes can decode in one step, and dbits is the same thing for
    the distance codes.  Subsequent tables are also less than or equal to
@@ -287,7 +287,7 @@ uch NextByte(CDecompressionObject* decompress)
    than five bits, flat.  The optimum values for speed end up being
    about one bit more than those, so lbits is 8+1 and dbits is 5+1.
    The optimum values may differ though from machine to machine, and
-   possibly even between compilers.  Your mileage may vary.
+   possibly even between compilers.
  */
 
 static const int lbits = 9; /* bits in base literal/length lookup table */
@@ -295,15 +295,15 @@ static const int dbits = 6; /* bits in base distance lookup table */
 
 #ifndef ASM_INFLATECODES
 
-/* inflate (decompress) the codes in a deflated (compressed) block.
-   Return an error code or zero if it all goes ok. */
+/* Inflate (decompress) the codes in a deflated (compressed) block.
+   Returns an error code, or zero on success. */
 int inflate_codes(CDecompressionObject* decompress,
-                  struct huft* tl, //literal/length
+                  struct huft* tl, // literal/length decoder tables
                   struct huft* td, //distance decoder tables
                   int bl, int bd)  //number of bits decoded by tl[] and td[]
 {
     unsigned e;      /* table entry flag/number of extra bits */
-    unsigned n, d;   /* length and index for copy */
+    unsigned n, d;   /* length and distance for copy */
     unsigned w;      /* current window position */
     struct huft* t;  /* pointer to table entry */
     unsigned ml, md; /* masks for bl and bd bits */
@@ -323,7 +323,7 @@ int inflate_codes(CDecompressionObject* decompress,
     /* inflate the coded data */
     ml = mask_bits[bl]; /* precompute masks for speed */
     md = mask_bits[bd];
-    while (1) /* do until end of block */
+    while (1) /* Repeat until the end of the block */
     {
         NEEDBITS((unsigned)bl, decompress)
         t = tl + ((unsigned)b & ml);
@@ -389,7 +389,7 @@ int inflate_codes(CDecompressionObject* decompress,
                         w += e;
                         d += e;
                     }
-                    else /* do it slowly to avoid memcpy() overlap */
+                    else /* copy byte-by-byte to handle overlap */
 #endif                   /* !NOMEMCPY */
                         do
                         {
@@ -408,7 +408,7 @@ int inflate_codes(CDecompressionObject* decompress,
                 break;
             }
 
-            if (e == 31) /* it's the EOB signal */
+            if (e == 31) /* end-of-block (EOB) code */
             {
                 /* sorry for this goto, but we have to exit two loops at once */
                 goto cleanup_decode;
@@ -438,7 +438,7 @@ cleanup_decode:
 
 #endif /* ASM_INFLATECODES */
 
-// "decompress" an inflated type 0 (stored) block.
+// Decompress a type 0 (stored) block.
 int inflate_stored(CDecompressionObject* decompress)
 {
     unsigned n; // number of bytes in block
@@ -451,7 +451,7 @@ int inflate_stored(CDecompressionObject* decompress)
     b = decompress->BitBuf; // initialize bit buffer
     k = decompress->BitCount;
 
-    // go to byte boundary
+    // align to a byte boundary
     n = k & 7;
     DUMPBITS(n);
 
@@ -464,20 +464,20 @@ int inflate_stored(CDecompressionObject* decompress)
         return 1; // error in compressed data
     DUMPBITS(16)
 
-    /* old copy routine, the new should be faster (I hope so)
-  // read and output the compressed data
-  while (n--)
-  {
-    NEEDBITS(8, decompress)
-    decompress->SlideWin[w++] = (uch)b;
-    if (w == decompress->WinSize)
-    {
-      decompress->Flush(w);
-      w = 0;
-    }
-    DUMPBITS(8, decompress)
-  }
-*/
+    /* old copy routine; the new one should be faster
+      // read and output the compressed data
+      while (n--)
+      {
+        NEEDBITS(8, decompress)
+        decompress->SlideWin[w++] = (uch)b;
+        if (w == decompress->WinSize)
+        {
+          decompress->Flush(w);
+          w = 0;
+        }
+        DUMPBITS(8, decompress)
+      }
+    */
 
     //copy bytes from input to the output
     while (n)
@@ -525,12 +525,12 @@ int inflate_stored(CDecompressionObject* decompress)
     return 0;
 }
 
-// decompress an inflated type 1 (fixed Huffman codes) block.  We should
-// either replace this with a custom decoder, or at least precompute the
-// Huffman tables.
+// Decompress a type 1 (fixed Huffman codes) block.
+// This should either be replaced with a custom decoder or at least have the
+// Huffman tables precomputed.
 int inflate_fixed(CDecompressionObject* decompress)
 {
-    // if first time, set up tables for fixed blocks
+    // if this is the first time, set up tables for fixed blocks
     if (decompress->fixed_tl == (struct huft*)NULL)
     {
         int i;           // temporary variable
@@ -543,7 +543,7 @@ int inflate_fixed(CDecompressionObject* decompress)
             l[i] = 9;
         for (; i < 280; i++)
             l[i] = 7;
-        for (; i < 288; i++) // make a complete, but wrong code set
+        for (; i < 288; i++) // make a complete but incorrect code set
             l[i] = 8;
         decompress->fixed_bl = 7;
         if ((i = huft_build(decompress, l, 288, 257,
@@ -574,7 +574,7 @@ int inflate_fixed(CDecompressionObject* decompress)
                          decompress->fixed_bl, decompress->fixed_bd) != 0;
 }
 
-/* decompress an inflated type 2 (dynamic Huffman codes) block. */
+/* Decompress a type 2 (dynamic Huffman codes) block. */
 int inflate_dynamic(CDecompressionObject* decompress)
 {
     int i; /* temporary variables */
@@ -589,7 +589,7 @@ int inflate_dynamic(CDecompressionObject* decompress)
     unsigned nb;                        /* number of bit length codes */
     unsigned nl;                        /* number of literal/length codes */
     unsigned nd;                        /* number of distance codes */
-    unsigned ll[MAXLITLENS + MAXDISTS]; /* lit./length and distance code lengths */
+    unsigned ll[MAXLITLENS + MAXDISTS]; /* literal/length and distance code lengths */
     ulg b;                              /* bit buffer */
     unsigned k;                         /* number of bits in bit buffer */
 
@@ -597,7 +597,7 @@ int inflate_dynamic(CDecompressionObject* decompress)
     b = decompress->BitBuf;
     k = decompress->BitCount;
 
-    /* read in table lengths */
+    /* read the table lengths */
     NEEDBITS(5, decompress)
     nl = 257 + ((unsigned)b & 0x1f); /* number of literal/length codes */
     DUMPBITS(5)
@@ -608,9 +608,9 @@ int inflate_dynamic(CDecompressionObject* decompress)
     nb = 4 + ((unsigned)b & 0xf); /* number of bit length codes */
     DUMPBITS(4)
     if (nl > MAXLITLENS || nd > MAXDISTS)
-        return 1; /* bad lengths */
+        return 1; /* invalid code counts */
 
-    /* read in bit-length-code lengths */
+    /* Read bit-length code lengths. */
     for (j = 0; j < nb; j++)
     {
         NEEDBITS(3, decompress)
@@ -620,7 +620,7 @@ int inflate_dynamic(CDecompressionObject* decompress)
     for (; j < 19; j++)
         ll[border[j]] = 0;
 
-    /* build decoding table for trees--single level, 7 bit lookup */
+    /* build a decoding table for the trees -- single-level, 7-bit lookup */
     bl = 7;
     i = huft_build(decompress, ll, 19, 19, NULL, NULL, &tl, &bl);
     if (bl == 0) /* no bit lengths */
@@ -644,7 +644,7 @@ int inflate_dynamic(CDecompressionObject* decompress)
         DUMPBITS(j)
         j = td->v.n;
         if (j < 16)          /* length of code in bits (0..15) */
-            ll[i++] = l = j; /* save last length in l */
+            ll[i++] = l = j; /* save the last length in l */
         else if (j == 16)    /* repeat last length 3 to 6 times */
         {
             NEEDBITS(2, decompress)
@@ -740,13 +740,13 @@ int inflate_dynamic(CDecompressionObject* decompress)
     if ((i = inflate_codes(decompress, tl, td, bl, bd)) != 0)
         TRACE_I("inflate_dynamic: error in inflate_codes");
 
-    /* free the decoding tables, return */
+    /* Free the decoding tables and return. */
     huft_free(decompress, tl);
     huft_free(decompress, td);
     return i;
 }
 
-/* decompress an inflated block */
+/* decompress a deflated block */
 int inflate_block(CDecompressionObject* decompress, int* e)
 //  int *e;
 {
@@ -758,12 +758,12 @@ int inflate_block(CDecompressionObject* decompress, int* e)
     b = decompress->BitBuf;
     k = decompress->BitCount;
 
-    /* read in last block bit */
+    /* read the last-block bit */
     NEEDBITS(1, decompress)
     *e = (int)b & 1;
     DUMPBITS(1)
 
-    /* read in block type */
+    /* read the block type */
     NEEDBITS(2, decompress)
     t = (unsigned)b & 3;
     DUMPBITS(2)
@@ -785,7 +785,7 @@ int inflate_block(CDecompressionObject* decompress, int* e)
     return 2;
 }
 
-//decompress an inflated entry
+//decompress a deflated entry
 int Inflate(CDecompressionObject* decompress)
 {
     CALL_STACK_MESSAGE1("Inflate()");
@@ -794,7 +794,7 @@ int Inflate(CDecompressionObject* decompress)
 
     /*
 #ifdef DEBUG
-  unsigned h = 0;       // maximum struct huft's malloc'ed
+  unsigned h = 0;       // maximum number of malloc'ed struct huft objects
 #endif
 */
 
@@ -852,8 +852,8 @@ int FreeFixedHufman(CDecompressionObject* decompress)
 }
 
 /*
- * GRR:  moved huft_build() and huft_free() down here; used by explode()
- *       and fUnZip regardless of whether USE_ZLIB defined or not
+ * Moved huft_build() and huft_free() here; they are used by explode()
+ * and fUnZip regardless of whether USE_ZLIB is defined.
  */
 
 /* If BMAX needs to be larger than 16, then h and x[] should be ulg. */
@@ -1002,9 +1002,9 @@ int huft_build(CDecompressionObject* decompress,
                 if ((unsigned)w + j > el && (unsigned)w < el)
                     j = el - w; /* make EOB code end at table */
                 z = 1 << j;     /* table entries for j-bit table */
-                l[h] = j;       /* set table size in stack */
+                l[h] = j;       /* save table size on the stack */
 
-                /* allocate and link in new table */
+                /* allocate and link the new table */
                 if ((q = (struct huft*)malloc((z + 1) * sizeof(struct huft))) ==
                     (struct huft*)NULL)
                 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salinflt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 32 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 243 comment units, 243 review results, 243 resolved results, and 243 apply results.
- Branch-target comment guard passed for `src/salinflt.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/salinflt.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 58 provider calls, 908385 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 31 calls, 554140 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 27 calls, 354245 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
