### PR TITLE
[translation] Fix src/viewer.h comments

### DIFF
--- a/src/viewer.h
+++ b/src/viewer.h
@@ -169,12 +169,12 @@ protected:
 
     void CodeCharacters(unsigned char* start, unsigned char* end);
     // if 'hFile' is NULL, Prepare/LoadBefore/LoadBehind open and close the file themselves
-    // if 'hFile' points to a variable (initialize its value to NULL at the start),
-    // the methods open the file and store the file handle into that variable (when opening succeeds).
-    // On the next call they do not open the file again and reuse the handle from that variable.
-    // They also do not close the handle when exiting; the caller must handle that.
-    // This is an optimization for network drives where repeatedly opening/closing the file 
-    // slowed down searching terribly.
+    // if 'hFile' points to a variable (initialize it to NULL before the first call),
+    // the methods open the file and store the file handle in that variable if opening succeeds.
+    // On subsequent calls, they do not open the file again and reuse the handle from that variable.
+    // They do not close the handle on return; the caller must ensure that.
+    // This is an optimization for network drives, where repeatedly opening and closing the file
+    // caused severe delays during searching.
     BOOL LoadBefore(HANDLE* hFile);
     BOOL LoadBehind(HANDLE* hFile);
 

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -380,8 +380,8 @@ protected:
     DWORD RepeatCmdAfterRefresh; // command to repeat after refresh (-1 = no command)
 
     char* Caption;     // if not NULL, contains the proposed viewer window caption
-    BOOL WholeCaption; // meaningful if Caption != NULL. TRUE -> only 
-                       // Caption is displayed in the viewer title; FALSE -> append 
+    BOOL WholeCaption; // meaningful if Caption != NULL. TRUE -> only
+                       // Caption is displayed in the viewer title; FALSE -> append
                        // the standard " - Viewer" to Caption.
 
     BOOL CanSwitchToHex,           // TRUE if switching to hex is possible when there are more than 10000 characters per line


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/viewer.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning low`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 131 comment units, 131 review results, 131 resolved results, and 131 apply results.
- Branch-target comment guard passed for `src/viewer.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/viewer.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 18 provider calls, 311057 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 16 calls, 268606 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 42451 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
