### PR TITLE
[translation] Fix src/sort.h comments

### DIFF
--- a/src/sort.h
+++ b/src/sort.h
@@ -31,7 +31,7 @@ typedef BOOL (*CLessFunction)(const CFileData&, const CFileData&, BOOL);
 int CmpNameExt(const CFileData& f1, const CFileData& f2);
 int CmpNameExtIgnCase(const CFileData& f1, const CFileData& f2); // ignore-case variant
 
-// NOTE: sort codes in RefreshDirectory, ChangeSortType and CompareDirectories must match!!!
+// WARNING: the sort codes in RefreshDirectory, ChangeSortType, and CompareDirectories must match!!
 
 BOOL LessNameExt(const CFileData& f1, const CFileData& f2, BOOL reverse);
 BOOL LessNameExtIgnCase(const CFileData& f1, const CFileData& f2, BOOL reverse);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/sort.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 6 comment units, 6 review results, 6 resolved results, and 6 apply results.
- Branch-target comment guard passed for `src/sort.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/sort.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 42891 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 42891 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
