### PR TITLE
[translation] Fix src/versinfo.h comments

### DIFF
--- a/src/versinfo.h
+++ b/src/versinfo.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-// Used to read (and optionally modify) the VERSIONINFO resource. Reading alone 
+// Used to read (and optionally modify) the VERSIONINFO resource. Reading alone
 // could be handled by the GetFileVersionInfo/VerQueryValue API, but that API does not support later modifications,
-// so we solve the problem with our own module. Using the API would also mean 
+// so we solve the problem with our own module. Using the API would also mean
 // linking Version.LIB/DLL, which we do not use for anything else.
 // WARNING: the module exists both in Salamander and in Translator.
 

--- a/src/versinfo.h
+++ b/src/versinfo.h
@@ -48,7 +48,7 @@ public:
     WCHAR* Key;
     BOOL Text;      // 1 if the version resource contains text data and 0 if the version resource contains binary data
     VOID* Value;    // depends on Type
-    WORD ValueSize; // used only for Var blocks, otherwise we compute it
+    WORD ValueSize; // used only for Var blocks; otherwise computed
     TIndirectArray<CVersionBlock> Children;
 
 public:
@@ -117,14 +117,14 @@ private:
 };
 
 // VS_VERSIONINFO:
-// 2 bytes: Length in bytes (this block, and all child blocks. does _not_ include alignment padding between subsequent blocks)
-// 2 bytes: Length in bytes of VS_FIXEDFILEINFO struct
-// 2 bytes: Type (contains 1 if version resource contains text data and 0 if version resource contains binary data)
-// Variable length unicode string (null terminated): Key (currently "VS_VERSION_INFO")
-// Variable length padding to align VS_FIXEDFILEINFO on a 32-bit boundary
-// VS_FIXEDFILEINFO struct
-// Variable length padding to align Child struct on a 32-bit boundary
-// Child struct (zero or one StringFileInfo structs, zero or one VarFileInfo structs)
+// 2 bytes: Length in bytes (this block and all child blocks; does _not_ include alignment padding between subsequent blocks)
+// 2 bytes: Length in bytes of the VS_FIXEDFILEINFO structure
+// 2 bytes: Type (1 if the version resource contains text data, 0 if it contains binary data)
+// Variable-length Unicode string (null-terminated): Key (currently "VS_VERSION_INFO")
+// Variable-length padding to align VS_FIXEDFILEINFO on a 32-bit boundary
+// VS_FIXEDFILEINFO structure
+// Variable-length padding to align the child structure on a 32-bit boundary
+// Child structure (zero or one StringFileInfo structures, zero or one VarFileInfo structures)
 
 // StringFileInfo:
 // 2 bytes: Length in bytes (includes this block, as well as all Child blocks)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/versinfo.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 27 comment units, 27 review results, 27 resolved results, and 27 apply results.
- Branch-target comment guard passed for `src/versinfo.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/versinfo.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 105466 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 5 calls, 105466 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
