### PR TITLE
[translation] Initial src/consts.h comments translation

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 


### PR DESCRIPTION
Adds the `CommentsTranslationProject: TRANSLATED` header marker to `src/consts.h`.

Cherry-picked from `comments-translation-v2` commit `f542473`.