### PR TITLE
[translation] Fix src/shexreg.h comments

### DIFF
--- a/src/shexreg.h
+++ b/src/shexreg.h
@@ -146,10 +146,10 @@ extern char ShellExtConfigSubmenuName[SEC_SUBMENUNAME_MAX];
 // when loading, verify the version and reload the registry if it differs from the one in use
 extern DWORD ShellExtConfigVersion;
 
-// returns the index of the specified item
+// returns the item at the specified index
 CShellExtConfigItem* SECGetItem(int index);
 
-// if an item with a matching cmd is found, stores its index in index and returns TRUE; otherwise returns FALSE
+// if an item with a matching Cmd is found, stores the found item's index in index and returns TRUE; otherwise returns FALSE
 BOOL SECGetItemIndex(UINT cmd, int* index);
 
 BOOL SECLoadRegistry();

--- a/src/shexreg.h
+++ b/src/shexreg.h
@@ -17,8 +17,8 @@
 //
 
 //
-// included in Open Salamander for configuration and inter-process communication
-// and simultaneously compiled into SHELLEXT.DLL for presentation and coordination
+// part of Open Salamander for configuration and mutual communication
+// and also part of SHELLEXT.DLL for presentation and mutual communication
 //
 
 //
@@ -146,10 +146,10 @@ extern char ShellExtConfigSubmenuName[SEC_SUBMENUNAME_MAX];
 // when loading, verify the version and reload the registry if it differs from the one in use
 extern DWORD ShellExtConfigVersion;
 
-// returns the item at the specified index
+// returns the index of the specified item
 CShellExtConfigItem* SECGetItem(int index);
 
-// if an item with matching Cmd is found, fills index and returns TRUE; otherwise returns FALSE
+// if an item with a matching cmd is found, stores its index in index and returns TRUE; otherwise returns FALSE
 BOOL SECGetItemIndex(UINT cmd, int* index);
 
 BOOL SECLoadRegistry();
@@ -227,14 +227,13 @@ typedef struct CSalShExtSharedMem CSalShExtSharedMem;
 
 #ifdef INSIDE_SALAMANDER
 
-// writes the registry entries required by the library
-// parameters: path to the library, whether to skip loading the DLL when verifying its version,
-// and the registry view (0, 32-bit, or 64-bit) that should be updated
+// writes the registry entries needed for the library to work
+// parameters: path to the library; FALSE/TRUE = test/do not test the DLL version by loading it; and 0 or the registry view (32-bit or 64-bit) to write to
 BOOL SECRegisterToRegistry(const char* shellExtensionPath, BOOL doNotLoadDLL, REGSAM regView);
 
 #ifdef ENABLE_SH_MENU_EXT
 
-// saves the configuration to the registry
+// saves data to the registry
 BOOL SECSaveRegistry();
 
 // returns the number of items in the list


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/shexreg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 63 comment units, 63 review results, 63 resolved results, and 63 apply results.
- Branch-target comment guard passed for `src/shexreg.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/shexreg.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 10 provider calls, 167988 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 105407 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 62581 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
