### PR TITLE
[translation] Fix src/salmoncl.h comments

### DIFF
--- a/src/salmoncl.h
+++ b/src/salmoncl.h
@@ -65,7 +65,7 @@ void SalmonSetSLG(const char* slgName); // sets the language in salmon
 void SalmonCheckBugs();
 
 // stores the exception info in shared memory and asks Salmon to create a minidump; then waits for it to finish
-// returns TRUE if successful, FALSE if Salmon could not be invoked for some reason
+// returns TRUE on success, FALSE if Salmon could not be invoked for some reason
 BOOL SalmonFireAndWait(const EXCEPTION_POINTERS* e, char* bugReportPath);
 
 #endif //INSIDE_SALAMANDER


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salmoncl.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 21 comment units, 21 review results, 21 resolved results, and 21 apply results.
- Branch-target comment guard passed for `src/salmoncl.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/salmoncl.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 69703 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 48986 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20717 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
