### PR TITLE
[translation] Fix src/shiconov.h comments

### DIFF
--- a/src/shiconov.h
+++ b/src/shiconov.h
@@ -31,7 +31,7 @@ struct CShellIconOverlayItem
     CLSID IconOverlayIdCLSID;                // CLSID of the respective IShellIconOverlayIdentifier object
     int Priority;                            // priority of this icon overlay (0-100, the highest priority is zero)
     HICON IconOverlay[ICONSIZE_COUNT];       // icon overlay in all sizes
-    BOOL GoogleDriveOverlay;                 // TRUE = Google Drive handler (their handler crashes, so we handle it with extra synchronization)
+    BOOL GoogleDriveOverlay;                 // TRUE = Google Drive handler (it crashes, so extra synchronization is used)
 
     void Cleanup();
 
@@ -44,7 +44,7 @@ class CShellIconOverlays
 protected:
     TIndirectArray<CShellIconOverlayItem> Overlays; // priority-sorted list of icon overlays
     CRITICAL_SECTION GD_CS;                         // for Google Drive we need to mutually exclude calls to IsMemberOf from both icon readers (otherwise it crashes and corrupts its heap)
-    BOOL GetGDAlreadyCalled;                        // TRUE = we already checked where the folder for Google Drive is located
+    BOOL GetGDAlreadyCalled;                        // TRUE = the location of the Google Drive folder has already been checked
     char GoogleDrivePath[MAX_PATH];                 // folder for Google Drive (we do not call their handler elsewhere; it is disgustingly slow and, without the extra synchronization, it crashes)
     BOOL GoogleDrivePathIsFromCfg;                  // TRUE if the folder for Google Drive obtained from the Google Drive configuration (FALSE = it may be only the default one and Google Drive may not be installed at all)
     BOOL GoogleDrivePathExists;                     // does the folder for Google Drive exist on disk?


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/shiconov.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 27 comment units, 27 review results, 27 resolved results, and 27 apply results.
- Branch-target comment guard passed for `src/shiconov.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/shiconov.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 35757 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 35757 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
