### PR TITLE
[translation] Fix src/shares.cpp comments

### DIFF
--- a/src/shares.cpp
+++ b/src/shares.cpp
@@ -19,7 +19,7 @@ CSharesItem::CSharesItem(const char* localPath, const char* remoteName, const ch
         char buff[MAX_PATH];
         lstrcpyn(buff, localPath, MAX_PATH);
         SalPathAddBackslash(buff, MAX_PATH); // in case it was only "c:", make sure a root is created
-        if (SalGetFullName(buff))            // root "c\\", others without the trailing '\\' at the end
+        if (SalGetFullName(buff))            // root "c:\\", others without a trailing '\\'
         {
             LocalPath = DupStr(buff);
             RemoteName = DupStr(remoteName);
@@ -27,7 +27,7 @@ CSharesItem::CSharesItem(const char* localPath, const char* remoteName, const ch
             if (LocalPath != NULL && RemoteName != NULL && Comment != NULL)
             {
                 char* s = strrchr(LocalPath, '\\');
-                if (s == NULL || *(s + 1) == 0) // root path; s == NULL is only for safety, but it can never happen
+                if (s == NULL || *(s + 1) == 0) // root path; s == NULL is just a safeguard and should never occur
                     LocalName = LocalPath;
                 else
                     LocalName = s + 1;
@@ -262,7 +262,7 @@ BOOL CShares::GetUNCPath(const char* path, char* uncPath, int uncPathMax)
         // append the share name
         strcat(unc, item->RemoteName);
         SalPathAddBackslash(unc, 2 * MAX_PATH); // we want a backslash at the end
-        // from the original path, append the directories starting from the share
+        // append the directories from the original path after the share
         if (strlen(item->LocalPath) < strlen(path))
         {
             const char* s = path + strlen(item->LocalPath);
@@ -270,7 +270,7 @@ BOOL CShares::GetUNCPath(const char* path, char* uncPath, int uncPathMax)
                 s++; // skip an optional backslash
             strcat(unc, s);
         }
-        if (!SalGetFullName(unc)) // root "c\\", others without the trailing '\\' at the end
+        if (!SalGetFullName(unc)) // root "c:\", others without a trailing '\\'
         {
             TRACE_E("Unexpected path in CSharesItem::GetUNCPath()");
             HANDLES(LeaveCriticalSection(&CS));


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/shares.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 32 comment units, 32 review results, 32 resolved results, and 32 apply results.
- Branch-target comment guard passed for `src/shares.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/shares.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 119983 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 74646 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 45337 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
