### PR TITLE
[translation] Fix src/stswnd.cpp comments

### DIFF
--- a/src/stswnd.cpp
+++ b/src/stswnd.cpp
@@ -1339,7 +1339,7 @@ public:
     }
 
     STDMETHOD(QueryInterface)
-    (REFIID refiid, void FAR* FAR* ppv)
+    (REFIID refiid, void FAR * FAR * ppv)
     {
         if (refiid == IID_IUnknown || refiid == IID_IDropTarget)
         {

--- a/src/stswnd.cpp
+++ b/src/stswnd.cpp
@@ -389,7 +389,7 @@ void CStatusWindow::SetThrobber(BOOL show, int delay, BOOL calledFromDestroyWind
     }
     else
     {
-        if (DelayedThrobber) // Waiting to be shown, but the throbber should be hidden, cancel the wait
+        if (DelayedThrobber) // The throbber is waiting to be shown, but it should be hidden; cancel the wait
         {
             if (HWindow == NULL)
                 TRACE_E("Unexpected situation 2 in CStatusWindow::SetThrobber(): DelayedThrobber is TRUE but HWindow is NULL");
@@ -1002,7 +1002,7 @@ void CStatusWindow::Paint(HDC hdc, BOOL highlightText, BOOL highlightHotTrackOnl
                 if (truncateEnd)
                 { // Without truncation, or with the end trimmed
                     ExtTextOut(dc, TextRect.left, textY, 0, NULL, Text, min(visibleChars, firstClipChar), NULL);
-                    if (visibleChars < min(TextLen, firstClipChar)) // If the end was trimmed -> append "..."
+                    if (visibleChars < min(TextLen, firstClipChar)) // If the end was trimmed, append "..."
                     {
                         int offset = (visibleChars > 0) ? AlpDX[visibleChars - 1] : 0;
                         ExtTextOut(dc, TextRect.left + offset, textY, 0, NULL, "...", 3, NULL);
@@ -1027,7 +1027,7 @@ void CStatusWindow::Paint(HDC hdc, BOOL highlightText, BOOL highlightHotTrackOnl
                 // Without truncation or the trimmed end
                 int visibleChars2 = visibleChars - lastClipChar;
                 ExtTextOut(dc, TextRect.left + AlpDX[lastClipChar - 1], textY, 0, NULL, Text + lastClipChar, visibleChars2, NULL);
-                if (visibleChars < TextLen) // If the end was trimmed -> append "..."
+                if (visibleChars < TextLen) // If the end was truncated, append "..."
                 {
                     int offset = (visibleChars > 0) ? AlpDX[visibleChars - 1] : 0;
                     ExtTextOut(dc, TextRect.left + offset, textY, 0, NULL, "...", 3, NULL);
@@ -1362,7 +1362,7 @@ public:
         if (--RefCount == 0)
         {
             delete this;
-            return 0; // Must not touch the object, it no longer exists
+            return 0; // Must not touch the object; it no longer exists
         }
         return RefCount;
     }
@@ -1935,7 +1935,7 @@ CStatusWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             }
             if (isInSizeRect)
             {
-                // Drive info works only if it's not an FS that doesn't support drive info
+                // Drive info works only if the FS supports drive info
                 if (FilesWindow->Is(ptDisk) || FilesWindow->Is(ptZIPArchive) ||
                     FilesWindow->Is(ptPluginFS) && FilesWindow->GetPluginFS()->NotEmpty() &&
                         FilesWindow->GetPluginFS()->IsServiceSupported(FS_SERVICE_SHOWINFO))
@@ -2074,7 +2074,7 @@ CStatusWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                         CHotTrackItem* lastItem = NULL;
                         if (HotTrackItems.Count > 0)
                             lastItem = &HotTrackItems[HotTrackItems.Count - 1];
-                        //if (HotItem->Chars != (int)TextLen) // This condition failed when a filter was active
+                        //if (HotItem->Chars != (int)TextLen) // This condition failed when a filter was attached
                         if (HotItem != lastItem)
                         {
                             // Path shortening


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/stswnd.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 125 comment units, 125 review results, 125 resolved results, and 125 apply results.
- Branch-target comment guard passed for `src/stswnd.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/stswnd.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
