### PR TITLE
[translation] Fix src/svg.h comments

### DIFF
--- a/src/svg.h
+++ b/src/svg.h
@@ -64,7 +64,7 @@ protected:
     void ColorizeSVG(NSVGimage* image, DWORD state);
 
 protected:
-    int Width; // dimension of a single image in points
+    int Width; // Width of a single image in points
     int Height;
     HBITMAP HBitmaps[SVGSTATE_COUNT];
 };


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/svg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 17 comment units, 17 review results, 17 resolved results, and 17 apply results.
- Branch-target comment guard passed for `src/svg.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/svg.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 43006 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43006 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
