### PR TITLE
[translation] Fix src/svg.cpp comments

### DIFF
--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -125,7 +125,7 @@ void RenderSVGImage(NSVGrasterizer* rast, HDC hDC, int x, int y, const char* svg
 
         if (!enabled)
         {
-            DWORD disabledColor = GetSVGSysColor(COLOR_BTNSHADOW); // JRYFIXME - initial draft: where will we take the disabled color from?
+            DWORD disabledColor = GetSVGSysColor(COLOR_BTNSHADOW); // JRYFIXME - initial draft: where will we get the disabled color from?
             NSVGshape* shape = image->shapes;
             while (shape != NULL)
             {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/svg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 10 comment units, 10 review results, 10 resolved results, and 10 apply results.
- Branch-target comment guard passed for `src/svg.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/svg.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 44192 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 21701 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 22491 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
