### PR TITLE
[translation] Fix src/shellib.h comments

### DIFF
--- a/src/shellib.h
+++ b/src/shellib.h
@@ -123,7 +123,7 @@ public:
     }
 
     STDMETHOD(QueryInterface)
-    (REFIID, void FAR* FAR*);
+    (REFIID, void FAR * FAR*);
     STDMETHOD_(ULONG, AddRef)
     (void) { return ++RefCount; }
     STDMETHOD_(ULONG, Release)
@@ -345,7 +345,7 @@ public:
                               const wchar_t* mapW);
 
     STDMETHOD(QueryInterface)
-    (REFIID, void FAR* FAR*);
+    (REFIID, void FAR * FAR*);
     STDMETHOD_(ULONG, AddRef)
     (void) { return ++RefCount; }
     STDMETHOD_(ULONG, Release)
@@ -433,7 +433,7 @@ public:
     }
 
     STDMETHOD(QueryInterface)
-    (REFIID, void FAR* FAR*);
+    (REFIID, void FAR * FAR*);
     STDMETHOD_(ULONG, AddRef)
     (void) { return ++RefCount; }
     STDMETHOD_(ULONG, Release)

--- a/src/shellib.h
+++ b/src/shellib.h
@@ -96,13 +96,13 @@ private:
     DWORD MouseButton; // -1 = uninitialized value, otherwise MK_LBUTTON or MK_RBUTTON
 
 public:
-    // Last effect returned by GiveFeedback method - introduced because
+    // Last effect returned by the GiveFeedback method. Introduced because
     // DoDragDrop does not return dwEffect == DROPEFFECT_MOVE; for MOVE it returns dwEffect == 0.
-    // For the reasons, see "Handling Shell Data Transfer Scenarios", section "Handling Optimized Move Operations":
+    // For details, see "Handling Shell Data Transfer Scenarios", section "Handling Optimized Move Operations":
     // http://msdn.microsoft.com/en-us/library/windows/desktop/bb776904%28v=vs.85%29.aspx
-    // (shortly: an optimized Move is done, which means that it does not create a copy to the destination followed by deleting
-    //            the original, so that the source does not accidentally delete the original (it may not have been moved yet), and it receives
-    //            the operation result DROPEFFECT_NONE or DROPEFFECT_COPY)
+    // (in short: an optimized Move is performed, which means no copy to the destination followed by deletion
+    //            of the original is done; to prevent the source from accidentally deleting the original before it
+    //            has actually been moved, the operation returns DROPEFFECT_NONE or DROPEFFECT_COPY)
     DWORD LastEffect;
 
     BOOL DragFromPluginFSWithCopyAndMove; // dragging from the plugin FS with possible Copy and Move, details above
@@ -132,7 +132,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // we must not touch the object, it no longer exists
+            return 0; // Do not touch the object; it no longer exists.
         }
         return RefCount;
     }
@@ -354,7 +354,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // we must not touch the object, it no longer exists
+            return 0; // The object must not be accessed; it no longer exists
         }
         return RefCount;
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/shellib.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 58 comment units, 58 review results, 58 resolved results, and 58 apply results.
- Branch-target comment guard passed for `src/shellib.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/shellib.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 101642 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 56944 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 44698 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
