### PR TITLE
[translation] Fix src/stswnd.h comments

### DIFF
--- a/src/stswnd.h
+++ b/src/stswnd.h
@@ -72,7 +72,7 @@ protected:
     int TextLen; // Number of characters in 'Text' pointer without the terminator
     char* Size;
     int PathLen;          // -1 (the path occupies the entire Text); otherwise the path length in Text (the remainder is the filter)
-    BOOL History;         // Show the arrow between the text and the size?
+    BOOL History;         // Show the history drop-down arrow between the text and the size?
     BOOL Hidden;          // Show the filter symbol?
     int HiddenFilesCount; // how many files are filtered out?
     int HiddenDirsCount;  // And directories


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/stswnd.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 62 comment units, 62 review results, 62 resolved results, and 62 apply results.
- Branch-target comment guard passed for `src/stswnd.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/stswnd.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 152520 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 152520 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
