### PR TITLE
[translation] Initial src/consts.h comments translation

### DIFF
--- a/src/consts.h
+++ b/src/consts.h
@@ -1,64 +1,63 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
-// aktualni verze konfigurace (popis viz. mainwnd2.cpp)
+// current configuration version (see mainwnd2.cpp for details)
 extern const DWORD THIS_CONFIG_VERSION;
 
-// Expirace verze: pro beta a PB verze odkomentovat, pro ostre verze zakomentovat:
+// Version expiration: uncomment for beta and PB builds, comment out for release builds:
 //#define USE_BETA_EXPIRATION_DATE
 
-// pro PB (EAP) verze odkomentovat, pro ostatni verze zakomentovat:
+// For PB (EAP) builds uncomment, for other builds comment out:
 //#define THIS_IS_EAP_VERSION
 
 #ifdef USE_BETA_EXPIRATION_DATE
 
-// urcuje prvni den, kdy uz tato beta verze nepobezi
+// specifies the first day when this beta build will no longer run
 extern SYSTEMTIME BETA_EXPIRATION_DATE;
 
 #endif // USE_BETA_EXPIRATION_DATE
 
-// jen pro DEBUG verzi Salama: umozni debugovat tvorbu bugreportu (defaultne se nedela,
-// exceptiona se jen preda MSVC debuggeru)
+// DEBUG build only: allows debugging bug report creation (normally no report is built,
+// the exception is simply passed to the MSVC debugger)
 //#define ENABLE_BUGREPORT_DEBUGGING   1
 
-// slouzi pro detekci, zda wheel message prisla pres hook nebo primo
-extern BOOL MouseWheelMSGThroughHook; // TRUE: zprava sla skrz hook v case MouseWheelMSGTime; FALSE: zprava sla skrz panel v case MouseWheelMSGTime
-extern DWORD MouseWheelMSGTime;       // casove razitko pri posledni zprave
-#define MOUSEWHEELMSG_VALID 100       // [ms] pocet milisekund, po ktere je validni jeden kanal (hook vs okno)
+// used to detect whether a wheel message came through the hook or directly
+extern BOOL MouseWheelMSGThroughHook; // TRUE: the message went through the hook at the time stored in MouseWheelMSGTime; FALSE: the message went through the panel at the time stored in MouseWheelMSGTime
+extern DWORD MouseWheelMSGTime;       // timestamp of the last wheel message
+#define MOUSEWHEELMSG_VALID 100       // [ms] number of milliseconds for which one channel (hook vs. window) remains valid
 
 enum
 {
     otViewerWindow = 10,
 };
 
-// podpora pro horizontalni scroll (funguje jiz na W2K/XP s Intellipoint ovladacema, oficialne podporeno od Visty)
+// horizontal scroll support (works on W2K/XP with Intellipoint drivers, officially supported since Vista)
 #define WM_MOUSEHWHEEL 0x020E
 BOOL PostMouseWheelMessage(MSG* pMSG);
 
-// zjisti jestli je velka sance (jiste se to urcit neda), ze Salamander v pristich par
-// okamzicich nebude "busy" (nebude otevreny zadny modalni dialog a nebude se zpracovavat
-// zadna zprava) - v tomto pripade vraci TRUE (jinak FALSE); neni-li 'lastIdleTime' NULL,
-// vraci se v nem GetTickCount() z okamziku posledniho prechodu z "idle" do "busy" stavu
-// je mozne volat z libovolneho threadu
+// checks if it is very likely (though not guaranteed) that Salamander will not be "busy" in the next
+// few moments (no modal dialog open and no message being processed). Returns TRUE in that case, otherwise FALSE.
+// If 'lastIdleTime' is not NULL, it receives GetTickCount() from the last idle->busy transition.
+// Can be called from any thread.
 BOOL SalamanderIsNotBusy(DWORD* lastIdleTime);
 
-// otevre HTML help Salamandera nebo pluginu, jazyk helpu (adresar s .chm soubory) vybira takto:
-// -adresar ziskany z aktualniho .slg souboru Salamandera (viz SLGHelpDir v shared\versinfo.rc)
-// -HELP\ENGLISH\*.chm
-// -prvni nalezeny podadresar v podadresari HELP
-// 'helpFileName' je jmeno .chm souboru, se kterym se ma pracovat (jmeno je bez cesty), je-li NULL,
-// jde o "salamand.chm"; 'parent' je parent messageboxu s chybou; 'command' je prikaz HTML helpu,
-// viz HHCDisplayXXX; 'dwData' je parametr prikazu HTML helpu, viz HHCDisplayXXX
-// je mozne volat z libovolneho threadu
-// Pokud je 'quiet' TRUE, nezobrazi se chybova hlaska.
-// Vraci TRUE, pokud se help podarilo otevrite, jinak vraci FALSE;
+// opens Salamander or plugin HTML help. The help language (directory with .chm files) is selected as follows:
+// - directory from the current Salamander .slg file (see SLGHelpDir in shared\versinfo.rc)
+// - HELP\ENGLISH\*.chm
+// - first subdirectory found in HELP
+// 'helpFileName' is the .chm file name to use (without path); if NULL, "salamand.chm" is used.
+// 'parent' is the parent of the error message box; 'command' is the HTML Help command (HHCDisplayXXX);
+// 'dwData' is the parameter of the HTML Help command. Can be called from any thread.
+// If 'quiet' is TRUE, no error message is shown.
+// Returns TRUE if the help was opened successfully, otherwise FALSE.
 BOOL OpenHtmlHelp(char* helpFileName, HWND parent, CHtmlHelpCommand command, DWORD_PTR dwData, BOOL quiet);
 
-extern CRITICAL_SECTION OpenHtmlHelpCS; // kriticka sekce pro OpenHtmlHelp()
+extern CRITICAL_SECTION OpenHtmlHelpCS; // critical section used by OpenHtmlHelp()
 
-/* jednoduche zajisteni behu v kriticke sekci, priklad pouziti:
+/* simple way to run inside a critical section, example usage:
   static CCriticalSection cs;
   CEnterCriticalSection enterCS(cs);
 */
@@ -93,610 +92,613 @@ public:
     }
 };
 
-// protoze windowsova GetTempFileName nefunguje, napsali jsme si vlastniho klona:
-// vytvori soubor/adresar (podle 'file') na ceste 'path' (NULL -> Window TEMP dir),
-// s prefixem 'prefix', vraci jmeno vytvoreneho souboru v 'tmpName' (min. velikost MAX_PATH),
-// vraci "uspech?" (pri neuspechu vraci pres SetLastError kod Windows chyby - pro kompatib.)
+// Windows GetTempFileName does not work for us, so we wrote our own clone:
+// creates a file/directory (depending on 'file') at 'path' (NULL -> Windows TEMP dir),
+// with prefix 'prefix', returns the created name in 'tmpName' (at least MAX_PATH in size).
+// Returns success status; on failure SetLastError contains the Windows error code for compatibility.
 BOOL SalGetTempFileName(const char* path, const char* prefix, char* tmpName, BOOL file);
 
-// protoze windowsova verze MoveFile nezvlada prejmenovani souboru s read-only atributem na Novellu,
-// napsali jsme si vlastni (nastane-li chyba pri MoveFile, zkusi shodit read-only, provest operaci,
-// a pak ho zase nahodit)
+// Windows MoveFile cannot rename a file with the read-only attribute on Novell volumes,
+// so we have our own version (on failure we drop the read-only flag, perform the operation,
+// then restore it)
 BOOL SalMoveFile(const char* srcName, const char* destName);
 
-// varianta k windowsove verzi GetFileSize (ma jednodussi osetreni chyb); 'file' je otevreny
-// soubor pro volani GetFileSize(); v 'size' vraci ziskanou velikost souboru; vraci uspech,
-// pri FALSE (chyba) je v 'err' windowsovy kod chyby a v 'size' nula
+// replacement for Windows GetFileSize with simpler error handling; 'file' is an open
+// handle for GetFileSize(); the result is stored in 'size'. Returns success, otherwise
+// 'err' receives the Windows error code and 'size' is zero
 BOOL SalGetFileSize(HANDLE file, CQuadWord& size, DWORD& err);
-BOOL SalGetFileSize2(const char* fileName, CQuadWord& size, DWORD* err); // 'err' muze byt NULL pokud nas nezajima
+BOOL SalGetFileSize2(const char* fileName, CQuadWord& size, DWORD* err); // 'err' may be NULL if the error code is not needed
 
 struct COperation;
 
-// zjisti velikost souboru, na ktery vede symlink 'fileName'; je-li 'op' ruzne od NULL,
-// pri cancelu se vnitrek 'op' uvolni; je-li 'fileName' NULL, bere se 'op->SourceName';
-// velikost vraci v 'size'; 'ignoreAll' je in + out, je-li TRUE vsechny chyby se ignoruji
-// (pred akci je treba priradit FALSE, jinak se okno s chybou vubec nezobrazi, pak uz
-// nemenit); pri chybe zobrazi standardni okno s dotazem Retry / Ignore / Ignore All / Cancel
-// s parentem 'parent'; pokud velikost uspesne zjisti, vraci TRUE; pri chybe a stisku
-// tlacitka Ignore / Igore All v okne s chybou, vraci FALSE a v 'cancel' vraci FALSE;
-// je-li 'ignoreAll' TRUE, okno se neukaze, na tlacitko se neceka, chova se jako by
-// uzivatel stiskl Ignore; pri chybe a stisku Cancel v okne s chybou vraci FALSE a
-// v 'cancel' vraci TRUE
+// Finds the size of the file pointed to by the symlink 'fileName'. If 'op' is not NULL
+// and the operation is canceled the structure is released. If 'fileName' is NULL,
+// 'op->SourceName' is used instead. The size is returned in 'size'. 'ignoreAll' works as
+// both input and output; set it to FALSE before the call or the error dialog will never
+// appear. On error the standard Retry/Ignore/Ignore All/Cancel dialog with the parent
+// window 'parent' is shown. When Ignore or Ignore All is pressed the function returns
+// FALSE and 'cancel' receives FALSE.
+// If 'ignoreAll' is TRUE the dialog is skipped and behaves as if the user had clicked
+// Ignore; when Cancel is pressed the function returns FALSE and 'cancel' receives TRUE
 BOOL GetLinkTgtFileSize(HWND parent, const char* fileName, COperation* op, CQuadWord* size,
                         BOOL* cancel, BOOL* ignoreAll);
 
-// protoze windowsova verze GetFileAttributes neumi pracovat se jmeny koncicimi mezerou/teckou,
-// napsali jsme si vlastni (u techto jmen pridava backslash na konec, cimz uz pak
-// GetFileAttributes funguje spravne, ovsem jen pro adresare, pro soubory s mezerou/teckou na
-// konci reseni nemame, ale aspon se to nezjistuje od jineho souboru - windowsova verze
-// orizne mezery/tecky a pracuje tak s jinym souborem/adresarem)
+// Windows GetFileAttributes cannot handle names ending with a space or dot, so we created
+// our own version. For such names it appends a backslash which fixes GetFileAttributes for directories;
+// files with trailing spaces/dots remain problematic, but at least we avoid reading attributes of another file
+// because the Windows version trims spaces/dots and operates on a different name.
 DWORD SalGetFileAttributes(const char* fileName);
 
-// pokud ma soubor/adresar 'name' read-only atribut, pokusime se ho vypnout
-// (duvod: napr. aby sel smazat pres DeleteFile); pokud uz mame atributy 'name'
-// nactene, predame je v 'attr', je-li 'attr' -1, ctou se atributy 'name' z disku;
-// vraci TRUE pokud se provede pokus o zmenu atributu (uspech se nekontroluje)
-// POZNAMKA: vypina jen read-only atribut, aby v pripade vice hardlinku nedoslo
-// k zbytecne velke zmene atributu na zbyvajicich hardlinkach souboru (atributy
-// vsechny hardlinky sdili)
+// If the file or directory 'name' has the read-only attribute we try to clear it
+// (so DeleteFile can succeed). If the attributes have already been read we pass them in 'attr';
+// when 'attr' is -1 the attributes are read from disk. Returns TRUE if the change was attempted
+// (the success is not checked). NOTE: only the read-only attribute is cleared to avoid unnecessary
+// attribute changes on other hard links which all share the same attributes.
 BOOL ClearReadOnlyAttr(const char* name, DWORD attr = -1);
 
-// smaze link na adresar (junction point, symbolic link, mount point); pri uspechu
-// vraci TRUE; pri chybe vraci FALSE a neni-li 'err' NULL, vraci kod chyby v 'err'
+// Deletes a directory link (junction point, symbolic link, mount point). Returns TRUE on success;
+// on failure returns FALSE and if 'err' is not NULL, the error code is stored there.
 BOOL DeleteDirLink(const char* name, DWORD* err);
 
-// vraci TRUE, pokud je cesta 'path' na NOVELLskem svazku (slouzi k detekci toho,
-// jestli lze pouzit fast-directory-move)
+// Returns TRUE if 'path' resides on a NOVELL volume (used to detect whether fast-directory-move can be used)
 BOOL IsNOVELLDrive(const char* path);
 
-// vraci TRUE, pokud je cesta 'path' na LANTASTICskem svazku (slouzi k detekci toho,
-// jestli je nutne po kopirovani kontrolovat velikost souboru); pro optimalizacni
-// ucely se vyuzivaji 'lastLantasticCheckRoot' (pro prvni volani "", pak nemenit)
-// a 'lastIsLantasticPath' (vysledek pro 'lastLantasticCheckRoot')
+// Returns TRUE if 'path' is located on a LANTASTIC volume (used to decide
+// whether the file size must be verified after copying). For performance the
+// parameters 'lastLantasticCheckRoot' (empty for the first call, then unchanged)
+// and 'lastIsLantasticPath' (result for 'lastLantasticCheckRoot') are used
 BOOL IsLantasticDrive(const char* path, char* lastLantasticCheckRoot, BOOL& lastIsLantasticPath);
 
-// vraci TRUE pro sitove cesty
+// returns TRUE for network paths
 BOOL IsNetworkPath(const char* path);
 
-// vraci TRUE pokud 'path' lezi na svazku, ktery podporuje ADS (nebo nastala chyba pri
-// zjistovani o jaky file-system jde) a jsme pod NT/W2K/XP; neni-li 'isFAT32' NULL,
-// vraci v nem TRUE pokud 'path' vede na FAT32 svazek; vraci FALSE jen pokud je
-// jiste, ze FS nepodporuje ADS
+// returns TRUE if 'path' lies on a volume supporting ADS (or an error occurred while
+// detecting the file system) and we are on NT/W2K/XP; if 'isFAT32' is not NULL,
+// it receives TRUE if 'path' points to a FAT32 volume; returns FALSE only when it is
+// certain the FS does not support ADS
 BOOL IsPathOnVolumeSupADS(const char* path, BOOL* isFAT32);
 
-// test jestli jde o Sambu (Linuxova podpora sdileni disku s Windows)
+// test whether this is a Samba share (Linux sharing with Windows)
 BOOL IsSambaDrivePath(const char* path);
 
-// test jestli jde o UNC cestu (detekuje oba formaty: \\server\share i \\?\UNC\server\share)
+// test whether the path is UNC (detects both \\server\share and \\?\UNC\server\share formats)
 BOOL IsUNCPath(const char* path);
 
-// test jestli jde o UNC root (detekuje jen format: \\server\share)
+// test whether the path is UNC root (only detects the \\server\share format)
 BOOL IsUNCRootPath(const char* path);
 
-// vytvoreni souboru se jmenem 'fileName' pres klasicke volani Win32 API
-// CreateFile (lpSecurityAttributes==NULL, dwCreationDisposition==CREATE_NEW,
-// hTemplateFile==NULL); tato metoda resi kolizi 'fileName' s dosovym nazvem
-// jiz existujiciho souboru/adresare (jen pokud nejde i o kolizi s dlouhym
-// jmenem souboru/adresare) - zajisti zmenu dosoveho jmena tak, aby se soubor se
-// jmenem 'fileName' mohl vytvorit (zpusob: docasne prejmenuje konfliktni
-// soubor/adresar na jine jmeno a po vytvoreni 'fileName' ho prejmenuje zpet);
-// vraci handle souboru nebo pri chybe INVALID_HANDLE_VALUE (chyba je v GetLastError());
-// neni-li 'encryptionNotSupported' NULL a soubor nejde otevrit s Encrypted
-// atributem, zkusi ho otevrit jeste bez Encrypted atributu, pokud se to povede,
-// soubor je smazan a do 'encryptionNotSupported' se zapise TRUE - navratova hodnota
-// funkce a GetLastError() obsahuji "puvodni" chybu (otevirani s Encrypted atributem)
+// creates a file named 'fileName' using the standard Win32 API CreateFile
+// (lpSecurityAttributes==NULL, dwCreationDisposition==CREATE_NEW, hTemplateFile==NULL).
+// This method handles collisions between 'fileName' and an existing DOS name
+// (only when it is not also a long-name collision) by temporarily renaming the
+// conflicting file/directory and renaming it back after creating 'fileName'.
+// Returns a file handle or INVALID_HANDLE_VALUE on error (GetLastError()).
+// If 'encryptionNotSupported' is not NULL and the file cannot be opened with the
+// Encrypted attribute, it tries again without encryption support,
+// the file is deleted and 'encryptionNotSupported' is set to TRUE - the function's
+// return value and GetLastError() contain the original error from opening with the Encrypted attribute
 HANDLE SalCreateFileEx(const char* fileName, DWORD desiredAccess,
                        DWORD shareMode, DWORD flagsAndAttributes,
                        BOOL* encryptionNotSupported);
 
-// zkontroluje posledni komponentu jmena v ceste 'path', pokud obsahuje na
-// zacatku nebo na konci mezeru nebo na konci tecku, vraci TRUE, jinak FALSE
+// Checks the last component of the name in 'path'. If it starts or ends with a
+// space or ends with a dot the function returns TRUE; otherwise FALSE
 BOOL FileNameInvalidForManualCreate(const char* path);
 
-// oriznuti mezer na zacatku a na konci jmena (CutWS nebo StripWS nebo CutWhiteSpace nebo StripWhiteSpace)
-// vraci TRUE pokud doslo k orezu
+// Trims spaces from the beginning and end of the name (CutWS or StripWS or CutWhiteSpace or StripWhiteSpace)
+// Returns TRUE if trimming occurred
 BOOL CutSpacesFromBothSides(char* path);
 
-// oriznuti mezer na zacatku a mezer a tecek na konci jmena, dela to tak Explorer
-// a lidi tlacili, ze to tak taky chteji, viz https://forum.altap.cz/viewtopic.php?f=16&t=5891
-// a https://forum.altap.cz/viewtopic.php?f=2&t=4210
-// vraci TRUE pokud se zmeni obsah 'path'
+// Trims leading spaces and trailing spaces or dots in the same way Explorer does
+// because users requested this behavior, see https://forum.altap.cz/viewtopic.php?f=16&t=5891
+// and https://forum.altap.cz/viewtopic.php?f=2&t=4210. Returns TRUE if 'path' was modified
 BOOL MakeValidFileName(char* path);
 
-// pokud 'name' konci na mezeru/tecku, udela se kopie 'name' do 'nameCopy' a doplni
-// se na konec '\\', pak se 'name' nasmeruje do 'nameCopy'; bezne API funkce
-// orezavaji tise mezery/tecky z konce cesty a pracuji pak s jinymi soubory/adresari
-// nez chceme, pridany '\\' na konci to resi
+// If 'name' ends with a space or dot a copy of 'name' is made to 'nameCopy' and
+// a '\\' is appended. 'name' is then redirected to 'nameCopy'. Standard API
+// functions silently trim trailing spaces or dots and operate on other
+// files/directories than intended; adding '\\' at the end fixes that
 void MakeCopyWithBackslashIfNeeded(const char*& name, char (&nameCopy)[3 * MAX_PATH]);
 
-// vraci TRUE pokud jmeno konci na backslash ('\\' pridany na konci resi invalidni jmena)
+// Returns TRUE if the name ends with a backslash (the added '\\' fixes invalid names)
 BOOL NameEndsWithBackslash(const char* name);
 
-// pokud 'name' konci na mezeru/tecku nebo obsahuje ':' (kolize s ADS), vraci TRUE, jinak FALSE,
-// je-li 'ignInvalidName' TRUE, vraci TRUE jen pokud 'name' obsahuje ':' (kolize s ADS)
+// Returns TRUE if 'name' ends with a space/dot or contains ':' (ADS conflict), otherwise FALSE.
+// When 'ignInvalidName' is TRUE, returns TRUE only if 'name' contains ':' (ADS conflict)
 BOOL FileNameIsInvalid(const char* name, BOOL isFullName, BOOL ignInvalidName = FALSE);
 
-// vraci FALSE, pokud obsazene komponenty cesty konci na mezeru/tecku
-// a je-li 'cutPath' TRUE, zaroven cestu zkrati k prvni invalidni komponente
-// (pro chybove hlaseni), jinak vraci TRUE
+// Returns FALSE if any component of the path ends with a space or dot. When
+// 'cutPath' is TRUE the path is shortened to the first invalid component (for an
+// error message). Otherwise returns TRUE
 BOOL PathContainsValidComponents(char* path, BOOL cutPath);
 
-// vytvoreni adresare se jmenem 'name' pres klasicke volani Win32 API
-// CreateDirectory(lpSecurityAttributes==NULL); tato metoda resi kolizi 'name'
-// s dosovym nazvem jiz existujiciho souboru/adresare (jen pokud nejde i o
-// kolizi s dlouhym jmenem souboru/adresare) - zajisti zmenu dosoveho jmena
-// tak, aby se adresar se jmenem 'name' mohl vytvorit (zpusob: docasne prejmenuje
-// konfliktni soubor/adresar na jine jmeno a po vytvoreni 'name' ho
-// prejmenuje zpet); dale resi jmena koncici na mezery (umi je vytvorit, narozdil
-// od CreateDirectory, ktera mezery bez varovani orizne a vytvori tak vlastne
-// jiny adresar); vraci TRUE pri uspechu, pri chybe FALSE (vraci v 'err'
-// (neni-li NULL) kod Windows chyby)
+// creates a directory called 'name' using the standard CreateDirectory API
+// (lpSecurityAttributes==NULL). The function resolves collisions with an
+// existing DOS name (provided the long name itself does not collide) by
+// temporarily renaming the conflicting item so the directory can be created and
+// then restoring the original name. It also supports names ending with spaces,
+// which CreateDirectory would otherwise trim. Returns TRUE on success or FALSE
+// on failure. If 'err' is not NULL it receives the Windows error code.
 BOOL SalCreateDirectoryEx(const char* name, DWORD* err);
 
-void InitLocales();                                       // nutne volat pres pouzitim NumberToStr a PrintDiskSize
-char* NumberToStr(char* buffer, const CQuadWord& number); // prevod int -> prehlednejsi string, !char buffer[50]!
-int NumberToStr2(char* buffer, const CQuadWord& number);  // prevod int -> prehlednejsi string, !char buffer[50]!, vraci pocet znaku nakopirovanych do bufferu
-char* GetErrorText(DWORD error);                          // prevadi cislo chyby na string
-WCHAR* GetErrorTextW(DWORD error);                        // prevadi cislo chyby na string
-BOOL IsDirError(DWORD err);                               // tyka se chyba prace s adresari ?
+void InitLocales();                                       // must be called before NumberToStr and PrintDiskSize
+char* NumberToStr(char* buffer, const CQuadWord& number); // converts integer to a more readable string, !char buffer[50]!
+int NumberToStr2(char* buffer, const CQuadWord& number);  // converts integer to a readable string, !char buffer[50]!, returns number of characters copied to the buffer
+char* GetErrorText(DWORD error);                          // converts error code to a string
+WCHAR* GetErrorTextW(DWORD error);                        // converts error code to a wide string
+BOOL IsDirError(DWORD err);                               // does the error relate to directories?
 
-// normal i UNC cesty: maji stejny root?
+// regular and UNC paths: do they share the same root?
 BOOL HasTheSameRootPath(const char* path1, const char* path2);
 
-// zjisti, jestli maji obe cesty stejny root a jsou z jednoho svazku (resi
-// cesty obsahujici reparse pointy a substy)
-// POZOR: jde o dost POMALOU funkci (az 200ms)
+// checks whether both paths have the same root and lie on the same volume
+// (handles paths containing reparse points and SUBST drives)
+// WARNING: this function can be quite slow (up to 200 ms)
 BOOL HasTheSameRootPathAndVolume(const char* p1, const char* p2);
 
-// vraci TRUE, pokud jsou cesty 'path1' a 'path2' ze stejneho svazku; v 'resIsOnlyEstimation'
-// (neni-li NULL) vraci TRUE, pokud neni vysledek jisty (jisty je jen v pripade, ze se
-// podarilo ziskat "volume name" (GUID) u obou cest, coz pripada v uvahu jen pro lokalni
-// cesty pod W2K nebo novejsimi z rady NT)
-// POZOR: jde o dost POMALOU funkci (az 200ms)
+// returns TRUE if 'path1' and 'path2' are on the same volume; if 'resIsOnlyEstimation'
+// is not NULL it is set to TRUE when the result is only an estimation (certain only
+// when the "volume name" GUID could be obtained for both paths, which is possible
+// only for local paths under Windows 2000 or newer)
+// WARNING: this function can be quite slow (up to 200 ms)
 BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOnlyEstimation);
 
-// porovna dve cesty: ignore-case, ignoruje take jeden backslash na zacatku a konci cest
+// compares two paths: case-insensitive and ignoring a single backslash at the start and end
 BOOL IsTheSamePath(const char* path1, const char* path2);
 
-// zjisti, jestli je cesta typu plugin FS, 'path' je zjistovana cesta, 'fsName' je
-// buffer MAX_PATH znaku pro jmeno FS (nebo NULL), vraci 'userPart' (je-li != NULL) - ukazatel
-// do 'path' na prvni znak pluginem definovane cesty (za prvni ':')
+// determines whether 'path' is a plugin FS path; 'path' is the path to check,
+// 'fsName' is a MAX_PATH buffer for the FS name (or NULL); stores in 'userPart'
+// (if not NULL) a pointer into 'path' to the first character of the plugin-defined path (after the first ':')
 BOOL IsPluginFSPath(const char* path, char* fsName = NULL, const char** userPart = NULL);
 BOOL IsPluginFSPath(char* path, char* fsName = NULL, char** userPart = NULL);
 
-// test, jestli jde o cestu s URL, napr. "file:///c|/WINDOWS/clock.avi" = "c:\\WINDOWS\\clock.avi"
+// test whether the path is a URL, e.g. "file:///c|/WINDOWS/clock.avi" becomes "c:\\WINDOWS\\clock.avi"
 BOOL IsFileURLPath(const char* path);
 
-// zjisti podle pripony souboru, jestli jde o link (.lnk, .pif nebo .url); je-li, vraci 1,
-// jinak vraci 0
+// determines from a file extension whether it is a shortcut (.lnk, .pif or .url);
+// returns 1 for shortcuts or 0 otherwise
 int IsFileLink(const char* fileExtension);
 
-// ziska UNC i normalni root cestu z 'path', v 'root' vraci cestu ve formatu 'C:\' nebo '\\SERVER\SHARE\',
-// vraci pocet znaku root cesty (bez null-terminatoru); 'root' je buffer aspon MAX_PATH znaku, pri delsi
-// UNC root ceste dojde k orezu na MAX_PATH-2 znaku a doplneni backslashe (stejne to na 100% neni root cesta)
+// obtains the UNC or drive root from 'path'; 'root' receives it in the form
+// "C:\\" or "\\SERVER\\SHARE\\". The function returns the number of characters
+// in the root (without the null terminator). If the UNC root is longer it is
+// truncated to MAX_PATH-2 characters and a trailing backslash is added because
+// such a string cannot be a real root
 int GetRootPath(char* root, const char* path);
 
-// vraci ukazatel za root (presneji na backslash hned za rootem) UNC i normalni cesty 'path'
+// returns a pointer just after the root (specifically to the backslash) of a
+// UNC or standard path
 const char* SkipRoot(const char* path);
 
-// vraci TRUE pokud se podari 'path' (UNC i normal cesta) zkratit o posledni adresar
-// (zariznuti na poslednim backslashi - v oriznute ceste zustava na konci backslash jen u 'c:\'),
-// v 'cutDir' se vraci ukazatel na posledni adresar (odriznutou cast)
-// nahrazka za PathRemoveFileSpec
+// returns TRUE if 'path' (UNC or standard) can be shortened by removing the last
+// directory. The last backslash remains only for paths like "c:\". If 'cutDir' is
+// not NULL it receives a pointer to the removed directory
+// replacement for PathRemoveFileSpec
 BOOL CutDirectory(char* path, char** cutDir = NULL);
 
-// spoji 'path' a 'name' do 'path', zajisti spojeni backslashem, 'path' je buffer alespon 'pathSize' znaku
-// vraci TRUE pokud se 'name' veslo za 'path'; je-li 'path' nebo 'name' prazdne,
-// spojovaci (pocatecni/ukoncovaci) backslash nebude (napr. "c:\" + "" -> "c:")
+// concatenates 'name' to 'path' ensuring a single backslash separator. 'path'
+// must hold at least 'pathSize' characters. Returns TRUE if 'name' fits; if
+// either parameter is empty no separator is added (e.g. "c:\" + "" -> "c:")
 BOOL SalPathAppend(char* path, const char* name, int pathSize);
 
-// pokud jeste 'path' nekonci na backslash, prida ho na konec 'path'; 'path' je buffer alespon 'pathSize'
-// znaku; vraci TRUE pokud se backslash vesel za 'path'; je-li 'path' prazdne, backslash se neprida
+// if 'path' does not already end with a backslash, appends one to the end of 'path'; 'path' is a buffer of at least 'pathSize'
+// characters; returns TRUE if the backslash fits after 'path'; if 'path' is empty, no backslash is added
 BOOL SalPathAddBackslash(char* path, int pathSize);
 
-// pokud je v 'path' na konci backslash, odstrani ho
+// removes a trailing backslash from 'path' if present
 void SalPathRemoveBackslash(char* path);
 
-// prevede vsechny '/' na '\\' a zaroven pokud jsou za sebou dva nebo vice '\\',
-// necha jen jeden (krome dvou '\\' na zacatku stringu, coz oznacuje UNC cestu)
+// converts all '/' characters to '\\' and collapses repeated '\\' to a single one
+// except for the two leading characters that denote a UNC path
 void SlashesToBackslashesAndRemoveDups(char* path);
 
-// z plneho jmena udela jmeno ("c:\path\file" -> "file")
+// extracts the file name from a full path ("c:\\path\\file" -> "file")
 void SalPathStripPath(char* path);
 
-// pokud je ve jmene pripona, odstrani ji
+// removes the file extension if one is present
 void SalPathRemoveExtension(char* path);
 
-// pokud ve jmenu 'path' jeste neni pripona, prida priponu 'extension' (napr. ".txt"), 'path' je buffer
-// alespon 'pathSize' znaku, vraci FALSE pokud buffer 'path' nestaci pro vyslednou cestu
+// if 'path' has no extension yet, append 'extension' (for example ".txt").
+// 'path' must hold at least 'pathSize' characters; returns FALSE when the buffer
+// is not large enough for the resulting string
 BOOL SalPathAddExtension(char* path, const char* extension, int pathSize);
 
-// zmeni/prida priponu 'extension' (napr. ".txt") ve jmenu 'path', 'path' je buffer
-// alespon 'pathSize' znaku, vraci FALSE pokud buffer 'path' nestaci pro vyslednou cestu
+// changes or adds the extension 'extension' (for example ".txt") in 'path'.
+// 'path' must hold at least 'pathSize' characters; returns FALSE if the buffer
+// is not large enough for the resulting string
 BOOL SalPathRenameExtension(char* path, const char* extension, int pathSize);
 
-// vraci ukazatel do 'path' na jmeno souboru/adresare (backslash na konci 'path' ignoruje),
-// pokud jmeno neobsahuje jine backslashe nez na konci retezce, vraci 'path'
+// returns a pointer into 'path' pointing to the file or directory name. A
+// trailing backslash is ignored. If there are no other backslashes the function
+// simply returns 'path'
 const char* SalPathFindFileName(const char* path);
 
-// Pracuje pro normalni i UNC cesty.
-// Vrati pocet znaku spolecne cesty. Na normalni ceste musi byt root ukonceny zpetnym
-// lomitkem, jinak funkce vrati 0. ("C:\"+"C:"->0, "C:\A\B"+"C:\"->3, "C:\A\B\"+"C:\A"->4,
-// "C:\AA\BB"+"C:\AA\CC"->5)
+// Works for both regular and UNC paths.
+// Returns the number of characters common to both paths. For a regular path the
+// root must end with a backslash, otherwise the function returns 0. Examples:
+// "C:\"+"C:"->0, "C:\A\B"+"C:\"->3, "C:\A\B\"+"C:\A"->4,
+// "C:\AA\BB"+"C:\AA\CC"->5
 int CommonPrefixLength(const char* path1, const char* path2);
 
-// Vraci TRUE, pokud je cesta 'prefix' zakladem cesty 'path'. Jinak vraci FALSE.
+// Returns TRUE if the path 'prefix' is a prefix of the path 'path'. Otherwise returns FALSE.
 // "C:\aa","C:\Aa\BB"->TRUE
 // "C:\aa","C:\aaa"->FALSE
 // "C:\aa\","C:\Aa"->TRUE
 // "\\server\share","\\server\share\aaa"->TRUE
-// Pracuje pro normalni i UNC cesty.
+// Works with both regular and UNC paths.
 BOOL SalPathIsPrefix(const char* prefix, const char* path);
 
-// odstrani ".." (vynecha ".." spolu s jednim podadresarem vlevo) a "." (vynecha jen ".")
-// z cesty; podminkou je backslash jako oddelovac podadresaru; 'afterRoot' ukazuje za root
-// zpracovavane cesty (zmeny cesty se deji jen za 'afterRoot'); vraci TRUE pokud se upravy
-// podarily, FALSE pokud se nedaji odstranit ".." (vlevo uz je root)
+// Removes ".." (together with one directory to the left) and "." (only the "." itself)
+// from a path; backslashes must be used as directory separators; 'afterRoot' points past the
+// root of the processed path (the path is modified only after 'afterRoot'); returns TRUE if the
+// adjustments succeed, or FALSE if ".." cannot be removed because the root has already been reached
 BOOL SalRemovePointsFromPath(char* afterRoot);
 BOOL SalRemovePointsFromPath(WCHAR* afterRoot);
 
-// upravuje relativni nebo absolutni cestu na absolutni bez '.', '..' a koncoveho backslashe (krom
-// "X:\"); je-li 'curDir' NULL, relativni cesty typu "\path" a "path" vraci chybu (neurcitelne), jinak je
-// 'curDir' platna upravena aktualni cesta (UNC i normal); aktualni cesty ostatnich disku (mimo
-// 'curDir'; jen normal, ne UNC) jsou v DefaultDir (pred pouzitim je dobre zavolat
-// CMainWindow::UpdateDefaultDir); 'name' - in/out buffer alespon MAX_PATH znaku (jeho velikost je v 'nameBufSize');
-// neni-li 'nextFocus' NULL a zadana relativni cesta neobsahuje backslash - strcpy(nextFocus, name)
-// vraci TRUE - jmeno 'name' je pripraveno k pouziti, jinak neni-li 'errTextID' NULL obsahuje
-// chybu (konstanty pro LoadStr - IDS_SERVERNAMEMISSING, IDS_SHARENAMEMISSING, IDS_TOOLONGPATH,
-// IDS_INVALIDDRIVE, IDS_INCOMLETEFILENAME, IDS_EMPTYNAMENOTALLOWED a IDS_PATHISINVALID);
-// v 'callNethood' (neni-li NULL) se vraci TRUE ma-li se volat Nethood plugin pri chybach
-// IDS_SERVERNAMEMISSING a IDS_SHARENAMEMISSING, je-li 'allowRelPathWithSpaces' TRUE, neoreze
-// mezery ze zacatku relativni cesty (bezne dela, aby si lidi nevytvareli omylem nazvy s mezerami
-// na zacatku, mezery a tecky na konci orezou wokna)
-// vraci TRUE pokud v ceste neni chyba, jinak se vraci FALSE (napr. "\\\" nebo "\\server\\")
+// Converts a relative or absolute path to an absolute one without '.', '..', or a trailing
+// backslash (except "X:\"); if 'curDir' is NULL, relative paths such as "\\path" and "path"
+// are reported as errors (they are indeterminate); otherwise 'curDir' must be a valid adjusted
+// current path (UNC or regular); current paths of other drives (except 'curDir'; regular only,
+// not UNC) are in DefaultDir (it is advisable to call CMainWindow::UpdateDefaultDir before use);
+// 'name' is an in/out buffer of at least MAX_PATH characters (its size is in 'nameBufSize');
+// if 'nextFocus' is not NULL and the specified relative path contains no backslash,
+// strcpy(nextFocus, name) is called
+// Returns TRUE - the name in 'name' is ready for use; otherwise, if 'errTextID' is not NULL it
+// contains the error (constants for LoadStr - IDS_SERVERNAMEMISSING, IDS_SHARENAMEMISSING,
+// IDS_TOOLONGPATH, IDS_INVALIDDRIVE, IDS_INCOMLETEFILENAME, IDS_EMPTYNAMENOTALLOWED, and
+// IDS_PATHISINVALID); TRUE is returned in 'callNethood' (if not NULL) if the Nethood plugin should
+// be called for IDS_SERVERNAMEMISSING and IDS_SHARENAMEMISSING; if 'allowRelPathWithSpaces' is
+// TRUE, leading spaces are not trimmed from a relative path (normally they are, to prevent users
+// from accidentally creating names with leading spaces; Windows trims trailing spaces and dots)
+// Returns TRUE if the path contains no error, otherwise FALSE (e.g. "\\\" or "\\server\\")
 BOOL SalGetFullName(char* name, int* errTextID = NULL, const char* curDir = NULL,
                     char* nextFocus = NULL, BOOL* callNethood = NULL, int nameBufSize = MAX_PATH,
                     BOOL allowRelPathWithSpaces = FALSE);
 
-// zkusi pristup na cestu 'path' (normal nebo UNC), probiha ve vedlejsim threadu, takze
-// umoznuje prerusit zkousku klavesou ESC (po jiste dobe vybali okenko s hlasenim o ESC)
-// 'echo' TRUE znamena povoleny vypis chybove hlasky (pokud cesta nebude pristupna);
-// 'err' ruzne od ERROR_SUCCESS v kombinaci s 'echo' TRUE pouze zobrazi chybu (na cestu
-// se jiz nepristupuje); 'postRefresh' je parametr do volani EndStopRefresh (normalne TRUE);
-// 'parent' je parent messageboxu; vraci ERROR_SUCCESS v pripade, ze je cesta v poradku,
-// jinak vraci standardni Windowsovy kod chyby nebo ERROR_USER_TERMINATED v pripade, ze
-// user pouzil klavesu ESC k preruseni testu
+// tries to access the 'path' (regular or UNC) in a worker thread so
+// the attempt can be interrupted with the ESC key (after a while a
+// message about the pressed ESC is shown)
+// When 'echo' is TRUE an error message is displayed if the path is not
+// accessible. If 'err' differs from ERROR_SUCCESS together with 'echo' TRUE, the
+// error is shown and no additional check is performed. 'postRefresh' is passed
+// to EndStopRefresh (normally TRUE). 'parent' is the parent message box. The
+// function returns ERROR_SUCCESS when the path is valid or a standard Windows
+// error code (or ERROR_USER_TERMINATED when ESC was pressed) otherwise.
 DWORD SalCheckPath(BOOL echo, const char* path, DWORD err, BOOL postRefresh, HWND parent);
 
-// zkusi jestli je cesta 'path' pristupna, prip. obnovi sitova spojeni pomoci funkci
-// CheckAndRestoreNetworkConnection a CheckAndConnectUNCNetworkPath; vraci TRUE pokud
-// je cesta pristupna; 'parent' je parent messageboxu; 'tryNet' je TRUE pokud ma smysl
-// zkouset obnovit sitova spojeni
+// Tries to access 'path' and optionally restores network connections via
+// CheckAndRestoreNetworkConnection and CheckAndConnectUNCNetworkPath.
+// Returns TRUE when the path is accessible. 'parent' is the parent message box;
+// 'tryNet' specifies whether attempting to restore the connection makes sense.
 BOOL SalCheckAndRestorePath(HWND parent, const char* path, BOOL tryNet);
 
-// zkusi jestli je cesta 'path' pristupna, prip. ji zkrati; je-li 'tryNet' TRUE, prip. obnovi
-// sitova spojeni pomoci funkci CheckAndRestoreNetworkConnection a CheckAndConnectUNCNetworkPath
-// (je-li 'donotReconnect' TRUE, zjisti se pouze chyba, obnova spojeni uz se neprovede) a nastavi
-// 'tryNet' na FALSE; vraci 'err' (kod chyby aktualni cesty), 'lastErr' (kod chyby vedouci ke
-// zkraceni cesty), 'pathInvalid' (TRUE pokud se zkusila obnova sit. spojeni bez uspechu),
-// 'cut' (TRUE pokud je vysledna cesta zkracena); 'parent' je parent messageboxu; vraci TRUE
-// pokud je vysledna cesta 'path' pristupna
+// Checks if 'path' is accessible and optionally shortens it. When 'tryNet' is
+// TRUE, network connections can be restored using
+// CheckAndRestoreNetworkConnection and CheckAndConnectUNCNetworkPath (unless
+// 'donotReconnect' is TRUE, in which case the error is only reported). The
+// function updates 'tryNet' to FALSE and returns 'err' (current path error),
+// 'lastErr' (error that caused path shortening), 'pathInvalid' (TRUE when a
+// network reconnection failed), and 'cut' (TRUE when the final path is shorter).
+// 'parent' is the parent window. Returns TRUE if the resulting path is
+// accessible.
 BOOL SalCheckAndRestorePathWithCut(HWND parent, char* path, BOOL& tryNet, DWORD& err, DWORD& lastErr,
                                    BOOL& pathInvalid, BOOL& cut, BOOL donotReconnect);
 
-// rozpozna o jaky typ cesty (FS/windowsova/archiv) jde a postara se o rozdeleni na
-// jeji casti (u FS jde o fs-name a fs-user-part, u archivu jde o path-to-archive a
-// path-in-archive, u windowsovych cest jde o existujici cast a zbytek cesty), u FS cest
-// se nic nekontroluje, u windowsovych (normal + UNC) cest se kontroluje kam az cesta existuje
-// (prip. obnovi sitove spojeni), u archivu se kontroluje existence souboru archivu
-// (rozliseni archivu dle pripony); pouziva SalGetFullName, proto je dobre napred zavolat
-// CMainWindow::UpdateDefaultDir)
-// 'path' je plna nebo relativni cesta (buffer min. 'pathBufSize' znaku; u relativnich cest se
-// uvazuje aktualni cesta 'curPath' (neni-li NULL) jako zaklad pro vyhodnoceni plne cesty;
-// 'curPathIsDiskOrArchive' je TRUE pokud je 'curPath' windowsova nebo archivova cesta;
-// pokud je aktualni cesta archivova, obsahuje 'curArchivePath' jmeno archivu, jinak je NULL),
-// do 'path' se ulozi vysledna plna cesta (musi byt min. 'pathBufSize' znaku); vraci TRUE pri
-// uspesnem rozpoznani, pak 'type' je typ cesty (viz PATH_TYPE_XXX) a 'secondPart' je nastavene:
-// - do 'path' na pozici za existujici cestu (za '\\' nebo na konci retezce; existuje-li
-//   v ceste soubor, ukazuje za cestu k tomuto souboru) (typ cesty windows), POZOR: neresi
-//   se delka vracene casti cesty (cela cesta muze byt delsi nez MAX_PATH)
-// - za soubor archivu (typ cesty archiv), POZOR: neresi se delka cesty v archivu (muze byt
-//   delsi nez MAX_PATH)
-// - za ':' za nazvem file-systemu - user-part cesty file-systemu (typ cesty FS), POZOR: neresi
-//   se delka user-part cesty (muze byt delsi nez MAX_PATH);
-// pokud vraci TRUE je jeste 'isDir' nastavena na:
-// - TRUE pokud existujici cast cesty je adresar, FALSE == soubor (typ cesty windows)
-// - FALSE pro cesty typu archiv a FS;
-// pokud vrati FALSE, userovi byla vypsana chyba (az na jednu vyjimku - viz popis SPP_INCOMLETEPATH),
-// ktera pri rozpoznavani nastala (neni-li 'error' NULL, vraci se v nem jedna z konstant SPP_XXX);
-// 'errorTitle' je titulek messageboxu s chybou; pokud je 'nextFocus' != NULL a windowsova/archivova
-// cesta neobsahuje '\\' nebo na '\\' jen konci, nakopiruje se cesta do 'nextFocus' (viz SalGetFullName)
+// Detects the path type (FS, Windows, or archive) and splits it into parts.
+// For FS paths this means fs-name and user part, for archives the path to the
+// archive file and the path inside it, and for Windows paths the existing part
+// and the remainder. FS paths are not validated; Windows paths are checked for
+// how far they exist (and network connections are restored if needed). Archive
+// paths check for file existence based on extension. Because SalGetFullName is
+// used, CMainWindow::UpdateDefaultDir should be called beforehand.
+// 'path' is a full or relative path (buffer of at least 'pathBufSize' chars; for
+// relative paths the current directory 'curPath' is used as the base). If the
+// current path is an archive, 'curArchivePath' holds its file name. The resolved
+// full path is stored back to 'path'. On success TRUE is returned, 'type' holds
+// the path type (PATH_TYPE_XXX) and 'secondPart' points to:
+// - in Windows paths: the location after the existing portion (after '\\' or at
+//   end; if a file is present it points after the file name). Length is not
+//   checked (may exceed MAX_PATH).
+// - in archive paths: after the archive file name (length may exceed MAX_PATH).
+// - in FS paths: after ':' following the file-system name; length of the user
+//   part is not checked.
+// When TRUE is returned, 'isDir' is additionally set to:
+// - TRUE if the existing portion is a directory, FALSE if it is a file (Windows
+//   path type)
+// - FALSE for archive and FS paths.
+// If FALSE is returned, an error message has already been shown to the user
+// (except for SPP_INCOMLETEPATH). If 'error' is not NULL, one of the SPP_XXX
+// constants is stored there. 'errorTitle' is the title of the error message box.
+// When 'nextFocus' is not NULL and the path does not contain '\\' or ends with
+// '\\', the path is copied into 'nextFocus' (see SalGetFullName).
 BOOL SalParsePath(HWND parent, char* path, int& type, BOOL& isDir, char*& secondPart,
                   const char* errorTitle, char* nextFocus, BOOL curPathIsDiskOrArchive,
                   const char* curPath, const char* curArchivePath, int* error,
                   int pathBufSize);
 
-// ziska z windowsove cilove cesty existujici cast a operacni masku; pripadnou neexistujici cast
-// umozni vytvorit; pri uspechu vraci TRUE a existujici windowsovou cilovou cestu (v 'path')
-// a nalezenou operacni masku (v 'mask' - ukazuje do bufferu 'path', ale cesta a maska jsou oddelene
-// nulou; pokud v ceste neni maska, automaticky vytvori masku "*.*"); 'parent' - parent pripadnych
-// messageboxu; 'title' + 'errorTitle' jsou titulky messageboxu s informaci + chybou; 'selCount' je
-// pocet oznacenych souboru a adresaru; 'path' je na vstupu cilova cesta ke zpracovani, na vystupu
-// (alespon 2 * MAX_PATH znaku) existujici cilova cesta; 'secondPart' ukazuje do 'path' na pozici
-// za existujici cestu (za '\\' nebo na konec retezce; existuje-li v ceste soubor, ukazuje za cestu
-// k tomuto souboru); 'pathIsDir' je TRUE/FALSE pokud existujici cast cesty je adresar/soubor;
-// 'backslashAtEnd' je TRUE pokud byl pred provedenim "parse" na konci 'path' backslash (napr.
-// SalParsePath takovy backslash rusi); 'dirName' + 'curDiskPath' nejsou NULL pokud je oznaceny
-// max. jeden soubor/adresar (jeho jmeno bez cesty je v 'dirName'; pokud neni nic oznacene, bere
-// se focus) a aktualni cesta je windowsova (cesta je v 'curDiskPath'); 'mask' je na vystupu
-// ukazatel na operacni masku do bufferu 'path'; pokud je v ceste chyba, vraci metoda FALSE,
-// problem uz byl uzivateli ohlasen
+// obtains the existing part and operation mask from a Windows target path; allows any non-existent part
+// to be created; on success returns TRUE, the existing Windows target path (in 'path')
+// and the found operation mask (in 'mask' - it points into the 'path' buffer, but the path and mask are separated
+// by a null character; if the path contains no mask, it automatically creates the mask "*.*"); 'parent' is the parent of any
+// message boxes; 'title' + 'errorTitle' are the captions of the information + error message boxes; 'selCount' is
+// the number of selected files and directories; 'path' is the input target path to process, on output
+// (at least 2 * MAX_PATH characters) the existing target path; 'secondPart' points into 'path' to the position
+// after the existing path (after '\\' or at the end of the string; if the path contains a file, it points after the path
+// to that file); 'pathIsDir' is TRUE/FALSE if the existing part of the path is a directory/file;
+// 'backslashAtEnd' is TRUE if there was a backslash at the end of 'path' before "parse" was performed (for example,
+// SalParsePath removes such a backslash); 'dirName' + 'curDiskPath' are not NULL if at most one file/directory is selected
+// (its name without the path is in 'dirName'; if nothing is selected, the focused item is used)
+// and the current path is a Windows path (the path is in 'curDiskPath'); 'mask' is on output
+// a pointer to the operation mask in the 'path' buffer; if the path contains an error, the method returns FALSE,
+// the problem has already been reported to the user
 BOOL SalSplitWindowsPath(HWND parent, const char* title, const char* errorTitle, int selCount,
                          char* path, char* secondPart, BOOL pathIsDir, BOOL backslashAtEnd,
                          const char* dirName, const char* curDiskPath, char*& mask);
 
-// ziska z cilove cesty existujici cast a operacni masku; pripadnou neexistujici cast rozpozna; pri
-// uspechu vraci TRUE, relativni cestu k vytvoreni (v 'newDirs'), existujici cilovou cestu (v 'path';
-// existujici jen za predpokladu vytvoreni relativni cesty 'newDirs') a nalezenou operacni masku
-// (v 'mask' - ukazuje do bufferu 'path', ale cesta a maska jsou oddelene nulou; pokud v ceste neni
-// maska, automaticky vytvori masku "*.*"); 'parent' - parent pripadnych messageboxu;
-// 'title' + 'errorTitle' jsou titulky messageboxu s informaci + chybou; 'selCount' je pocet oznacenych
-// souboru a adresaru; 'path' je na vstupu cilova cesta ke zpracovani, na vystupu (alespon 2 * MAX_PATH
-// znaku) existujici cilova cesta (vzdy konci backslashem); 'afterRoot' ukazuje do 'path' za root cesty
-// (za '\\' nebo na konec retezce); 'secondPart' ukazuje do 'path' na pozici za existujici cestu (za
-// '\\' nebo na konec retezce; existuje-li v ceste soubor, ukazuje za cestu k tomuto souboru);
-// 'pathIsDir' je TRUE/FALSE pokud existujici cast cesty je adresar/soubor; 'backslashAtEnd' je
-// TRUE pokud byl pred provedenim "parse" na konci 'path' backslash (napr. SalParsePath takovy
-// backslash rusi); 'dirName' + 'curPath' nejsou NULL pokud je oznaceny max. jeden soubor/adresar
-// (jeho jmeno bez cesty je v 'dirName'; jeho cesta je v 'curPath'; pokud neni nic oznacene, bere
-// se focus); 'mask' je na vystupu ukazatel na operacni masku do bufferu 'path'; neni-li 'newDirs' NULL,
-// pak jde o buffer (o velikosti alespon MAX_PATH) pro relativni cestu (vzhledem k existujici ceste
-// v 'path'), kterou je nutne vytvorit (uzivatel s vytvorenim souhlasi, byl pouzit stejny dotaz jako
-// u kopirovani z disku na disk; prazdny retezec = nic nevytvaret); je-li 'newDirs' NULL a je-li
-// potreba vytvorit nejakou relativni cestu, je jen vypsana chyba; 'isTheSamePathF' je funkce pro
-// porovnani dvou cest (potrebna jen pokud 'curPath' neni NULL), je-li NULL pouzije se IsTheSamePath;
-// pokud je v ceste chyba, vraci metoda FALSE, problem uz byl uzivateli ohlasen
+// Retrieves the existing portion and the operation mask from the target path;
+// recognizes any non-existent part. On success returns TRUE, the relative path
+// to create (in 'newDirs'), the existing target path (in 'path'; valid only if
+// the relative path will be created) and the found operation mask (in 'mask'
+// pointing into the 'path' buffer; the path and mask are separated by a zero. If
+// the path contains no mask, "*.*" is generated automatically). 'parent' is the
+// parent of message boxes; 'title' + 'errorTitle' are their captions;
+// 'selCount' is the number of selected files and directories. 'path' is the
+// input target path and on output (at least 2 * MAX_PATH characters) it holds
+// the existing target path (always ending with a backslash). 'afterRoot' points
+// inside 'path' just after the root (after '\\' or at the end). 'secondPart'
+// points inside 'path' just after the existing portion (after '\\' or at the
+// end; if a file is present it points after that file). 'pathIsDir' is TRUE or
+// FALSE depending on whether the existing part is a directory or a file.
+// 'backslashAtEnd' is TRUE if there was a backslash at the end of 'path' before
+// parsing (SalParsePath removes such a backslash). 'dirName' and 'curPath' are
+// non-NULL when at most one file/directory is selected-its name without the path
+// is stored in 'dirName' and its path in 'curPath'; if nothing is selected the
+// focused item is used. 'mask' receives the operation mask pointer inside
+// 'path'. When 'newDirs' is not NULL it is a buffer (at least MAX_PATH) for the
+// relative path (with respect to the existing path in 'path') that must be
+// created (the user agreed to create it using the same prompt as for disk to
+// disk copy; empty string means create nothing). If 'newDirs' is NULL and a
+// relative path needs to be created but cannot be, only an error is shown.
+// 'isTheSamePathF' is a comparison function for two paths (used only when
+// 'curPath' is not NULL; otherwise IsTheSamePath is used). The method returns
+// FALSE on error and the user has already been notified
 BOOL SalSplitGeneralPath(HWND parent, const char* title, const char* errorTitle, int selCount,
                          char* path, char* afterRoot, char* secondPart, BOOL pathIsDir, BOOL backslashAtEnd,
                          const char* dirName, const char* curPath, char*& mask, char* newDirs,
                          SGP_IsTheSamePathF isTheSamePathF);
 
-// zjisti jestli je mozne retezec 'fileNameComponent' pouzit jako komponentu
-// jmena na Windows filesystemu (resi retezce delsi nez MAX_PATH-4 (4 = "C:\"
-// + null-terminator), prazdny retezec, retezce znaku '.', retezce white-spaces,
-// znaky "*?\\/<>|\":" a jednoducha jmena typu "prn" a "prn  .txt")
+// tests whether the string 'fileNameComponent' can be used as a name component
+// on a Windows filesystem (handles strings longer than MAX_PATH-4 (4 = "C:\\"
+// + null terminator), an empty string, strings of '.' characters, strings of white-space,
+// the characters "*?\\/<>|\":" and simple names such as "prn" and "prn  .txt")
 BOOL SalIsValidFileNameComponent(const char* fileNameComponent);
 
-// pretvori retezec 'fileNameComponent' tak, aby mohl byt pouzity jako komponenta
-// jmena na Windows filesystemu (resi retezce delsi nez MAX_PATH-4 (4 = "C:\"
-// + null-terminator), resi prazdny retezec, retezce znaku '.', retezce
-// white-spaces, znaky "*?\\/<>|\":" nahradi '_' + jednoducha jmena typu "prn"
-// a "prn  .txt" doplni o '_' na konci nazvu); 'fileNameComponent' musi jit
-// rozsirit alespon o jeden znak (maximalne se vsak z 'fileNameComponent'
-// pouzije MAX_PATH bytu)
+// transforms 'fileNameComponent' so it can be used as a Windows file name
+// component (handles strings longer than MAX_PATH-4 (4 = "C:\" + null terminator),
+// empty strings, strings of '.', whitespace-only strings; characters "*?\\/<>|:"
+// are replaced with '_'; simple names like "prn" and "prn  .txt" get an '_'
+// appended at the end of the name); 'fileNameComponent' must be extendable by at
+// least one character (but at most MAX_PATH bytes of 'fileNameComponent' are used)
 void SalMakeValidFileNameComponent(char* fileNameComponent);
 
-// tisk velikosti mista na disku, mode==0 "1.23 MB", mode==1 "1 230 000 bytes, 1.23 MB",
-// mode==2 "1 230 000 bytes", mode==3 (vzdy v celych KB), mode==4 (jako mode==0, ale vzdy
-// aspon 3 platne cislice, napr. "2.00 MB")
+// prints disk space size; mode==0 "1.23 MB", mode==1 "1 230 000 bytes, 1.23 MB",
+// mode==2 "1 230 000 bytes", mode==3 (always whole KBs), mode==4 (like mode==0 but
+// always at least 3 significant digits, e.g. "2.00 MB")
 char* PrintDiskSize(char* buf, const CQuadWord& size, int mode);
 
-// prevadi pocet sekund na retezec ("5 sec", "1 hr 34 min", atp.); 'buf' je
-// buffer pro vysledny text, musi byt velky aspon 100 znaku; 'secs' je pocet sekund;
-// vraci 'buf'
+// converts the number of seconds to a string ("5 sec", "1 hr 34 min", etc.);
+// 'buf' is the output buffer (at least 100 chars); 'secs' is the number of seconds.
+// returns 'buf'
 char* PrintTimeLeft(char* buf, CQuadWord const& secs);
 
-// zdvojuje '&' - hodi se pro cesty zobrazovane v menu ('&&' se zobrazi jako '&');
-// 'buffer' je vstupne/vystupni retezec, 'bufferSize' je velikost 'buffer' v bytech;
-// vraci TRUE pokud zdvojenim nedoslo ke ztrate znaku z konce retezce (buffer byl dost
-// veliky)
+// duplicates '&' - useful for paths shown in menus ('&&' displays as '&');
+// 'buffer' is an in/out string, 'bufferSize' its size in bytes.
+// returns TRUE if doubling did not truncate the string (buffer was large enough)
 BOOL DuplicateAmpersands(char* buffer, int bufferSize, BOOL skipFirstAmpersand = FALSE);
 
-// likviduje '&' - hodi se pro prikazy z menu, ktere potrebujeme zobrazit ocistene
-// od horkych klaves; najde-li dvojici "&&", nahradi ji jednim znakem '&'
-// 'text' je vstupne/vystupni retezec
+// Removes '&' characters. Useful for menu commands that should be displayed
+// without hot-key markers; if a double "&&" is found it is replaced with a
+// single '&'. 'text' is an input/output string.
 void RemoveAmpersands(char* text);
 
-// zdvojuje '\\' - hodi se pro texty, ktere posilame do LookForSubTexts, ktera '\\\\'
-// zase zredukuje na '\\'; 'buffer' je vstupne/vystupni retezec, 'bufferSize' je velikost
-// 'buffer' v bytech; vraci TRUE pokud zdvojenim nedoslo ke ztrate znaku z konce retezce
-// (buffer byl dost veliky)
+// Duplicates '\\'. Useful for strings passed to LookForSubTexts, which reduces
+// "\\\\" back to "\\". 'buffer' is both input and output; 'bufferSize' is its
+// size in bytes. Returns TRUE if doubling did not truncate the string (buffer
+// was large enough).
 BOOL DuplicateBackslashes(char* buffer, int bufferSize);
 
-// zdvojuje '$' - slouzi pro import starych cest (hotpaths), ktere mohou obsahovat $(SalDir)
-// a nove na nich podporuje Sal/Env promenne jako napriklad $(SalDir) nebo $(WinDir)
-// behem zavadeni jsem narazil na to, ze 2.5RC1, kde jsme podporili tyto promenne pro editory,
-// viewery, archivery se tato expanze nedelala; dodatecne to neresim, zavedu konverzi pouze
-// pro HotPaths
-// 'buffer' je vstupne/vystupni retezec, 'bufferSize' je velikost 'buffer' v bytech;
-// vraci TRUE pokud zdvojenim nedoslo ke ztrate znaku z konce retezce (buffer byl dost
-// veliky)
+// Duplicates '$'. Used when importing old paths (HotPaths), which may
+// contain $(SalDir) and now support Sal/Env variables such as $(SalDir) or
+// $(WinDir). In 2.5RC1 this expansion was not done for editors, viewers, or
+// archivers; this conversion is added only for HotPaths.
+// 'buffer' is the input/output string, 'bufferSize' is the size of 'buffer' in
+// bytes. Returns TRUE if doubling did not truncate the string (the buffer was
+// large enough).
 BOOL DuplicateDollars(char* buffer, int bufferSize);
 
-// najde si v 'buf' jmeno (preskoci mezery na zacatku i konci) a pokud existuje ('buf'
-// neobsahuje jen mezery), neni v uvozovkach a obsahuje aspon jednu mezeru, da ho do
-// uvozovek; vraci FALSE pokud neni dost mista na pridani uvozovek ('bufSize' je
-// velikost 'buf')
+// Searches 'buf' for a name (trimming spaces at both ends). If the name exists,
+// is not quoted and contains at least one space, it is wrapped in quotes. The
+// function returns FALSE when there is not enough room to add the quotes
+// ('bufSize' specifies the buffer size).
 BOOL AddDoubleQuotesIfNeeded(char* buf, int bufSize);
 
-// oriznuti '"' na zacatku a na konci 'path' (CutDoubleQuotes nebo StripDoubleQuotes nebo CutQuotes nebo StripQuotes)
-// vraci TRUE pokud doslo k orezu
+// trims '"' at the beginning and end of 'path' (CutDoubleQuotes or StripDoubleQuotes or
+// CutQuotes or StripQuotes). Returns TRUE if trimming occurred
 BOOL CutDoubleQuotesFromBothSides(char* path);
 
-// do 1/5 sekundy pockame na pusteni ESC (aby se po ESC v dialogu hned neprerusilo
-// napr. cteni listingu v panelu)
+// wait up to 1/5 second for ESC to be released so that the dialog does not
+// immediately abort operations such as reading a panel listing
 void WaitForESCRelease();
 
-// zkontroluje jestli je root-parent okna 'parent' foreground window, pokud ne,
-// udela se FlashWindow(root-parent, TRUE) a vrati se root-parent, jinak se vraci NULL
+// checks whether the root parent of 'parent' is the foreground window; if not
+// FlashWindow(root-parent, TRUE) is called and root-parent is returned,
+// otherwise NULL is returned
 HWND GetWndToFlash(HWND parent);
 
-// projde v threadu 'tid' (0=aktualni) vsechna okna (EnumThreadWindows) a vsem enablovanym a
-// viditelnym dialogum (class name "#32770") vlastnenym oknem 'parent' postne WM_CLOSE;
-// pouziva se pri critical shutdown k odblokovani okna/dialogu, nad kterym jsou otevrene
-// modalni dialogy, hrozi-li vice vrstev, je nutne volat opakovane
+// walks through all windows of thread 'tid' (0 means current) with
+// EnumThreadWindows and posts WM_CLOSE to every enabled visible dialog
+// (class name "#32770") owned by 'parent'. Used during critical shutdown to
+// unblock windows when multiple layers of modal dialogs are open; call
+// repeatedly if more layers appear
 void CloseAllOwnedEnabledDialogs(HWND parent, DWORD tid = 0);
 
-// vraci zobrazitelnou podobu atributu souboru/adresare; 'text' je buffer aspon 10 znaku;
-// 'attrs' jsou atributy souboru/adresare
+// returns a displayable form of file or directory attributes; 'text' must be a
+// buffer of at least 10 characters; 'attrs' are the attributes to format
 void GetAttrsString(char* text, DWORD attrs);
 
-// nakopiruje retezec 'srcStr' za retezec 'dstStr' (za jeho koncovou nulu);
-// 'dstStr' je buffer o velikosti 'dstBufSize' (musi byt nejmene rovno 2);
-// pokud se do bufferu oba retezce nevejdou, jsou zkraceny (vzdy tak, aby se
-// veslo co nejvice znaku z obou retezu)
+// Copies 'srcStr' after the terminating zero of 'dstStr'.
+// 'dstStr' is a buffer of size 'dstBufSize' (must be at least 2).
+// If both strings do not fit, they are truncated so that as many characters as
+// possible from both strings are kept.
 void AddStrToStr(char* dstStr, int dstBufSize, const char* srcStr);
 
-// vytvori plne jmeno souboru (alokovane); pokud neni 'dosName' NULL a 'path'+'name' je prilis
-// dlouhe jmeno, zkusi se spojit 'path'+'dosName'; pokud 'skip', 'skipAll' a 'sourcePath' nejsou
-// NULL a dojde k chybe "prilis dlouhe jmeno", umozni uzivateli toto jmeno preskocit (v tomto pripade
-// vraci NULL a ve 'skip' TRUE), pokud user da "Skip All", nastavi 'skipAll' na TRUE
-// 'sourcePath' je pouzita pro Focus tlacitko (v panelu zobrazime prilis dlouhou komponentu ve zdrojove
-// ceste, ktera by v cilove ceste zpusobila problem).
+// Creates an allocated full file name. If 'dosName' is not NULL and
+// 'path'+'name' is too long, it tries 'path'+'dosName'. If 'skip', 'skipAll',
+// and 'sourcePath' are not NULL and a "name too long" error occurs, the user
+// can skip this name (the function then returns NULL and sets 'skip' to TRUE).
+// If the user selects "Skip All", 'skipAll' is set to TRUE. 'sourcePath' is
+// used for the Focus button (the panel shows the too-long component in the
+// source path that would cause the problem in the target path).
 char* BuildName(char* path, char* name, char* dosName = NULL, BOOL* skip = NULL, BOOL* skipAll = NULL,
                 const char* sourcePath = NULL);
 
-// vraci z panelu datum+cas pro soubor/adresar 'f' (resi i datumy+casy dodavane pluginy - nemusi
-// byt platne)
+// retrieves the date and time for file/directory 'f' from the panel (also handles
+// values supplied by plugins-they may be invalid)
 void GetFileDateAndTimeFromPanel(DWORD validFileData, CPluginDataInterfaceEncapsulation* pluginData,
                                  const CFileData* f, BOOL isDir, SYSTEMTIME* st, BOOL* validDate,
                                  BOOL* validTime);
 
-// vraci z panelu velikost pro soubor/adresar 'f' (resi i velikosti dodavane pluginy - nemusi
-// byt platne)
+// retrieves the size for file/directory 'f' from the panel (also handles sizes
+// supplied by plugins-they may be invalid)
 void GetFileSizeFromPanel(DWORD validFileData, CPluginDataInterfaceEncapsulation* pluginData,
                           const CFileData* f, BOOL isDir, CQuadWord* size, BOOL* validSize);
 
 void DrawSplitLine(HWND HWindow, int newDragSplitX, int oldDragSplitX, RECT client);
-BOOL InitializeCheckThread(); // inicializace threadu pro CFilesWindow::CheckPath()
-void ReleaseCheckThreads();   // uvolneni threadu pro CFilesWindow::CheckPath()
-void InitDefaultDir();        // inicializace pole DefaultDir (posledni navstivene cesty na vsech drivech)
+BOOL InitializeCheckThread(); // initializes the thread used by CFilesWindow::CheckPath()
+void ReleaseCheckThreads();   // releases the thread used by CFilesWindow::CheckPath()
+void InitDefaultDir();        // initializes the DefaultDir array (last visited paths for all drives)
 
-// zobrazi/schova zpravu ve vlastnim threadu (neodcerpa message-queue), zobrazi najednou jen
-// jednu zpravu, opakovane volani ohlasi chybu do TRACE (neni fatalni), 'delay' je zpozdeni
-// pred otevrenim okenka (od okamziku volani CreateSafeWaitWindow)
-// 'message' muze byt vicerakova; jednotlive radky se oddeluji znakem '\n'
-// 'caption' muze byt NULL: pouzije se pak "Open Salamander"
-// 'showCloseButton' udava, zda bude okenko obsahovat tlacitko Close
-// 'hForegroundWnd' urcuje okno, ktere musi byt aktivni, aby bylo okenko zobrazeno
-// a zaroven urcuje okno, ktere bude aktivovana pri kliknuti do wait okenka
+// shows or hides a message window in its own thread without draining the
+// message queue; only one message can be displayed at a time. Repeated calls
+// report an error in TRACE (non-fatal). 'delay' is the wait time before the
+// window is opened (counted from the call to CreateSafeWaitWindow).
+// 'message' may span multiple lines separated by '\n'. If 'caption' is NULL the
+// default caption "Open Salamander" is used.
+// 'showCloseButton' determines whether the window has a Close button.
+// 'hForegroundWnd' designates the window that must stay active for the wait window
+// to be shown and which is activated when clicking the wait window
 void CreateSafeWaitWindow(const char* message, const char* caption, int delay,
                           BOOL showCloseButton, HWND hForegroundWnd);
 void DestroySafeWaitWindow(BOOL killThread = FALSE);
-// zhasne 'show'==FALSE a pak zobrazi 'show'==TRUE vytvorene okenko
-// volat jako reakci na WM_ACTIVATE z okna hForegroundWnd:
+// hides the created window when 'show'==FALSE and shows it when 'show'==TRUE.
+// Call in response to WM_ACTIVATE from the hForegroundWnd window:
 //    case WM_ACTIVATE:
 //    {
 //      ShowSafeWaitWindow(LOWORD(wParam) != WA_INACTIVE);
 //      break;
 //    }
-// Pokud je thread (ze ktereho bylo okenko vytvoreno) zamestnan, nedochazi
-// k distribuci zprav, takze nedojde ani k doruceni WM_ACTIVATE pri kliknuti
-// na jinou aplikaci. Zpravy se doruci az ve chvili zobrazeni messageboxu,
-// coz presne potrebujeme: docasne se nechame schovat a pozdeji (po zavreni
-// messageboxu a aktivaci okna hForegroundWnd) zase zobrazit.
+// If the thread that created the window is busy, messages are not dispatched,
+// so WM_ACTIVATE is not delivered when the user clicks another application. The
+// messages are delivered only when the message box is shown, which is what we
+// need: hide temporarily and show again later (after the message box is closed
+// and the hForegroundWnd window is activated).
 void ShowSafeWaitWindow(BOOL show);
-// po zavolani CreateSafeWaitWindow nebo ShowSafeWaitWindow vraci funkce FALSE az do doby,
-// kdy user kliknul mysi na Close tlacitko (pokud je zobrazeno); pak vraci TRUE
+// after calling CreateSafeWaitWindow or ShowSafeWaitWindow the function returns
+// FALSE until the user clicks the Close button (if shown); then it returns TRUE
 BOOL GetSafeWaitWindowClosePressed();
-// vraci TRUE pokud uzivatel macka ESC nebo kliknul mysi na Close tlacitko
+// returns TRUE if the user presses ESC or clicks the Close button
 BOOL UserWantsToCancelSafeWaitWindow();
-// slouzi pro dodatecnou zmenu textu v okenku
-// POZOR: nedochazi k novemu layoutovani okna a pokud dojde k vetsimu natazeni
-// textu, bude orezan; pouzivat napriklad pro countdown: 60s, 55s, 50s, ...
+// Used to change the message text later. NOTE: the window layout is not
+// recomputed; if the text grows it will be truncated. Useful for countdowns
+// like 60s, 55s, 50s, ...
 void SetSafeWaitWindowText(const char* message);
 
-// vraci TRUE pokud je Salamander aktivni (foreground window PID == current PID)
+// returns TRUE when Salamander is active (foreground window PID == current PID)
 BOOL SalamanderActive();
 
-// odstraneni adresare vcetne jeho obsahu (SHFileOperation je priserne pomaly)
+// removes a directory along with its contents (SHFileOperation is terribly slow)
 void RemoveTemporaryDir(const char* dir);
 
-// pomocna funkce pro pridani jmena do seznamu jmen (oddelenych mezerou), vraci uspech
+// helper for adding a name to a space-separated list; returns success
 BOOL AddToListOfNames(char** list, char* listEnd, const char* name, int nameLen);
 
-// pokud adresar neexistuje, umozni jej vytvorit,
-// pokud adresar existuje nebo je uspesne vytvoren vraci TRUE
-// parent je parent messageboxu s chybami, NULL = hlavni okno Salamandera
-// quiet = TRUE  - neptat se jestli chce vytvaret, ale pozor, chyby ukazuje pokud errBuf == NULL
-// pokud errBuf != NULL, je errBufSize velikost bufferu pro popis chyby,
-// pokud newDir != NULL, je v newDir vracen prvni vytvoreny podadresar (plnou cestou),
-// pokud cesta komplet existuje, je newDir=="", newDir ukazuje na buffer o velikosti MAX_PATH
-// noRetryButton = TRUE - chybove dialogy nemaji obsahovat Retry/Cancel buttony, ale jen OK button
-// manualCrDir = TRUE - nedovolime vytvorit adresar s mezerou na zacatku (pri rucnim vytvareni
-// adresare, jinak Windowsum mezery na zacatku nevadi)
+// if the directory does not exist, the user can create it;
+// returns TRUE if the directory exists or is created successfully
+// 'parent' is the parent window for error message boxes; NULL = Salamander's main window
+// quiet = TRUE - do not ask whether to create it, but note that errors are shown if errBuf == NULL
+// if errBuf != NULL, errBufSize is the size of the error-description buffer
+// if newDir != NULL, the first created subdirectory (full path) is returned in 'newDir'
+// if the full path already exists, newDir==""; newDir points to a buffer of size MAX_PATH
+// noRetryButton = TRUE - error dialogs contain only an OK button, not Retry/Cancel
+// manualCrDir = TRUE - do not allow creating a directory with a leading space (during manual
+// directory creation; otherwise Windows allows leading spaces)
 BOOL CheckAndCreateDirectory(const char* dir, HWND parent = NULL, BOOL quiet = FALSE, char* errBuf = NULL,
                              int errBufSize = 0, char* newDir = NULL, BOOL noRetryButton = FALSE,
                              BOOL manualCrDir = FALSE);
 
-// smaze z disku prazdne podadresare v 'dir' a je-li 'dir' po vymazu podadresaru prazdny,
-// je smazan take
+// removes empty subdirectories under 'dir' and deletes 'dir' itself when it becomes empty
 void RemoveEmptyDirs(const char* dir);
 
-// vykona rutina pro otevirani vieweru - pouziva se v CFilesWindow::ViewFile a
-// CSalamanderForViewFileOnFS::OpenViewer; dalsi vyuziti se neocekava, proto nejsou
-// popsany parametry a navratove hodnoty
+// routine used to open the viewer-used in CFilesWindow::ViewFile and
+// CSalamanderForViewFileOnFS::OpenViewer; no other use is expected, therefore
+// parameters and return values are not documented
 BOOL ViewFileInt(HWND parent, const char* name, BOOL altView, DWORD handlerID, BOOL returnLock,
                  HANDLE& lock, BOOL& lockOwner, BOOL addToHistory, int enumFileNamesSourceUID,
                  int enumFileNamesLastFileIndex);
 
-// prevede string ('str' o delce 'len') na unsigned __int64 (muze predchazet
-// znamenko '+'; ignoruje white-spaces na zacatku a konci retezce);
-// neni-li 'isNum' NULL, vraci se v nem TRUE, pokud cely retezec
-// 'str' reprezentuje cislo
+// converts the string ('str' of length 'len') to unsigned __int64 (a leading
+// '+' sign is allowed; leading and trailing white-space is ignored);
+// if 'isNum' is not NULL it receives TRUE when the entire string represents
+// a number
 unsigned __int64 StrToUInt64(const char* str, int len, BOOL* isNum = NULL);
 
-// spousti handler exceptiony "in-page-error" a "access violation - read/write on XXX" (testuje se
-// jestli se exceptiona vztahuje k souboru - 'fileMem' je pocatecni adresa, 'fileMemSize' je velikost
-// aktualniho view mapovaneho souboru), pouzito pri mapovani souboru do pameti (chyba
-// cteni/zapisu vyvola tuto exceptionu)
+// handles the "in-page-error" and "access violation - read/write on XXX" exceptions
+// (checks whether the exception is related to the file: 'fileMem' is the base address,
+// 'fileMemSize' is the size of the current mapped file view); used when mapping files
+// into memory (a read/write error raises one of these exceptions)
 int HandleFileException(EXCEPTION_POINTERS* e, char* fileMem, DWORD fileMemSize);
 
 struct CSalamanderVarStrEntry;
 
-// ValidateVarString a ExpandVarString:
-// metody pro overovani a expanzi retezcu s promennymi ve tvaru "$(var_name)", "$(var_name:num)"
-// (num je sirka promenne, jde o ciselnou hodnotu od 1 do 9999), "$(var_name:max)" ("max" je
-// symbol, ktery oznacuje, ze sirka promenne se ridi hodnotou v poli 'maxVarWidths', podrobnosti
-// u ExpandVarString) a "$[env_var]" (expanduje hodnotu promenne prostredi); pouziva se pokud si
-// uzivatel muze zadat format retezce (jako napr. v info-line) priklad retezce s promennymi:
-// "$(files) files and $(dirs) directories" - promenne 'files' a 'dirs'
+// ValidateVarString and ExpandVarString:
+// methods for validating and expanding strings with variables like "$(var_name)",
+// "$(var_name:num)" (num is the field width, numeric 1..9999), "$(var_name:max)"
+// ("max" means the width follows the value in 'maxVarWidths'; details with
+// ExpandVarString) and "$[env_var]" for environment variables.
+// Used where the user can define a format string (e.g. in the info line). Example
+// string with variables: "$(files) files and $(dirs) directories" where
+// the variables are 'files' and 'dirs'.
 
-// kontroluje syntaxi 'varText' (retezce s promennymi), vraci FALSE pokud najde chybu, jeji
-// pozici umisti do 'errorPos1' (offset zacatku chybne casti) a 'errorPos2' (offset konce chybne
-// casti); 'variables' je pole struktur CSalamanderVarStrEntry, ktere je ukonceno strukturou s
-// Name==NULL; 'msgParent' je parent message-boxu s chybami, je-li NULL, chyby se nevypisuji
+// checks the syntax of 'varText' (string with variables); returns FALSE on error and
+// provides the error position in 'errorPos1' (start offset) and 'errorPos2' (end offset).
+// 'variables' is an array of CSalamanderVarStrEntry terminated with Name==NULL.
+// 'msgParent' is the parent of error message boxes; if NULL, errors are not displayed
 BOOL ValidateVarString(HWND msgParent, const char* varText, int& errorPos1, int& errorPos2,
                        const CSalamanderVarStrEntry* variables);
 
-// naplni 'buffer' vysledkem expanze 'varText' (retezce s promennymi), vraci FALSE pokud je
-// 'buffer' maly (predpoklada overeni retezce s promennymi pres ValidateVarString, jinak
-// vraci FALSE i pri chybe syntaxe) nebo uzivatel kliknul na Cancel pri chybe environment-variable
-// (nenalezena nebo prilis velka); 'bufferLen' je velikost bufferu 'buffer';
-// 'variables' je pole struktur CSalamanderVarStrEntry, ktere je ukonceno strukturou
-// s Name==NULL; 'param' je ukazatel, ktery se predava do CSalamanderVarStrEntry::Execute
-// pri expanzi nalezene promenne; 'msgParent' je parent message-boxu s chybami, je-li NULL,
-// chyby se nevypisuji; je-li 'ignoreEnvVarNotFoundOrTooLong' TRUE, ignoruji se chyby
-// environment-variable (nenalezena nebo prilis velka), je-li FALSE, zobrazi se messagebox
-// s chybou; neni-li 'varPlacements' NULL, ukazuje na pole DWORDu o '*varPlacementsCount' polozkach,
-// ktere bude naplneno DWORDy slozenymi vzdy z pozice promenne ve vystupnim bufferu (spodni WORD)
-// a poctu znaku promenne (horni WORD); neni-li 'varPlacementsCount' NULL, vraci se v nem pocet
-// naplnenych polozek v poli 'varPlacements' (jde vlastne o pocet promennych ve vstupnim
-// retezci);
-// pokud se tato metoda pouziva jen k expanzi retezce pro jednu hodnotu 'param', meli by
-// byt nastaveny 'detectMaxVarWidths' na FALSE, 'maxVarWidths' na NULL a 'maxVarWidthsCount'
-// na 0; pokud se ovsem pouziva tato metoda pro expanzi retezce opakovane pro urcitou
-// mnozinu hodnot 'param' (napr. u Make File List je to expanze radky postupne pro vsechny
-// oznacene soubory a adresare), ma smysl pouzivat i promenne ve tvaru "$(varname:max)",
-// u techto promennych se sirka urci jako nejvetsi sirka expandovane promenne v ramci cele
-// mnoziny hodnot; omereni nejvetsi sirky expandovane promenne se provadi v prvnim cyklu
-// (pro vsechny hodnoty mnoziny) volani ExpandVarString, v prvnim cyklu ma parametr
-// 'detectMaxVarWidths' hodnotu TRUE a pole 'maxVarWidths' o 'maxVarWidthsCount' polozkach
-// je predem nulovane (slouzi pro ulozeni maxim mezi jednotlivymi volanimi ExpandVarString);
-// samotna expanze pak probiha v druhem cyklu (pro vsechny hodnoty mnoziny) volani
-// ExpandVarString, v druhem cyklu ma parametr 'detectMaxVarWidths' hodnotu FALSE a pole
-// 'maxVarWidths' o 'maxVarWidthsCount' polozkach obsahuje predpocitane nejvetsi sirky
-// (z prvniho cyklu)
+// fills 'buffer' with the result of expanding 'varText'; returns FALSE if the
+// buffer is too small (the variable string should be validated first via
+// ValidateVarString, otherwise FALSE is also returned for syntax errors) or when
+// the user clicked Cancel for an environment-variable error (not found or too
+// long). 'bufferLen' is the size of 'buffer'. 'variables' is an array of
+// CSalamanderVarStrEntry structures terminated by Name==NULL. 'param' is passed
+// to CSalamanderVarStrEntry::Execute when expanding a variable. 'msgParent' is
+// the parent for error message boxes; if NULL, errors are not shown. When
+// 'ignoreEnvVarNotFoundOrTooLong' is TRUE, environment-variable errors are
+// ignored; otherwise a message box is shown. If 'varPlacements' is not NULL it
+// points to an array of DWORDs of '*varPlacementsCount' items that receives the
+// variable positions in the output buffer (low WORD) and their lengths (high
+// WORD). If 'varPlacementsCount' is not NULL it receives the number of filled
+// entries.
+// When this method is used just once for a single 'param', set
+// 'detectMaxVarWidths' to FALSE, 'maxVarWidths' to NULL and 'maxVarWidthsCount'
+// to 0. When expanding repeatedly for a set of values (e.g. Make File List), it
+// makes sense to use variables like "$(varname:max)"; their width is measured as
+// the maximum width of the expanded variable across the whole set. Measuring is
+// done during the first cycle (for all values) with 'detectMaxVarWidths' TRUE
+// and 'maxVarWidths' zeroed. The actual expansion then happens in the second
+// cycle with 'detectMaxVarWidths' FALSE and 'maxVarWidths' containing the
+// precomputed widths from the first cycle.
 BOOL ExpandVarString(HWND msgParent, const char* varText, char* buffer, int bufferLen,
                      const CSalamanderVarStrEntry* variables, void* param,
                      BOOL ignoreEnvVarNotFoundOrTooLong = FALSE,
@@ -704,40 +706,40 @@ BOOL ExpandVarString(HWND msgParent, const char* varText, char* buffer, int buff
                      BOOL detectMaxVarWidths = FALSE, int* maxVarWidths = NULL,
                      int maxVarWidthsCount = 0);
 
-// ulozi na clipboard Unicode verzi textu str o delce len znaku
-// vraci ERROR_SUCCESS nebo GetLastError
+// stores the Unicode version of 'str' of length 'len' on the clipboard
+// returns ERROR_SUCCESS or GetLastError
 DWORD AddUnicodeToClipboard(const char* str, int len);
 
-// vrzne text na clipboard; pokud showEcho, zobrazi message box, ze jako OK
-// pokud je textLen==-1, napocita si delku sam
+// puts text on the clipboard; if showEcho is TRUE a message box confirming success is shown
+// when textLen==-1 the length is calculated automatically
 BOOL CopyTextToClipboard(const char* text, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
 BOOL CopyTextToClipboardW(const wchar_t* text, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
 BOOL CopyHTextToClipboard(HGLOBAL hGlobalText, int textLen = -1, BOOL showEcho = FALSE, HWND hEchoParent = NULL);
 
-// zjisti z bufferu 'pattern' o delce 'patternLen' jestli jde o text (existuje kodova stranka,
-// ve ktere obsahuje jen povolene znaky - zobrazitelne a ridici) a pokud jde o text, zjisti take
-// jeho kodovou stranku (nejpravdepodobnejsi); 'parent' je parent messageboxu; je-li 'forceText'
-// TRUE, neprovadi se kontrola na nepovolene znaky (pouziva se, pokud 'pattern' obsahuje text);
-// neni-li 'isText' NULL, vraci se v nem TRUE pokud jde o text; neni-li 'codePage' NULL, jde
-// o buffer (min. 101 znaku) pro jmeno kodove stranky (nejpravdepodobnejsi)
+// examines buffer 'pattern' of length 'patternLen' to determine whether it is text (that is,
+// whether there is a code page in which it contains only allowed characters - printable and control).
+// If it is text, it also determines its most probable code page. 'parent' is the parent of the
+// message box. When 'forceText' is TRUE, forbidden characters are not checked (used when 'pattern'
+// contains text). If 'isText' is not NULL it receives TRUE if the buffer is text. If 'codePage'
+// is not NULL, it is a buffer (at least 101 chars) for the code page name
 void RecognizeFileType(HWND parent, const char* pattern, int patternLen, BOOL forceText,
                        BOOL* isText, char* codePage);
 
-// nastavi jmeno volajicimu threadu ve VC debuggeru
+// sets the calling thread name in the VC debugger
 void SetThreadNameInVC(LPCSTR szThreadName);
 
-// nastavi jmeno volajicimu threadu ve VC debuggeru a Trace Serveru
+// sets the calling thread name in both the VC debugger and the Trace Server
 void SetThreadNameInVCAndTrace(const char* name);
 
-// nacitani konfigurace
+// configuration loading
 class CEditorMasks;
 class CViewerMasks;
 
-// funkce spojene s drag&dropem a dalsimi shellovymi vecmi
+// functions related to drag&drop and other shell tasks
 
 class CFilesWindow;
 
-// operace shellu
+// shell operations
 enum CShellAction
 {
     saLeftDragFiles,
@@ -746,7 +748,7 @@ enum CShellAction
     saCopyToClipboard,
     saCutToClipboard,
     saProperties,
-    saPermissions, // stejne jako saProperties, jen se pokusi vybrat "security tab"
+    saPermissions, // same as saProperties but tries to activate the "security" tab
 };
 
 class CCopyMoveData;
@@ -767,7 +769,7 @@ BOOL MouseConfirmDrop(DWORD& effect, DWORD& defEffect, DWORD& grfKeyState);
 void DropEnd(BOOL drop, BOOL shortcuts, void* param, BOOL ownRutine, BOOL isFakeDataObject, int tgtType);
 void EnterLeaveDrop(BOOL enter, void* param);
 
-// uklada na clipboard prefered drop effect a informaci o puvodu ze Salamandera
+// stores the preferred drop effect on the clipboard and marks that it originated from Salamander
 void SetClipCutCopyInfo(HWND hwnd, BOOL copy, BOOL salObject);
 
 void ShellAction(CFilesWindow* panel, CShellAction action, BOOL useSelection = TRUE,
@@ -776,194 +778,204 @@ void ExecuteAssociation(HWND hWindow, const char* path, const char* name);
 
 BOOL CanUseShellExecuteWndAsParent(const char* cmdName);
 
-// zjisti jestli je soubor placeholder (online soubor ve OneDrive slozce),
-// viz http://msdn.microsoft.com/en-us/library/windows/desktop/dn323738%28v=vs.85%29.aspx
+// checks whether the file is a placeholder (an online file in a OneDrive folder),
+// see http://msdn.microsoft.com/en-us/library/windows/desktop/dn323738%28v=vs.85%29.aspx
 BOOL IsFilePlaceholder(WIN32_FIND_DATA const* findData);
 
-// pred otevrenim editoru nebo vieweru se placeholder prevadi na offline file,
-// aby s nim umel viewer/editor pracovat
+// before opening an editor or viewer the placeholder is converted to an offline file
+// so that the viewer/editor can handle it
 //BOOL MakeFileAvailOfflineIfOneDriveOnWin81(HWND parent, const char *name);
 
-// nastavi prioritu threadu na normal a vyvola v try-except bloku menu->InvokeCommand()
-// pred ukoncenim zase nastavi prioritu threadu na puvodni hodnotu
+// sets the thread priority to normal and calls menu->InvokeCommand() in a try-except block;
+// before exiting it restores the thread priority to its original value
 BOOL SafeInvokeCommand(IContextMenu2* menu, CMINVOKECOMMANDINFO& ici);
 
-// pokud je 'hInstance' NULL, bude se cist z HLanguage; jinak z 'hInstance'
-char* LoadStr(int resID, HINSTANCE hInstance = NULL);   // taha string z resourcu
-WCHAR* LoadStrW(int resID, HINSTANCE hInstance = NULL); // taha wide-string z resourcu
+// if 'hInstance' is NULL strings are loaded from HLanguage; otherwise from 'hInstance'
+char* LoadStr(int resID, HINSTANCE hInstance = NULL);   // loads string from resources
+WCHAR* LoadStrW(int resID, HINSTANCE hInstance = NULL); // loads wide-string from resources
 
-// podpora pro tvorbu parametrizovanych textu (reseni jednotnych a mnoznych cisel
-// v textech); 'lpFmt' je formatovaci retezec pro vysledny text - popis jeho formatu
-// nasleduje; vysledny text se vraci v bufferu 'lpOut' o velikosti 'nOutMax' bytu;
-// 'lpParArray' je pole parametru textu, 'nParCount' je pocet techto parametru;
-// vraci delku vysledneho textu
+// support for creating parameterized texts (handling singular and plural forms
+// in text); 'lpFmt' is the format string for the resulting text - its format
+// is described below; the resulting text is returned in the 'lpOut' buffer of
+// size 'nOutMax' bytes; 'lpParArray' is the array of text parameters and
+// 'nParCount' is the number of these parameters; returns the length of the
+// resulting text
 //
-// popis formatovaciho retezce:
-//   - na zacatku kazdeho formatovaciho retezce je signatura "{!}"
-//   - uznavaji se nasledujici escape sekvence pro potlaceni vyznamu specialnich
-//     znaku ve formatovacim retezci (znak backslashe v tomto popisu
-//     neni zdvojen): "\\" = "\", "\{" = "{", "\}" = "}", "\:" = ":" a "\|" = "|"
-//   - text, ktery neni ve slozenych zavorkach se do vysledneho retezce
-//     prenasi beze zmen (az na escape sekvence)
-//   - parametrizovany text je ve slozenych zavorkach
-//   - kazdy parametrizovany text pouziva jeden parametr z 'lpParArray' - jde
-//     o 64-bitovy unsigned int
-//   - parametrizovany text obsahuje ruzne vysledne texty pro ruzne intervaly
-//     hodnot parametru
-//   - jednotlive vysledne texty a meze intervalu se oddeluji znakem "|"
-//   - parametrizovany text "{}" se pouziva pro preskoceni jednoho parametru
-//     z pole 'lpParArray' (nevytvari zadny vystupni text)
-//   - pokud je na zacatku parametrizovaneho textu cislo nasledovane dvojteckou,
-//     jde o index parametru (od jedne az do poctu parametru), ktery se ma pouzit,
-//     pokud neni index uveden, prideli se automaticky (postupne od jedne az do
-//     poctu parametru)
-//   - pri zadani indexu parametru nedochazi ke zmene postupne prirazovaneho
-//     indexu, napr. v "{!}%d file{2:s|0||1|s} and %d director{y|1|ies}" se pro
-//     prvni parametrizovany text pouzije parametr s indexem 2 a pro druhy
-//     s indexem 1
-//   - parametrizovanych textu se zadanym indexem je mozne pouzit libovolny pocet
+// description of the format string:
+//   - every format string starts with the signature "{!}"
+//   - the following escape sequences are recognized to suppress the special
+//     meaning of characters in the format string (the backslash character in
+//     this description is not doubled): "\\" = "\", "\{" = "{", "\}" = "}", "\:" = ":" and "\|" = "|"
+//   - text outside curly braces is copied to the resulting string unchanged
+//     (except for escape sequences)
+//   - parameterized text is enclosed in curly braces
+//   - each parameterized text uses one parameter from 'lpParArray' - it is a
+//     64-bit unsigned int
+//   - parameterized text contains different resulting texts for different
+//     parameter value ranges
+//   - individual resulting texts and range boundaries are separated by "|"
+//   - parameterized text "{}" is used to skip one parameter from 'lpParArray'
+//     (it produces no output text)
+//   - if a parameterized text starts with a number followed by a colon, it is
+//     the index of the parameter to use (from one up to the number of
+//     parameters); if no index is specified, it is assigned automatically
+//     (sequentially from one up to the number of parameters)
+//   - specifying a parameter index does not change the sequentially assigned
+//     index; for example, in "{!}%d file{2:s|0||1|s} and %d director{y|1|ies}"
+//     the first parameterized text uses parameter 2 and the second uses
+//     parameter 1
+//   - any number of parameterized texts with an explicitly specified index may
+//     be used
 //
-// priklady formatovacich retezcu:
-//   - "{!}director{y|1|ies}" pro hodnotu parametru od 0 do 1 (vcetne) bude
-//     "directory" a pro hodnotu od 2 do "nekonecna" (2^64-1) bude "directories"
-//   - "{!}soubo{rů|0|r|1|ry|4|rů}" pro hodnotu parametru 0 bude "souborů",
-//     pro 1 bude "soubor", pro 2 az 4 (vcetne) bude "soubory" a od 5
-//     do "nekonecna" bude "souborů"
+// examples of format strings:
+//   - "{!}director{y|1|ies}" for parameter values from 0 to 1 (inclusive) will
+//     be "directory", and for values from 2 to "infinity" (2^64-1) will be
+//     "directories"
+//   - "{!}soubo{rů|0|r|1|ry|4|rů}" for parameter value 0 will be "souborů", for
+//     1 will be "soubor", for 2 to 4 (inclusive) will be "soubory", and from 5
+//     to "infinity" will be "souborů"
 int ExpandPluralString(char* lpOut, int nOutMax, const char* lpFmt, int nParCount,
                        const CQuadWord* lpParArray);
 
 //
-// Do lpOut zapise retezec v zavislosti na promennych files a dirs:
+// Writes the text to 'lpOut' depending on the 'files' and 'dirs' variables:
 // files > 0 && dirs == 0  ->  XXX (selected/hidden) files
 // files == 0 && dirs > 0  ->  YYY (selected/hidden) directories
 // files > 0 && dirs > 0   ->  XXX (selected/hidden) files and YYY directories
 //
-// kde XXX a YYY odpovidaji hodnotam promennych files a dirs.
-// Promenna selectedForm ridi vlozeni slova selected
+// where XXX and YYY correspond to the values of 'files' and 'dirs'.
+// The variable 'selectedForm' controls insertion of the word "selected".
 //
-// V forDlgCaption je TRUE/FALSE pokud text je/neni urceny pro titulek dialogu
-// (v anglictine jsou nutna velka pocatecni pismena).
+// 'forDlgCaption' is TRUE/FALSE if the text is meant for a dialog caption
+// (capitalization is required in English).
 //
-// Vrati pocet nakopirovanych znaku bez terminatoru.
+// Returns the number of copied characters excluding the terminator.
 //
-// popis konstant epfdmXXX viz spl_gen.h
+// description of epfdmXXX constants is in spl_gen.h
 int ExpandPluralFilesDirs(char* lpOut, int nOutMax, int files, int dirs,
                           int mode, BOOL forDlgCaption);
 int ExpandPluralBytesFilesDirs(char* lpOut, int nOutMax, const CQuadWord& selectedBytes,
                                int files, int dirs, BOOL useSubTexts);
 
-// V textu nalezne pary '<' '>', vyradi je z bufferu a prida odkazy na
-// jejich obsah do 'varPlacements'. 'varPlacements' je pole DWORDu o '*varPlacementsCount'
-// polozkach, DWORDy jsou slozene vzdy z pozice odkazu ve vystupnim bufferu (spodni WORD)
-// a poctu znaku odkazu (horni WORD). Retezce "\<", "\>", "\\" jsou chapany
-// jako escape sekvence a budou nahrazeny znaky '<', '>' a '\\'.
-// Vraci TRUE v pripade uspechu, jinak FALSE; vzdy nastavi 'varPlacementsCount' na
-// pocet zpracovanych promennych.
+// Searches the text for '<' '>' pairs, removes them from the buffer, and stores
+// references to their contents in 'varPlacements'. 'varPlacements' is an array of
+// DWORDs with '*varPlacementsCount' items; each DWORD is composed of the position
+// of the reference in the output buffer (low WORD) and the number of characters
+// in the reference (high WORD). The strings "\<", "\>", "\\" are treated as
+// escape sequences and are replaced with '<', '>' and '\\'.
+// Returns TRUE on success, otherwise FALSE; always sets 'varPlacementsCount' to
+// the number of processed variables.
 BOOL LookForSubTexts(char* text, DWORD* varPlacements, int* varPlacementsCount);
 
-void MinimizeApp(HWND mainWnd);             // minimalizace app.
-void RestoreApp(HWND mainWnd, HWND dlgWnd); // obnova z minimized stavu app.
-                                            // meni format jmena (velikost pismen), filename musi byt vzdy terminovan znakem nula5
+void MinimizeApp(HWND mainWnd);             // minimize the application
+void RestoreApp(HWND mainWnd, HWND dlgWnd); // restore from minimized state
+                                            // adjusts the name format (letter case), filename must be null-terminated
 void AlterFileName(char* tgtName, char* filename, int filenameLen, int format, int change, BOOL dir);
 
-// vraci string s velikosti a casy souboru; Ve 'fileTime' vraci cas, promenna muze byt NULL;
-// neni-li 'getTimeFailed' NULL, zapise se do nej TRUE pri chybe ziskavani casu souboru
+// returns a string with size and times of the file; 'fileTime' receives the time (may be NULL);
+// if 'getTimeFailed' is not NULL it is set to TRUE on failure to obtain the file time
 void GetFileOverwriteInfo(char* buff, int buffLen, HANDLE file, const char* fileName, FILETIME* fileTime = NULL, BOOL* getTimeFailed = NULL);
 
-void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons);                // volat po zmene barev
-HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large = FALSE); // ikona drivu
+void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons);                // call after color change
+HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large = FALSE); // drive icon
 HICON SalLoadIcon(HINSTANCE hDLL, int id, int iconSize);
 
-// SetCurrentDirectory(systemovy adresar) - odpojeni od adresare v panelu
+// SetCurrentDirectory(system directory) - detach from panel directory
 void SetCurrentDirectoryToSystem();
 
-// nahradi substy v ceste 'resPath' jejich cilovymi cestami (prevod na cestu bez SUBST drive-letters);
-// vraci FALSE pri chybe
+// replaces SUBST drives in 'resPath' with their targets (converts to a path without SUBST drive letters);
+// returns FALSE on error
 BOOL ResolveSubsts(char* resPath);
 
-// Provede resolve substu a reparse pointu pro cestu 'path', nasledne se pro mount-point cesty
-// (pokud chybi tak pro root cesty) pokusi ziskat GUID path. Pri neuspechu vrati FALSE. Pri
-// uspechu, vrati TRUE a nastavi 'mountPoint' a 'guidPath' (pokud jsou ruzne od NULL, musi
-// odkazovat na buffery o velikosti minimalne MAX_PATH; retezce budou zakonceny zpetnym lomitkem).
+// Resolves SUBSTs and reparse points for 'path' and then tries to obtain the GUID path for
+// the mount point (or for the root if missing). On failure returns FALSE. On success returns
+// TRUE and sets 'mountPoint' and 'guidPath' (if not NULL, they must be buffers at least
+// MAX_PATH in size; strings will end with a backslash).
 BOOL GetResolvedPathMountPointAndGUID(const char* path, char* mountPoint, char* guidPath);
 
-// pokus o vraceni korektnich hodnot (umi i reparse pointy - zadava se komplet cesta misto rootu)
+// attempts to return correct values (handles reparse points - specify the full path instead of the root)
 CQuadWord MyGetDiskFreeSpace(const char* path, CQuadWord* total = NULL);
-// POZOR: nepouzivat navratovky 'lpNumberOfFreeClusters' a 'lpTotalNumberOfClusters', protoze u vetsich
-//        disku jsou v nich nesmysly (DWORD nemusi stacit pro celkovy pocet clusteru), resit pres
-//        MyGetDiskFreeSpace(path, total), ktera vraci 64-bitova cisla
+// NOTE: do not use the return values 'lpNumberOfFreeClusters' and 'lpTotalNumberOfClusters'
+// for large disks they may overflow. Use MyGetDiskFreeSpace(path, total) which returns 64-bit numbers.
 BOOL MyGetDiskFreeSpace(const char* path, LPDWORD lpSectorsPerCluster,
                         LPDWORD lpBytesPerSector, LPDWORD lpNumberOfFreeClusters,
                         LPDWORD lpTotalNumberOfClusters);
 
-// vylepsena GetVolumeInformation: pracuje s cestou (prochazi reparse pointy a substy);
-// v 'rootOrCurReparsePoint' (neni-li NULL, musi byt aspon MAX_PATH znaku) vraci bud
-// root nebo cestu k aktualnimu (poslednimu) lokalnimu reparse pointu na ceste 'path'
-// (POZOR: nefunguje pokud neni medium v drivu, GetCurrentLocalReparsePoint() timto netrpi);
-// v 'junctionOrSymlinkTgt' (neni-li NULL, musi byt aspon MAX_PATH znaku) vraci
-// cil aktualniho reparse pointu nebo prazdny retezec (pokud zadny reparse point neexistuje nebo
-// je neznameho typu nebo jde o volume mount point); v 'linkType' (neni-li NULL) vraci typ aktualniho
-// reparse pointu: 0 (neznamy nebo neexistuje), 1 (MOUNT POINT), 2 (JUNCTION POINT), 3 (SYMBOLIC LINK)
+// enhanced GetVolumeInformation: works with the path (walks reparse points and SUBST drives)
+// 'rootOrCurReparsePoint' (if not NULL and at least MAX_PATH chars) receives the
+// root or the path to the current (last) local reparse point on 'path'
+// (WARNING: this does not work if no medium is present in the drive; GetCurrentLocalReparsePoint() is not affected by this)
+// 'junctionOrSymlinkTgt' (if not NULL and at least MAX_PATH chars) receives the
+// target of the current reparse point or an empty string when none exists or it
+// is of unknown type or a volume mount point. 'linkType' (if not NULL) receives
+// the type of the current reparse point: 0 (unknown or none), 1 (MOUNT POINT),
+// 2 (JUNCTION POINT), 3 (SYMBOLIC LINK)
 BOOL MyGetVolumeInformation(const char* path, char* rootOrCurReparsePoint, char* junctionOrSymlinkTgt, int* linkType,
                             LPTSTR lpVolumeNameBuffer, DWORD nVolumeNameSize, LPDWORD lpVolumeSerialNumber,
                             LPDWORD lpMaximumComponentLength, LPDWORD lpFileSystemFlags,
                             LPTSTR lpFileSystemNameBuffer, DWORD nFileSystemNameSize);
 
-// vraci cilovou cestu reparse pointu 'repPointDir' v bufferu 'repPointDstBuf' (neni-li NULL)
-// o velikosti 'repPointDstBufSize'; 'repPointDir' a 'repPointDstBuf' muzou ukazovat
-// do jednoho bufferu (IN/OUT buffer); je-li 'makeRelPathAbs' TRUE a jde o relativni
-// symbolicky link, prevede cilovou cestu linku na absolutni;
-// vraci TRUE pri uspechu + v 'repPointType' (neni-li NULL) vraci typ reparse pointu:
-// 1 (MOUNT POINT), 2 (JUNCTION POINT), 3 (SYMBOLIC LINK)
+// returns the target path of the reparse point 'repPointDir' in 'repPointDstBuf'
+// (if not NULL) of size 'repPointDstBufSize'. 'repPointDir' and 'repPointDstBuf'
+// may point into the same buffer (IN/OUT). If 'makeRelPathAbs' is TRUE and it is a
+// relative symbolic link, the target path is converted to an absolute path.
+// Returns TRUE on success and when 'repPointType' is not NULL it receives the
+// reparse point type: 1 (MOUNT POINT), 2 (JUNCTION POINT), 3 (SYMBOLIC LINK)
 BOOL GetReparsePointDestination(const char* repPointDir, char* repPointDstBuf, DWORD repPointDstBufSize,
                                 int* repPointType, BOOL makeRelPathAbs);
 
-// v 'currentReparsePoint' (aspon MAX_PATH znaku) vraci aktualni (posledni) lokalni
-// reparse point, pri neuspechu vraci klasicky root; pri neuspechu vraci FALSE; neni-li
-// 'error' NULL, zapise se do nej pri chybe TRUE
+// 'currentReparsePoint' (at least MAX_PATH chars) receives the current (last)
+// local reparse point; on failure the standard root is returned and the result
+// is FALSE. If 'error' is not NULL it is set to TRUE when an error occurs.
 BOOL GetCurrentLocalReparsePoint(const char* path, char* currentReparsePoint, BOOL* error = NULL);
 
-// volat jen pro cesty 'path', jejichz root (po odstraneni substu) je DRIVE_FIXED (jinde nema smysl hledat
-// reparse pointy); hledame cestu bez reparse pointu, vedouci na stejny svazek jako 'path'; pro cestu
-// obsahujici symlink vedouci na sitovou cestu (UNC nebo mapovanou) vracime jen root teto sitove cesty
-// (ani Vista neumi delat s reparse pointy na sitovych cestach, takze to je nejspis zbytecne drazdit);
-// pokud takova cesta neexistuje z duvodu, ze aktualni (posledni) lokalni reparse point je volume mount
-// point (nebo neznamy typ reparse pointu), vracime cestu k tomuto volume mount pointu (nebo reparse
-// pointu neznameho typu); pokud cesta obsahuje vice nez 50 reparse pointu (nejspis nekonecny cyklus),
-// vracime puvodni cestu;
+// call only for paths whose root (after removing SUBSTs) is DRIVE_FIXED (there is
+// no point searching for reparse points elsewhere); we look for a path without
+// reparse points that leads to the same volume as 'path'; for a path containing
+// a symlink that leads to a network path (UNC or mapped), we return only the
+// root of that network path (even Vista cannot work with reparse points on
+// network paths, so this is probably unnecessary); if no such path exists
+// because the current (last) local reparse point is a volume mount point (or an
+// unknown type of reparse point), we return the path to this volume mount point
+// (or reparse point of an unknown type); if the path contains more than 50
+// reparse points (most likely an infinite loop), we return the original path;
 //
-// 'resPath' je buffer pro vysledek o velikosti MAX_PATH; 'path' je puvodni cesta; v 'cutResPathIsPossible'
-// (nesmi byt NULL) vracime FALSE pokud vysledna cesta v 'resPath' obsahuje na konci reparse point (volume
-// mount point nebo neznamy typ reparse pointu) a tudiz ji nesmime zkracovat (dostali bysme se tim nejspis
-// na jiny svazek); je-li 'rootOrCurReparsePointSet' neNULLove a obsahuje-li FALSE a na puvodni ceste je
-// aspon jeden lokalni reparse point (reparse pointy na sitove casti cesty ignorujeme), vracime v teto
-// promenne TRUE + v 'rootOrCurReparsePoint' (neni-li NULL) vracime plnou cestu k aktualnimu (poslednimu
-// lokalnimu) reparse pointu (pozor, ne kam vede); cilovou cestu aktualniho reparse pointu (jen je-li to
-// junction nebo symlink) vracime v 'junctionOrSymlinkTgt' (neni-li NULL) + typ vracime v 'linkType':
-// 2 (JUNCTION POINT), 3 (SYMBOLIC LINK); v 'netPath' (neni-li NULL) vracime sitovou cestu, na kterou
-// vede aktualni (posledni) lokalni symlink v ceste - v teto situaci se root sitove cesty vraci v 'resPath'
+// 'resPath' is a MAX_PATH-sized output buffer; 'path' is the original path; in
+// 'cutResPathIsPossible' (must not be NULL) we return FALSE if the resulting
+// path in 'resPath' ends with a reparse point (volume mount point or an unknown
+// type of reparse point) and therefore must not be shortened (that would most
+// likely take us to a different volume); if 'rootOrCurReparsePointSet' is not
+// NULL and contains FALSE, and the original path contains at least one local
+// reparse point (reparse points on the network part of the path are ignored),
+// we return TRUE in this variable and in 'rootOrCurReparsePoint' (if not NULL)
+// we return the full path to the current (last local) reparse point (note: not
+// where it leads); the target path of the current reparse point (only if it is
+// a junction or symlink) is returned in 'junctionOrSymlinkTgt' (if not NULL)
+// and its type is returned in 'linkType': 2 (JUNCTION POINT), 3 (SYMBOLIC
+// LINK); in 'netPath' (if not NULL) we return the network path to which the
+// current (last) local symlink in the path leads - in this situation, the root
+// of the network path is returned in 'resPath'
 void ResolveLocalPathWithReparsePoints(char* resPath, const char* path, BOOL* cutResPathIsPossible,
                                        BOOL* rootOrCurReparsePointSet, char* rootOrCurReparsePoint,
                                        char* junctionOrSymlinkTgt, int* linkType, char* netPath);
 
-// vylepsena GetDriveType: pracuje s cestou (prochazi reparse pointy a substy)
+// improved GetDriveType: works with a path and resolves reparse points and SUBSTs
 UINT MyGetDriveType(const char* path);
 
-// nase vlastni QueryDosDevice
-// 'driveNum' je 0-based (0=A: 2=C: ...)
+// our own QueryDosDevice
+// 'driveNum' is 0-based (0=A: 2=C: ...)
 BOOL MyQueryDosDevice(BYTE driveNum, char* target, int maxTarget);
 
-// detekuje zda 'driveNum' (0=A: 2=C: ...) je substed a pokud ano, kam je pripojeny
-// pokud drive neni substed, vraci FALSE
-// pokud je substed, vraci TRUE a do promenne 'path' (o maximalni delce 'pathMax')
-// ulozi cestu, kam je subst pripojeny
-// pokud je 'path' NULL, cesta nebude vracena
-// muze vratit cestu v UNC tvaru
+// detects whether 'driveNum' (0=A: 2=C: ...) is SUBSTed and if so where it is mounted
+// returns FALSE when the drive is not SUBSTed
+// when SUBSTed, returns TRUE and stores the target path into 'path'
+// (up to 'pathMax' characters). If 'path' is NULL the path is not returned.
+// The returned path may be in UNC form.
 BOOL GetSubstInformation(BYTE driveNum, char* path, int pathMax);
 
-// nahradi v retezci posledni znak '.' decimalnim separatorem ziskanym ze systemu LOCALE_SDECIMAL
-// delka retezce muze narust, protoze separator muze mit podle MSDN az 4 znaky
-// vraci TRUE, pokud byl buffer dostatecne veliky a operaci se povedlo dokoncit, jinak vraci FALSE
+// replaces the last '.' in the string with the decimal separator from LOCALE_SDECIMAL
+// the string may grow because the separator can have up to 4 characters according to MSDN
+// returns TRUE if the buffer was large enough and the operation succeeded, otherwise FALSE
 BOOL PointToLocalDecimalSeparator(char* buffer, int bufferSize);
 
 typedef WINBASEAPI LONG(WINAPI* MY_FMExtensionProc)(HWND hwnd,
@@ -971,52 +983,52 @@ typedef WINBASEAPI LONG(WINAPI* MY_FMExtensionProc)(HWND hwnd,
                                                     LONG lParam);
 void GetMessagePos(POINT& p);
 
-// Vrati handle ikony ziskany pomoci SHGetFileInfo nebo NULL v pripade neuspechu.
-// Volajici je zodpovedny za destrukci ikony. Ikona je prirazena do HANDLES.
+// Returns an icon handle obtained via SHGetFileInfo or NULL on failure.
+// The caller is responsible for destroying the icon. The icon is assigned to HANDLES.
 HICON GetFileOrPathIconAux(const char* path, BOOL large, BOOL isDir);
 
-// pokud je root UNCPath nepristupny (pro listing), zkusi navazat sitove spojeni,
-// o jmeno a heslo uzivatele si rekne samo, vraci TRUE pokud bylo spojeni navazano,
-// vraci FALSE pokud UNCPath neni UNC cesta nebo je root UNCPath pristupny nebo
-// pokud se spojeni nepodarilo navazat, v 'pathInvalid' vraci TRUE pokud user prerusil
-// dialog zadani jmena+hesla nebo jsme neuspesne zkusili navazat spojeni (napr.
-// "credentials conflict"); je-li 'donotReconnect' TRUE, nezkousi se navazat sitove
-// spojeni, vrati se rovnou, ze to nevyslo
+// If the UNC root is inaccessible (for listing), tries to establish a network
+// connection, asking the user for credentials if needed. Returns TRUE when the
+// connection succeeded. Returns FALSE if the path is not UNC, the root is
+// accessible, or the connection attempt failed. In 'pathInvalid' returns TRUE
+// when the user cancelled the credentials dialog or the attempt failed (e.g.
+// "credentials conflict"). When 'donotReconnect' is TRUE no connection attempt
+// is made and FALSE is returned immediately.
 BOOL CheckAndConnectUNCNetworkPath(HWND parent, const char* UNCPath, BOOL& pathInvalid,
                                    BOOL donotReconnect);
 
-// pokusi se obnovit sitove spojeni (existovalo-li) na 'drive:', parent - predek dialogu,
-// vraci TRUE pokud se obnova spojeni podarila (sit. disk je jiz opet namapovan)
-// v 'pathInvalid' vraci TRUE pokud user prerusil dialog zadani jmena+hesla nebo
-// jsme neuspesne zkusili navazat spojeni (napr. "credentials conflict")
+// Attempts to restore a network connection (if it previously existed) on
+// 'drive:'. 'parent' is the parent dialog. Returns TRUE if the connection was
+// restored successfully (the network drive is mapped again).
+// 'pathInvalid' returns TRUE if the user cancelled the username/password dialog
+// or an attempt to establish the connection failed (e.g. "credentials conflict")
 BOOL CheckAndRestoreNetworkConnection(HWND parent, const char drive, BOOL& pathInvalid);
 
-// funkce pro spravu threadu, pri ukoncovani procesu se tyto thready maji uzavrit,
-// pokud to neudelaji sami, musi se terminovat
+// thread management helpers-these threads should exit when the process ends; if
+// they do not, they must be terminated
 void AddAuxThread(HANDLE view, BOOL testIfFinished = FALSE);
 void TerminateAuxThreads();
 
-// vrati TRUE, pokud specifikovany soubor existuje; jinak vrati FALSE
+// returns TRUE if the specified file exists; otherwise FALSE
 extern "C" BOOL FileExists(const char* fileName);
 
-// vrati TRUE, pokud specifikovany adresar existuje; jinak vrati FALSE
+// returns TRUE if the specified directory exists; otherwise FALSE
 BOOL DirExists(const char* dirName);
 
 // tool tip
-void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay = 0); // popis v tooltip.h
-void SuppressToolTipOnCurrentMousePos();                                 // popis v tooltip.h
+void SetCurrentToolTip(HWND hNotifyWindow, DWORD id, int showDelay = 0); // see tooltip.h
+void SuppressToolTipOnCurrentMousePos();                                 // see tooltip.h
 
-// zajisti skoky kurzoru pri Ctrl+Left/Right po zpetnych lomitkach a mezerach
-// k editline nebo comboboxu priradi EditWordBreakProc
-// je mozne zavolat napriklad v WM_INITDIALOG
-// neni nutne odinstalovavat
+// Makes Ctrl+Left/Right skip over backslashes and spaces. Assigns
+// EditWordBreakProc to an edit line or combo box. Can be called from
+// WM_INITDIALOG. Uninstalling is not required.
 BOOL InstallWordBreakProc(HWND hWindow);
 
-// vymaze vsechny polozky z dropdown listboxu od comboboxu
-// pouzivame pri promazavani historii
+// removes all items from a combo box drop-down list
+// used when clearing history
 void ClearComboboxListbox(HWND hCombo);
 
-// struktura pro WM_USER_VIEWFILE a WM_USER_VIEWFILEWITH
+// structure for WM_USER_VIEWFILE and WM_USER_VIEWFILEWITH
 struct COpenViewerData
 {
     char* FileName;
@@ -1031,88 +1043,87 @@ struct COpenViewerData
 #define WM_USER_S_REFRESH_DIR WM_APP + 101 // [BOOL setRefreshEvent, time]
 
 #define WM_USER_SETDIALOG WM_APP + 103 // [CProgressData *data, 0] \
-                                       // nebo [0, 0] - setprogress
+                                       // or [0, 0] - setprogress
 #define WM_USER_DIALOG WM_APP + 104    // [int dlgID, void *data]
 
-// icon reader prave nacetl ikonu, vlozil ji do iconcache a rika to panelu
-// bezicimu v hlavnim threadu, aby se mohl prekreslit a ikonku zazalohovat do asociaci
-// index je dohledana pozice polozky v CFilesWindow::Files/Dirs
+// the icon reader has loaded an icon and stored it in the icon cache; it notifies
+// the panel running in the main thread so it can repaint and back up the icon in the associations
+// 'index' is the located position of the item in CFilesWindow::Files/Dirs
 #define WM_USER_REFRESHINDEX WM_APP + 105 // [int index, 0]
 
-#define WM_USER_END_SUSPMODE WM_APP + 106  // [0, 0] - rychlejsi aktivace okna
+#define WM_USER_END_SUSPMODE WM_APP + 106  // [0, 0] - faster window activation
 #define WM_USER_DRIVES_CHANGE WM_APP + 107 // [0, 0]
-#define WM_USER_ICON_NOTIFY WM_APP + 108   // [0, 0] - mysak je nad ikonkou v taskbare
-#define WM_USER_EDIT WM_APP + 110          // [begin, end] oznac tento interval
-#define WM_USER_SM_END_NOTIFY WM_APP + 111 // [0, 0] za 200ms naplanuje WM_USER_SM_END_NOTIFY_DELAYED
-#define WM_USER_DISPLAYPOPUP WM_APP + 112  // [0, commandID] je treba vybali popupmenu
-//#define WM_USER_SETPATHS        WM_APP + 113    // nepouzivat, stara zprava, kterou nam teoreticky mohou stare aplikace zasilat
+#define WM_USER_ICON_NOTIFY WM_APP + 108   // [0, 0] - the mouse pointer is over the icon in the taskbar
+#define WM_USER_EDIT WM_APP + 110          // [begin, end] select this interval
+#define WM_USER_SM_END_NOTIFY WM_APP + 111 // [0, 0] schedules WM_USER_SM_END_NOTIFY_DELAYED after 200ms
+#define WM_USER_DISPLAYPOPUP WM_APP + 112  // [0, commandID] a popup menu should be displayed
+//#define WM_USER_SETPATHS        WM_APP + 113    // do not use, legacy message that old applications may theoretically send us
 
-#define WM_USER_CHAR WM_APP + 114 // notifikace z listview
+#define WM_USER_CHAR WM_APP + 114 // notification from list view
 // [command, index]
-// command = 0 pro normalni konfiguraci,
-// command = 1 pro otevreni stranky Hot Paths; index pak vyjadruje polozku
-// command = 2 pro otevreni stranky User Menu
-// command = 3 pro otevreni stranky Internal Viewer
-// command = 4 pro otevreni stranky Views, index vyjadruje pohled
-// command = 5 pro otevreni stranky Panels
+// command = 0 for normal configuration
+// command = 1 to open the Hot Paths page; 'index' specifies the item
+// command = 2 to open the User Menu page
+// command = 3 to open the Internal Viewer page
+// command = 4 to open the Views page; 'index' specifies the view
+// command = 5 to open the Panels page
 #define WM_USER_CONFIGURATION WM_APP + 115
 #define WM_USER_MOUSEWHEEL WM_APP + 116     // [wParam, lParam] z WM_MOUSEWHEEL
 #define WM_USER_SKIPONEREFRESH WM_APP + 117 // [0, 0] za 500 ms SkipOneActivateRefresh = FALSE
-#define WM_USER_FLASHWINDOW WM_APP + 118    // [0, 0] zablika oknem
-#define WM_USER_SHOWWINDOW WM_APP + 119     // [0, 0] vytahne dopopredi okno (restorne, je-li treba)
+#define WM_USER_FLASHWINDOW WM_APP + 118    // [0, 0] flashes the window
+#define WM_USER_SHOWWINDOW WM_APP + 119     // [0, 0] brings the window to the foreground (restores if needed)
 #define WM_USER_DROPCOPYMOVE WM_APP + 120   // [CTmpDropData *, 0]
-#define WM_USER_CHANGEDIR WM_APP + 121      // [convertFSPathToInternal, newDir] - panel zmeni svou cestu (vola ChangeDir)
-#define WM_USER_FOCUSFILE WM_APP + 122      // [fileName, newPath] - panel zmeni svou cestu a vybere prislusny soubor
-#define WM_USER_CLOSEFIND WM_APP + 123      // [0, 0] - zavola DestroyWindow z threadu find okna
-#define WM_USER_SELCHANGED WM_APP + 124     // [0, 0] - notifikaci o zmene selectu
+#define WM_USER_CHANGEDIR WM_APP + 121      // [convertFSPathToInternal, newDir] - the panel changes its path (calls ChangeDir)
+#define WM_USER_FOCUSFILE WM_APP + 122      // [fileName, newPath] - the panel changes its path and selects the given file
+#define WM_USER_CLOSEFIND WM_APP + 123      // [0, 0] - calls DestroyWindow from the find window thread
+#define WM_USER_SELCHANGED WM_APP + 124     // [0, 0] - notification about selection change
 #define WM_USER_MOUSEHWHEEL WM_APP + 126    // [wParam, lParam] z WM_MOUSEHWHEEL
 
-#define WM_USER_CLOSEMENU WM_APP + 130 // [0, 0] - interni pro menu - je treba se zavrit
+#define WM_USER_CLOSEMENU WM_APP + 130 // [0, 0] - internal for menus - they must close
 
-#define WM_USER_REFRESH_PLUGINFS WM_APP + 133 // [0, 0] - volat u FS Event(FSE_ACTIVATEREFRESH)
-#define WM_USER_REFRESH_SHARES WM_APP + 134   // [0, 0] - snooper.cpp hlasi zmenu sharu v registry
-#define WM_USER_PROCESSDELETEMAN WM_APP + 135 // [0, 0] - cache.cpp: DeleteManager - spusteni zpracovani novych dat v hl. threadu
+#define WM_USER_REFRESH_PLUGINFS WM_APP + 133 // [0, 0] - call for FS Event(FSE_ACTIVATEREFRESH)
+#define WM_USER_REFRESH_SHARES WM_APP + 134   // [0, 0] - snooper.cpp reports a change in shares in the registry
+#define WM_USER_PROCESSDELETEMAN WM_APP + 135 // [0, 0] - cache.cpp: DeleteManager - start processing new data in the main thread
 
-#define WM_USER_CANCELPROGRDLG WM_APP + 136  // [0, 0] - CProgressDlgArray: po doruceni teto zpravy do CProgressDialog dojde k cancelu operace (bez dotazu; zavre se dialog operace)
-#define WM_USER_FOCUSPROGRDLG WM_APP + 137   // [0, 0] - CProgressDlgArray: po doruceni teto zpravy do CProgressDialog dojde aktivaci dialogu (nebo jeho popupu)
-#define WM_USER_ICONREADING_END WM_APP + 138 // [0, 0] - notifikace o ukonceni nacitani ikonek v panelu
+#define WM_USER_CANCELPROGRDLG WM_APP + 136  // [0, 0] - CProgressDlgArray: when this message arrives the operation is canceled (no prompt; the dialog closes)
+#define WM_USER_FOCUSPROGRDLG WM_APP + 137   // [0, 0] - CProgressDlgArray: activates the dialog (or its popup) when received
+#define WM_USER_ICONREADING_END WM_APP + 138 // [0, 0] - notification that icon reading in the panel has finished
 
-//presunuto do shexreg.h (konstanta se nesmi zmenit): #define WM_USER_SALSHEXT_PASTE  WM_APP + 139 // [postMsgIndex, 0] - SalamExt zada o provedeni prikazu Paste
+// moved to shexreg.h (constant must not change): #define WM_USER_SALSHEXT_PASTE  WM_APP + 139 // [postMsgIndex, 0] - SalamExt requests execution of the Paste command
 
-#define WM_USER_DROPUNPACK WM_APP + 140    // [allocatedTgtPath, operation] - drag&drop z archivu: cilova cesta + operace zjistena, nechame provest unpack
-#define WM_USER_PROGRDLGEND WM_APP + 141   // [cmd, 0] - CProgressDialog: pod W2K+ asi zbytecne: bypass bugy (zavrene dialogy zustavaly v taskbare) - zpozdene zavreni dialogu
-#define WM_USER_PROGRDLGSTART WM_APP + 142 // [0, 0] - CProgressDialog: pod W2K+ asi zbytecne: bypass bugy (na obrazovce zustaval bordel po dialogu) - zpozdeny start worker threadu
+#define WM_USER_DROPUNPACK WM_APP + 140    // [allocatedTgtPath, operation] - drag&drop from archive: target path and operation determined, perform unpack
+#define WM_USER_PROGRDLGEND WM_APP + 141   // [cmd, 0] - CProgressDialog: workaround for bugs on W2K+ (closed dialogs remained in the taskbar) - delayed close of the dialog
+#define WM_USER_PROGRDLGSTART WM_APP + 142 // [0, 0] - CProgressDialog: workaround for bugs on W2K+ (garbage left on screen) - delayed start of the worker thread
 
-//presunuto do shexreg.h (konstanta se nesmi zmenit): #define WM_USER_SALSHEXT_TRYRELDATA WM_APP + 143 // [0, 0] - SalamExt hlasi odblokovani paste-dat (viz CSalShExtSharedMem::BlockPasteDataRelease), nejsou-li data dale chranena, nechame je zrusit
+// moved to shexreg.h (constant must not change): #define WM_USER_SALSHEXT_TRYRELDATA WM_APP + 143 // [0, 0] - SalamExt reports release of the paste data lock (see CSalShExtSharedMem::BlockPasteDataRelease); if the data is no longer protected, let it be released
 
-#define WM_USER_DROPFROMFS WM_APP + 144    // [allocatedTgtPath, operation] - drag&drop z FS: cilova cesta + operace zjistena, nechame provest copy/move z FS
+#define WM_USER_DROPFROMFS WM_APP + 144    // [allocatedTgtPath, operation] - drag&drop from FS: target path and operation determined, perform copy/move from FS
 #define WM_USER_DROPTOARCORFS WM_APP + 145 // [CTmpDragDropOperData *, 0]
 
 #define WM_USER_SHCHANGENOTIFY WM_APP + 146 // message for SHChangeNotifyRegister [pidlList, SHCNE_xxx (event that occured)]
 
-#define WM_USER_REFRESH_DIR_EX WM_APP + 147 // [long_wait, time] - za (long_wait?5000:200) ms posle WM_USER_REFRESH_DIR_EX_DELAYED
+#define WM_USER_REFRESH_DIR_EX WM_APP + 147 // [long_wait, time] - after (long_wait ? 5000 : 200) ms sends WM_USER_REFRESH_DIR_EX_DELAYED
 
-#define WM_USER_SETPROGRESS WM_APP + 148 // [progress, text] slouzi pro prekroceni threadu
+#define WM_USER_SETPROGRESS WM_APP + 148 // [progress, text] used to cross thread boundaries
 
-// icon reader prave nacetl icon-overlay a rika to panelu bezicimu v hlavnim threadu, aby
-// se mohl prekreslit
-// index je pozice polozky v CFilesWindow::Files/Dirs
+// icon reader has just loaded an icon overlay and informs the panel running in the main thread so it can repaint
+// index is the position of the item in CFilesWindow::Files/Dirs
 #define WM_USER_REFRESHINDEX2 WM_APP + 149 // [int index, 0]
 
-#define WM_USER_DONEXTFOCUS WM_APP + 150       // [0, 0] - notifikace o zmene NextFocusName
-#define WM_USER_CREATEWAITWND WM_APP + 151     // [parent or NULL, delay] - zprava pro thread safe-wait-message: "create && show"
-#define WM_USER_DESTROYWAITWND WM_APP + 152    // [killThread, 0] - zprava pro thread safe-wait-message: "hide && destery"
-#define WM_USER_SHOWWAITWND WM_APP + 153       // [show, 0] - zprava pro thread safe-wait-message: "show || hide"
-#define WM_USER_SETWAITMSG WM_APP + 154        // [0, 0] - zprava pro thread safe-wait-message: byl zmenen text--prekresli se
-#define WM_USER_REPAINTALLICONS WM_APP + 155   // [0, 0] - refresh ikon v obou panelech
-#define WM_USER_REPAINTSTATUSBARS WM_APP + 156 // [0, 0] - refresh throbberu (dirline) v obou panelech
+#define WM_USER_DONEXTFOCUS WM_APP + 150       // [0, 0] - notification that NextFocusName changed
+#define WM_USER_CREATEWAITWND WM_APP + 151     // [parent or NULL, delay] - message for the safe wait message thread: "create && show"
+#define WM_USER_DESTROYWAITWND WM_APP + 152    // [killThread, 0] - message for the safe wait message thread: "hide && destroy"
+#define WM_USER_SHOWWAITWND WM_APP + 153       // [show, 0] - message for the safe wait message thread: "show || hide"
+#define WM_USER_SETWAITMSG WM_APP + 154        // [0, 0] - message for the safe wait message thread: text changed-repaint
+#define WM_USER_REPAINTALLICONS WM_APP + 155   // [0, 0] - refresh icons in both panels
+#define WM_USER_REPAINTSTATUSBARS WM_APP + 156 // [0, 0] - refresh the throbber (dirline) in both panels
 
-#define WM_USER_VIEWERCONFIG WM_APP + 158 // [hWnd, 0] - hWnd urcuje viewer, ktery bude po dokonfigurovani zkusen vytahnout nahoru
+#define WM_USER_VIEWERCONFIG WM_APP + 158 // [hWnd, 0] - hWnd indicates the viewer to bring to front after configuration
 
-#define WM_USER_UPDATEPANEL WM_APP + 159 // [0, 0] - pokud je dorucena \
-                                         // (doruci ji messageloopa pri otevreni messageboxu), \
-                                         // bude invalidatnut panel a bude nastavena scrollbara \
-                                         // (pouze pro interni pouziti !!!)
+#define WM_USER_UPDATEPANEL WM_APP + 159 // [0, 0] - when delivered \
+                                         // (the message loop sends it after opening a message box), \
+                                         // the panel will be invalidated and the scrollbar updated \
+                                         // (for internal use only)
 
 #define WM_USER_AUTOCONFIG WM_APP + 160     // KICKER - autoconfig
 #define WM_USER_ACFINDFINISHED WM_APP + 161 // KICKER - autoconfig
@@ -1120,139 +1131,156 @@ struct COpenViewerData
 #define WM_USER_ACADDFILE WM_APP + 163      // KICKER - autoconfig
 #define WM_USER_ACERROR WM_APP + 164        // KICKER - autoconfig
 
-#define WM_USER_QUERYCLOSEFIND WM_APP + 170  // [0, quiet] - zepta se v threadu find okna, jestli ho muzeme zavrit + na dotaz zastavi pripadne probihajici hledani
-#define WM_USER_COLORCHANGEFIND WM_APP + 171 // [0, 0] - informuje find okna o zmene barev
+#define WM_USER_QUERYCLOSEFIND WM_APP + 170  // [0, quiet] - ask the Find window thread whether it can be closed and stop any ongoing search if requested
+#define WM_USER_COLORCHANGEFIND WM_APP + 171 // [0, 0] - notifies Find windows about color changes
 
 #define WM_USER_HELPHITTEST WM_APP + 172  // lResult = dwContext, lParam = MAKELONG(x,y)
 #define WM_USER_EXITHELPMODE WM_APP + 173 // [0, 0]
 
-#define WM_USER_POSTCMDORUNLOADPLUGIN WM_APP + 180 // [plug-in iface, 0, 1 nebo salCmd+2 nebo menuCmd+502] - nastavi ShouldUnload nebo ShouldRebuildMenu nebo prida salCmd/menuCmd do dat plug-inu
-#define WM_USER_POSTMENUEXTCMD WM_APP + 181        // [plug-in iface, cmdID] - post menu-ext-cmd z plug-inu
+#define WM_USER_POSTCMDORUNLOADPLUGIN WM_APP + 180 // [plug-in iface, 0, 1 or salCmd+2 or menuCmd+502] - sets ShouldUnload or ShouldRebuildMenu or adds salCmd/menuCmd to plugin data
+#define WM_USER_POSTMENUEXTCMD WM_APP + 181        // [plug-in iface, cmdID] - post a menu-ext command from a plugin
 
-#define WM_USER_SHOWPLUGINMSGBOX WM_APP + 185 // [0, 0] - otevreni msg-boxu o plug-inu nad Bug Report dialogem
+#define WM_USER_SHOWPLUGINMSGBOX WM_APP + 185 // [0, 0] - open the plug-in message box above the Bug Report dialog
 
-// prikazy pro hlavni thread (v jinem threadu je nelze spoustet) - vyuziva Find dialog (bezi ve svem threadu)
-#define WM_USER_VIEWFILE WM_APP + 190     // [COpenViewerData *, altView] - otevreni souboru v (alternate) vieweru
-#define WM_USER_EDITFILE WM_APP + 191     // [name, 0] - otevreni souboru v editoru
-#define WM_USER_VIEWFILEWITH WM_APP + 192 // [COpenViewerData *, handlerID] - otevreni souboru ve vybranem vieweru
-#define WM_USER_EDITFILEWITH WM_APP + 193 // [name, handlerID] - otevreni souboru ve vybranem editoru
+// commands for the main thread (cannot be run from another thread) - uses the
+// Find dialog (running in its own thread)
+#define WM_USER_VIEWFILE WM_APP + 190     // [COpenViewerData *, altView] - open a file in the (alternate) viewer
+#define WM_USER_EDITFILE WM_APP + 191     // [name, 0] - open a file in the editor
+#define WM_USER_VIEWFILEWITH WM_APP + 192 // [COpenViewerData *, handlerID] - open a file in the selected viewer
+#define WM_USER_EDITFILEWITH WM_APP + 193 // [name, handlerID] - open a file in the selected editor
 
-#define WM_USER_DISPACHCHANGENOTIF WM_APP + 194 // [0, time] - zadost o rozeslani zprav o zmenach na cestach
+#define WM_USER_DISPACHCHANGENOTIF WM_APP + 194 // [0, time] - request to distribute notifications about path changes
 
-#define WM_USER_DISPACHCFGCHANGE WM_APP + 195 // [0, 0] - zadost o rozeslani zprav o zmenach v konfiguraci mezi plug-iny
+#define WM_USER_DISPACHCFGCHANGE WM_APP + 195 // [0, 0] - request to distribute configuration change notifications among plugins
 
-#define WM_USER_CFGCHANGED WM_APP + 196 // [0, 0] - zasilano internim viewerum a find oknum po zmene konfigurace
+#define WM_USER_CFGCHANGED WM_APP + 196 // [0, 0] - sent to internal viewers and Find windows after configuration changes
 
-#define WM_USER_CLEARHISTORY WM_APP + 197 // [0, 0] - informuje okno, ze ma promazat vsechny comboboxy obsahujici historie
+#define WM_USER_CLEARHISTORY WM_APP + 197 // [0, 0] - instructs the window to clear all combo boxes containing histories
 
-#define WM_USER_REFRESHTOOLTIP WM_APP + 198 // posti se do tooltip okna: dojde k novemu vytazeni textu, resize okna a prekresleni
-#define WM_USER_HIDETOOLTIP WM_APP + 199    // zprava pro prekroceni hranic threadu; zhasne tooltip
+#define WM_USER_REFRESHTOOLTIP WM_APP + 198 // sent to the tooltip window: fetch text again, resize the window, and repaint
+#define WM_USER_HIDETOOLTIP WM_APP + 199    // cross-thread message; hides the tooltip
 
 ////////////////////////////////////////////////////////
 //                                                    //
-// Prostor WM_APP + 200 az WM_APP + 399 je urcen      //
-// pro zpravy chodici take do oken pluginu.           //
-// Definice je v plugins\shared\spl_*.h               //
+// The range WM_APP + 200 to WM_APP + 399 is reserved  //
+// for messages also sent to plugin windows.           //
+// Definitions are in plugins\shared\spl_*.h           //
 //                                                    //
 ////////////////////////////////////////////////////////
 
-#define WM_USER_ENUMFILENAMES WM_APP + 400 // [requestUID, 0] - informuje zdroj (panely a Findy), ze maji resit pozadavek na enumeraci souboru pro viewer
+#define WM_USER_ENUMFILENAMES WM_APP + 400 // [requestUID, 0] - tells the source (panels and Find windows) to \
+                                           // handle a request for file enumeration for the viewer
 
-#define WM_USER_SM_END_NOTIFY_DELAYED WM_APP + 401  // [0, 0] notifikace o ukonceni suspend modu (zpozdena o 200ms, aby nedochazelo ke kolizi s WM_QUERYENDSESSION pri Shutdown / Log Off)
-#define WM_USER_REFRESH_DIR_EX_DELAYED WM_APP + 402 // [FALSE, time] - lisi se od WM_USER_REFRESH_DIR tim, ze jde pravdepodobne o zbytecny refresh (duvod: aktivace okna, zadost o lock-volume (dela se obdoba "hands-off"), atp.) (zpozdena o 200ms nebo 5s, aby nedochazelo ke kolizi s WM_QUERYENDSESSION pri Shutdown / Log Off nebo aby si proces zadajici o lock-volume stihl volume zamknout)
+#define WM_USER_SM_END_NOTIFY_DELAYED WM_APP + 401  // [0, 0] notification that suspend mode ended \
+                                                    // delayed by 200 ms to avoid conflicts with \
+                                                    // WM_QUERYENDSESSION during Shutdown/Log Off
+#define WM_USER_REFRESH_DIR_EX_DELAYED WM_APP + 402 // [FALSE, time] - unlike WM_USER_REFRESH_DIR this is \
+                                                    // probably an unnecessary refresh (window activation, \
+                                                    // request for a lock volume similar to "hands-off", etc.) \
+                                                    // delayed by 200 ms or 5 s so it does not collide with \
+                                                    // WM_QUERYENDSESSION during Shutdown/Log Off or so the \
+                                                    // process requesting the lock can lock the volume
 
-#define WM_USER_CLOSE_MAINWND WM_APP + 403 // [0, 0] - pouziva se misto WM_CLOSE pro zavreni hlavniho okna Salamandera (vyhoda: je mozne zjistit, jestli se nedistribuuje z jine nez hlavni message-loopy)
+#define WM_USER_CLOSE_MAINWND WM_APP + 403 // [0, 0] - used instead of WM_CLOSE for closing the main \
+                                           // Salamander window (advantage: we can detect whether it \
+                                           // is dispatched from a non-main message loop)
 
-#define WM_USER_HELP_MOUSEMOVE WM_APP + 405  // [0, mousePos] - zasilano behem Shift+F1 (ctx help) mode vsem child oknum; po obdrzeni jedne nebo vice WM_USER_MOUSEMOVE prijde WM_USER_MOUSELEAVE; slouzi k trackovani kurzoru mysi bez, aniz bychom nahazaovali capture
-#define WM_USER_HELP_MOUSELEAVE WM_APP + 406 // [0, 0] - prichazi po WM_USER_MOUSEMOVE, kdyz kurzor opousti childa
+#define WM_USER_HELP_MOUSEMOVE WM_APP + 405  // [0, mousePos] - sent during Shift+F1 (context help) mode \
+                                             // to all child windows; after one or more WM_USER_MOUSEMOVE \
+                                             // messages WM_USER_MOUSELEAVE follows; used to track the \
+                                             // mouse cursor without capture
+#define WM_USER_HELP_MOUSELEAVE WM_APP + 406 // [0, 0] - sent after WM_USER_MOUSEMOVE when the cursor leaves a child window
 
-//#define WM_USER_RENAME_NEXT_ITEM       WM_APP + 407 // [next, 0] - postne se po zmacknuti (Shift)Tab v inplace QuickRename pro prechod na (predchozi) dalsi polozku; inspired by Vista; 'next' je TRUE pro dalsi a FALSE pro predchozi
+//#define WM_USER_RENAME_NEXT_ITEM       WM_APP + 407 // [next, 0] - posted after pressing (Shift)Tab in inplace QuickRename to move to the (previous) next item; inspired by Vista; 'next' is TRUE for next and FALSE for previous
 
-#define WM_USER_PROGRDLG_UPDATEICON WM_APP + 408 // [0, 0] - CProgressDlgArray: po doruceni teto zpravy do CProgressDialog dojde k novemu nastaveni ikonky dialogu
+#define WM_USER_PROGRDLG_UPDATEICON WM_APP + 408 // [0, 0] - CProgressDlgArray: when this message arrives the \
+                                                 // icon of the CProgressDialog is updated
 
-#define WM_USER_FORCECLOSE_MAINWND WM_APP + 409 // [0, 0] - vynucene zavreni hlavniho okna Salamandera
+#define WM_USER_FORCECLOSE_MAINWND WM_APP + 409 // [0, 0] - forced closing of the main Salamander window
 
-#define WM_USER_INACTREFRESH_DIR WM_APP + 410 // [0, time] - zpozdeny refresh pri neaktivnim hl. okne Salamandera
+#define WM_USER_INACTREFRESH_DIR WM_APP + 410 // [0, time] - delayed refresh when the main Salamander window is inactive
 
-#define WM_USER_WAKEUP_FROM_IDLE WM_APP + 411 // [0, 0] - pokud je hlavni thread v IDLE, probere se
+#define WM_USER_WAKEUP_FROM_IDLE WM_APP + 411 // [0, 0] - wakes up the main thread when it is IDLE
 
-#define WM_USER_FINDFULLROWSEL WM_APP + 412 // [0, 0] - find okna maji nastavit sve list view, aby odpovidalo promenne Configuration.FindFullRowSelect
+#define WM_USER_FINDFULLROWSEL WM_APP + 412 // [0, 0] - Find windows must set their list view to match Configuration.FindFullRowSelect
 
-#define WM_USER_SLGINCOMPLETE WM_APP + 414 // [0, 0] - upozorneni, ze SLG neni kompletne prelozene, motivacni text aby se zapojili
+#define WM_USER_SLGINCOMPLETE WM_APP + 414 // [0, 0] - notification that SLG is not fully translated; encourages contributions
 
-#define WM_USER_USERMENUICONS_READY WM_APP + 415 // [bkgndReaderData, threadID] - notifikace pro hl. okno, ze se dokoncilo cteni ikon pro User Menu v threadu s ID 'threadID'
+#define WM_USER_USERMENUICONS_READY WM_APP + 415 // [bkgndReaderData, threadID] - notification for the main window \
+                                                 // that reading icons for the User Menu has finished in the \
+                                                 // thread with ID 'threadID'
 
 // states for Shift+F1 help mode
 #define HELP_INACTIVE 0 // not in Shift+F1 help mode (must be 0)
 #define HELP_ACTIVE 1   // in Shift+F1 help mode (non-zero)
 #define HELP_ENTERING 2 // entering Shift+F1 help mode (non-zero)
 
-#define STACK_CALLS_BUF_SIZE 5000       // kazdy thread bude mit 5KB prostor pro textovy call-stack
-#define STACK_CALLS_MAX_MESSAGE_LEN 500 // nejdelsi zpravu uvazujeme 500 znaku
+#define STACK_CALLS_BUF_SIZE 5000       // each thread will have 5KB space for the text call stack
+#define STACK_CALLS_MAX_MESSAGE_LEN 500 // the longest message is assumed to be 500 characters
 
-#define MENU_MARK_CX 9 // rozmery check mark pro menu
+#define MENU_MARK_CX 9 // check mark dimensions for menus
 #define MENU_MARK_CY 9
 
-#define BOTTOMBAR_CX 17 // rozmer tlacitka v souboru bottomtb.bmp (v bodech)
+#define BOTTOMBAR_CX 17 // button dimension in bottomtb.bmp (points)
 #define BOTTOMBAR_CY 13
 
-// barvy v CurrentColors[x]
-#define FOCUS_ACTIVE_NORMAL 0 // barvy pera pro ramecek kolem polozky
+// colors in CurrentColors[x]
+#define FOCUS_ACTIVE_NORMAL 0 // pen colors for the item frame
 #define FOCUS_ACTIVE_SELECTED 1
 #define FOCUS_FG_INACTIVE_NORMAL 2
 #define FOCUS_FG_INACTIVE_SELECTED 3
 #define FOCUS_BK_INACTIVE_NORMAL 4
 #define FOCUS_BK_INACTIVE_SELECTED 5
 
-#define ITEM_FG_NORMAL 6 // barvy textu polozek v panelu
+#define ITEM_FG_NORMAL 6 // text colors of items in the panel
 #define ITEM_FG_SELECTED 7
 #define ITEM_FG_FOCUSED 8
 #define ITEM_FG_FOCSEL 9
 #define ITEM_FG_HIGHLIGHT 10
 
-#define ITEM_BK_NORMAL 11 // barvy pozadi polozek v panelu
+#define ITEM_BK_NORMAL 11 // background color of panel items
 #define ITEM_BK_SELECTED 12
 #define ITEM_BK_FOCUSED 13
 #define ITEM_BK_FOCSEL 14
 #define ITEM_BK_HIGHLIGHT 15
 
-#define ICON_BLEND_SELECTED 16 // barvy pro blend ikonek
+#define ICON_BLEND_SELECTED 16 // colors for icon blending
 #define ICON_BLEND_FOCUSED 17
 #define ICON_BLEND_FOCSEL 18
 
-#define PROGRESS_FG_NORMAL 19 // barvy progress bary
+#define PROGRESS_FG_NORMAL 19 // progress bar colors
 #define PROGRESS_FG_SELECTED 20
 #define PROGRESS_BK_NORMAL 21
 #define PROGRESS_BK_SELECTED 22
 
-#define HOT_PANEL 23    // barva hot polozky v panelu
-#define HOT_ACTIVE 24   //                   v aktivnim titulku panelu
-#define HOT_INACTIVE 25 //                   v neaktivni tiulku panelu, statusbar,...
+#define HOT_PANEL 23    // color of the hot item in the panel
+#define HOT_ACTIVE 24   // in the active panel title
+#define HOT_INACTIVE 25 //                   in the inactive panel caption, status bar, ...
 
-#define ACTIVE_CAPTION_FG 26   // barva textu v aktivnim titulku panelu
-#define ACTIVE_CAPTION_BK 27   // barva pozadi v aktivnim titulku panelu
-#define INACTIVE_CAPTION_FG 28 // barva textu v neaktivnim titulku panelu
-#define INACTIVE_CAPTION_BK 29 // barva pozadi v neaktivnim titulku panelu
+#define ACTIVE_CAPTION_FG 26   // text color in the active panel title
+#define ACTIVE_CAPTION_BK 27   // background color in the active panel title
+#define INACTIVE_CAPTION_FG 28 // text color in the inactive panel title
+#define INACTIVE_CAPTION_BK 29 // background color in the inactive panel caption
 
-#define THUMBNAIL_FRAME_NORMAL 30 // barvy pera pro ramecek kolem thumbnails
+#define THUMBNAIL_FRAME_NORMAL 30 // pen colors for the frame around thumbnails
 #define THUMBNAIL_FRAME_FOCUSED 31
 #define THUMBNAIL_FRAME_SELECTED 32
 #define THUMBNAIL_FRAME_FOCSEL 33
 
-#define VIEWER_FG_NORMAL 0 // normalni barvy viewru
+#define VIEWER_FG_NORMAL 0 // normal viewer colors
 #define VIEWER_BK_NORMAL 1
 #define VIEWER_FG_SELECTED 2 // selected text
 #define VIEWER_BK_SELECTED 3
 
-#define NUMBER_OF_COLORS 34       // pocet barev ve schematu
-#define NUMBER_OF_VIEWERCOLORS 4  // pocet barev pro viewer
-#define NUMBER_OF_CUSTOMCOLORS 16 // uzivatelelm definovane barvy v barevnem dialogu
+#define NUMBER_OF_COLORS 34       // number of colors in the scheme
+#define NUMBER_OF_VIEWERCOLORS 4  // number of colors for the viewer
+#define NUMBER_OF_CUSTOMCOLORS 16 // user-defined colors in the color dialog
 
-// interni drzak barvy, ktery navic obsahuje flag
+// internal color holder with an extra flag
 typedef DWORD SALCOLOR;
 
 // SALCOLOR flags
-#define SCF_DEFAULT 0x01 // barevna slozka se ignoruje a pouzije se default hodnota
+#define SCF_DEFAULT 0x01 // the color component is ignored and the default value is used
 
 #define GetCOLORREF(rgbf) ((COLORREF)rgbf & 0x00ffffff)
 #define RGBF(r, g, b, f) ((COLORREF)(((BYTE)(r) | ((WORD)((BYTE)(g)) << 8)) | (((DWORD)(BYTE)(b)) << 16) | (((DWORD)(BYTE)(f)) << 24)))
@@ -1263,34 +1291,34 @@ inline void SetRGBPart(SALCOLOR* salColor, COLORREF rgb)
     *salColor = rgb & 0x00ffffff | (((DWORD)(BYTE)((BYTE)((*salColor) >> 24))) << 24);
 }
 
-extern SALCOLOR* CurrentColors;               // aktualni barvy
-extern SALCOLOR UserColors[NUMBER_OF_COLORS]; // zmenene barvy
+extern SALCOLOR* CurrentColors;               // current colors
+extern SALCOLOR UserColors[NUMBER_OF_COLORS]; // modified colors
 
-extern SALCOLOR SalamanderColors[NUMBER_OF_COLORS]; // standardni barvy
-extern SALCOLOR ExplorerColors[NUMBER_OF_COLORS];   // standardni barvy
-extern SALCOLOR NortonColors[NUMBER_OF_COLORS];     // standardni barvy
-extern SALCOLOR NavigatorColors[NUMBER_OF_COLORS];  // standardni barvy
+extern SALCOLOR SalamanderColors[NUMBER_OF_COLORS]; // standard colors
+extern SALCOLOR ExplorerColors[NUMBER_OF_COLORS];   // standard colors
+extern SALCOLOR NortonColors[NUMBER_OF_COLORS];     // standard colors
+extern SALCOLOR NavigatorColors[NUMBER_OF_COLORS];  // standard colors
 
-extern SALCOLOR ViewerColors[NUMBER_OF_VIEWERCOLORS]; // barvy vieweru
+extern SALCOLOR ViewerColors[NUMBER_OF_VIEWERCOLORS]; // viewer colors
 
-extern COLORREF CustomColors[NUMBER_OF_CUSTOMCOLORS]; // pro standardni color dialog
+extern COLORREF CustomColors[NUMBER_OF_CUSTOMCOLORS]; // for the standard color dialog
 
 #define CARET_WIDTH 2
-#define MIN_PANELWIDTH 5 // uzsi panel nedostava focus
+#define MIN_PANELWIDTH 5 // a narrower panel does not receive focus
 
-#define REFRESH_PAUSE 200 // pauza mezi dvema nejblizsimi refreshi
+#define REFRESH_PAUSE 200 // pause between the two nearest refreshes
 
-extern int SPACE_WIDTH; // mezera mezi sloupcema v detailed view
+extern int SPACE_WIDTH; // spacing between columns in detailed view
 
-#define MENU_CHECK_WIDTH 8 // rozmery check bitmap pro menu
+#define MENU_CHECK_WIDTH 8 // dimensions of the check bitmap for menus
 #define MENU_CHECK_HEIGHT 8
 
-// pocty pamatovanych stringu
+// numbers of remembered strings
 #define SELECT_HISTORY_SIZE 20    // select / unselect
 #define COPY_HISTORY_SIZE 20      // copy / move
 #define EDIT_HISTORY_SIZE 30      // command line
 #define CHANGEDIR_HISTORY_SIZE 20 // Shift+F7
-#define PATH_HISTORY_SIZE 30      // forward/backward historie cest + historie navstivenych cest (Alt+F12)
+#define PATH_HISTORY_SIZE 30      // forward/backward path history + visited paths history (Alt+F12)
 #define FILTER_HISTORY_SIZE 15    // filter
 #define FILELIST_HISTORY_SIZE 15
 #define CREATEDIR_HISTORY_SIZE 20   // create directory
@@ -1302,10 +1330,10 @@ extern int SPACE_WIDTH; // mezera mezi sloupcema v detailed view
 #define VK_BACKSLASH 220
 #define VK_RBRACKET 221
 
-// kdy testovat pokus o preruseni stavby scriptu
-#define BS_TIMEOUT 200 // milisekund od posledniho testu
+// when to test for an attempt to interrupt script building
+#define BS_TIMEOUT 200 // milliseconds since the last test
 
-// identifikace bandu v rebaru
+// band identifiers in the rebar
 #define BANDID_MENU 1
 #define BANDID_TOPTOOLBAR 2
 #define BANDID_UMTOOLBAR 3
@@ -1318,33 +1346,33 @@ extern int SPACE_WIDTH; // mezera mezi sloupcema v detailed view
 #define GET_X_LPARAM(lp) ((int)(short)LOWORD(lp))
 #define GET_Y_LPARAM(lp) ((int)(short)HIWORD(lp))
 
-// urcuji duvod, proc jsou v panelu neobsazeny nektere soubory/adresare
-#define HIDDEN_REASON_ATTRIBUTE 0x00000001 // maji atribut hidden nebo system a v konfiguraci je potlaceni zobrazovani takovych souboru/adresaru
-#define HIDDEN_REASON_FILTER 0x00000002    // soubor je odfiltrovan na zaklade filtru v panelu
-#define HIDDEN_REASON_HIDECMD 0x00000004   // jmeno bylo skryto prikazem Hide Selected/Unselected Names
+// reasons why some files/directories are not shown in the panel
+#define HIDDEN_REASON_ATTRIBUTE 0x00000001 // have the hidden or system attribute and configuration suppresses such files/directories
+#define HIDDEN_REASON_FILTER 0x00000002    // file is filtered out based on the panel filter
+#define HIDDEN_REASON_HIDECMD 0x00000004   // name was hidden using Hide Selected/Unselected Names
 
-// bitove pole drivu 'a' .. 'z'
+// bit field of drive letters 'a' .. 'z'
 #define DRIVES_MASK 0x03FFFFFF
 
 //
 // ****************************************************************************
 
 // Windows XP, Windows 2003.NET, Vista, Windows 7, Windows 8, Windows 8.1, Windows 10
-extern BOOL WindowsXP64AndLater;  // Windows XP64 nebo pozdejsi
-extern BOOL WindowsVistaAndLater; // Windows Vista nebo pozdejsi
-extern BOOL Windows7AndLater;     // Windows 7 nebo pozdejsi
-extern BOOL Windows8AndLater;     // Windows 8 nebo pozdejsi
-extern BOOL Windows8_1AndLater;   // Windows 8.1 nebo pozdejsi
-extern BOOL Windows10AndLater;    // Windows 10 nebo pozdejsi
+extern BOOL WindowsXP64AndLater;  // Windows XP64 or later
+extern BOOL WindowsVistaAndLater; // Windows Vista or later
+extern BOOL Windows7AndLater;     // Windows 7 or later
+extern BOOL Windows8AndLater;     // Windows 8 or later
+extern BOOL Windows8_1AndLater;   // Windows 8.1 or later
+extern BOOL Windows10AndLater;    // Windows 10 or later
 
-extern BOOL Windows64Bit; // x64 verze Windows
+extern BOOL Windows64Bit; // x64 version of Windows
 
-extern BOOL RunningAsAdmin; // TRUE pokud Salamander bezi "As Administrator"
+extern BOOL RunningAsAdmin; // TRUE when Salamander runs "As Administrator"
 
-extern DWORD CCVerMajor; // verze DLL common controls
+extern DWORD CCVerMajor; // version of the common controls DLL
 extern DWORD CCVerMinor;
 
-extern const char* SALAMANDER_TEXT_VERSION; // textove oznaceni aplikace vcetne verze
+extern const char* SALAMANDER_TEXT_VERSION; // textual application label including the version
 
 extern const char *LOW_MEMORY,
     *MAINWINDOW_NAME,
@@ -1353,56 +1381,56 @@ extern const char *LOW_MEMORY,
     *SAVEBITS_CLASSNAME,
     *SHELLEXECUTE_CLASSNAME;
 
-extern const char* STR_NONE; // "(none)" - plug-iny: pro DLLName a Version pokud jsou nezjistitelne
+extern const char* STR_NONE; // "(none)" - plugins: used for DLLName and Version when they cannot be determined
 
-extern char DefaultDir['z' - 'a' + 1][MAX_PATH]; // kam jit pri zmene disku
+extern char DefaultDir['z' - 'a' + 1][MAX_PATH]; // target path when changing drives
 
-extern int MyTimeCounter;                   // po kazdem pouziti inkrementovat !
-extern CRITICAL_SECTION TimeCounterSection; // pro synchronizaci pristupu k ^
+extern int MyTimeCounter;                   // increment after each use!
+extern CRITICAL_SECTION TimeCounterSection; // used to synchronize access to the above
 
-extern HINSTANCE NtDLL;               // handle k ntdll.dll
-extern HINSTANCE Shell32DLL;          // handle k shell32.dll (ikonky)
-extern HINSTANCE ImageResDLL;         // handle k imageres.dll (ikonky - Vista+)
-extern HINSTANCE User32DLL;           // handle k user32.dll (DisableProcessWindowsGhosting)
-extern HINSTANCE HLanguage;           // handle k jazykove zavislym resourcum (cesta: Configuration.LoadedSLGName)
-extern char CurrentHelpDir[MAX_PATH]; // po prvnim pouziti helpu je zde cesta do adresare helpu (umisteni vsech .chm souboru)
-extern WORD LanguageID;               // language-id jazykove zavislych resourcu (.SLG souboru)
+extern HINSTANCE NtDLL;               // handle to ntdll.dll
+extern HINSTANCE Shell32DLL;          // handle to shell32.dll (icons)
+extern HINSTANCE ImageResDLL;         // handle to imageres.dll (icons - Vista+)
+extern HINSTANCE User32DLL;           // handle to user32.dll (DisableProcessWindowsGhosting)
+extern HINSTANCE HLanguage;           // handle to language-specific resources (path: Configuration.LoadedSLGName)
+extern char CurrentHelpDir[MAX_PATH]; // after the first use of help this holds the path to the help directory (location of all .chm files)
+extern WORD LanguageID;               // language ID of the language-specific resources (.SLG file)
 
-extern BOOL UseCustomPanelFont; // pokud je TRUE, vychazi Font a FontUL ze struktury LogFont; jinak ze systemoveho fontu (default)
+extern BOOL UseCustomPanelFont; // if TRUE, Font and FontUL are based on LogFont; otherwise on the system font (default)
 extern HFONT Font;              // panel font
-extern HFONT FontUL;            // podtrzena verze
-extern int FontCharHeight;      // vyska fontu
-extern LOGFONT LogFont;         // struktura popisujici panel font
+extern HFONT FontUL;            // underlined version
+extern int FontCharHeight;      // font height
+extern LOGFONT LogFont;         // structure describing the panel font
 
-BOOL CreatePanelFont(); // naplni Font, FontULa FontCharHeight na zaklade LogFont
+BOOL CreatePanelFont(); // fills Font, FontUL and FontCharHeight based on LogFont
 
-extern HFONT EnvFont;         // font prostredi (edit, toolbar, header, status)
-extern HFONT EnvFontUL;       // font listboxu podtrzeny
-extern int EnvFontCharHeight; // vyska fontu
-extern HFONT TooltipFont;     // font pro tooltips (a statusbars, ale tam ho nepouzivame)
+extern HFONT EnvFont;         // environment font (edit, toolbar, header, status)
+extern HFONT EnvFontUL;       // underlined list box font
+extern int EnvFontCharHeight; // font height
+extern HFONT TooltipFont;     // font for tooltips (and status bars, although we don't use it there)
 
-BOOL GetSystemGUIFont(LOGFONT* lf); // vrati font pouzivany pro hlavni okno Salamandera
-BOOL CreateEnvFonts();              // naplni EnvFont, EnvFontUL, EnvFontCharHeight, TooltipFont na zaklade metrics
+BOOL GetSystemGUIFont(LOGFONT* lf); // returns the font used for the main Salamander window
+BOOL CreateEnvFonts();              // fills EnvFont, EnvFontUL, EnvFontCharHeight and TooltipFont based on system metrics
 
-extern DWORD MouseHoverTime; // po jake dobe ma dojit k vysviceni
+extern DWORD MouseHoverTime; // how long before highlighting occurs
 
-extern HBRUSH HNormalBkBrush;        // pozadi obycejne polozky v panelu
-extern HBRUSH HFocusedBkBrush;       // pozadi focusle polozky v panelu
-extern HBRUSH HSelectedBkBrush;      // pozadi selected polozky v panelu
-extern HBRUSH HFocSelBkBrush;        // pozadi focused & selected polozky v panelu
-extern HBRUSH HDialogBrush;          // vypln pozadi dialogu
-extern HBRUSH HButtonTextBrush;      // text tlacitek
-extern HBRUSH HDitherBrush;          // sachovnice o barevne hloubce 1 bit; pri kresleni lze barvu nastavit pres SetTextColor/SetBkColor
-extern HBRUSH HActiveCaptionBrush;   // pozadi aktivniho tiutlku panelu
-extern HBRUSH HInactiveCaptionBrush; // pozadi neaktivniho tiutlku panelu
+extern HBRUSH HNormalBkBrush;        // background of a regular panel item
+extern HBRUSH HFocusedBkBrush;       // background of the focused panel item
+extern HBRUSH HSelectedBkBrush;      // background of the selected panel item
+extern HBRUSH HFocSelBkBrush;        // background of a focused and selected item
+extern HBRUSH HDialogBrush;          // dialog background fill
+extern HBRUSH HButtonTextBrush;      // button text
+extern HBRUSH HDitherBrush;          // 1-bit checkerboard; the color can be set via SetTextColor/SetBkColor
+extern HBRUSH HActiveCaptionBrush;   // background of the active panel title
+extern HBRUSH HInactiveCaptionBrush; // background of the inactive panel title
 
 extern HBRUSH HMenuSelectedBkBrush;
 extern HBRUSH HMenuSelectedTextBrush;
 extern HBRUSH HMenuHilightBrush;
 extern HBRUSH HMenuGrayTextBrush;
 
-extern HACCEL AccelTable1; // akceleratory v panelech a cmdline
-extern HACCEL AccelTable2; // akceleratory v cmdline
+extern HACCEL AccelTable1; // accelerators in panels and the command line
+extern HACCEL AccelTable2; // accelerators in the command line
 
 extern int SystemDPI;
 
@@ -1411,61 +1439,61 @@ enum CIconSizeEnum
     ICONSIZE_16,   // 16x16 @ 100%DPI, 20x20 @ 125%DPI, 24x24 @ 150%DPI, ...
     ICONSIZE_32,   // 32x32 @ 100%DPI, ...
     ICONSIZE_48,   // 48x48 @ 100%DPI, ...
-    ICONSIZE_COUNT // items count
+    ICONSIZE_COUNT // item count
 };
 
-extern int IconSizes[ICONSIZE_COUNT]; // velikosti ikonek: 16, 32, 48
-extern int IconLRFlags;               // ridi barevnou hloubku nacitanych ikon
+extern int IconSizes[ICONSIZE_COUNT]; // icon sizes: 16, 32, 48
+extern int IconLRFlags;               // controls the color depth of loaded icons
 
-// POZOR: na Viste se pouziva pro ikony 48x48 overlay ICONSIZE_32 a pro thumbnaily overlay ICONSIZE_48
-extern HICON HSharedOverlays[ICONSIZE_COUNT];   // shared (ruka) ve vsech velikostech
-extern HICON HShortcutOverlays[ICONSIZE_COUNT]; // shortcut (levy dolni roh) ve vsech velikostech
-extern HICON HSlowFileOverlays[ICONSIZE_COUNT]; // slow files
+// NOTE: on Vista a 48x48 icon uses overlay ICONSIZE_32 and thumbnails use overlay ICONSIZE_48
+extern HICON HSharedOverlays[ICONSIZE_COUNT];   // shared (hand) overlay in all sizes
+extern HICON HShortcutOverlays[ICONSIZE_COUNT]; // shortcut (lower left corner) overlay in all sizes
+extern HICON HSlowFileOverlays[ICONSIZE_COUNT]; // slow file overlays
 
-extern CIconList* SimpleIconLists[ICONSIZE_COUNT]; // simple icons ve vsech velikostech
+extern CIconList* SimpleIconLists[ICONSIZE_COUNT]; // simple icons in all sizes
 
-#define THROBBER_WIDTH 12 // rozmery jednoho policka
+#define THROBBER_WIDTH 12 // dimensions of one frame
 #define THROBBER_HEIGHT 12
-#define THROBBER_COUNT 36     // celkovy pocet policek
-#define IDT_THROBBER_DELAY 30 // delay [ms] v animaci jednoho policka
+#define THROBBER_COUNT 36     // total number of frames
+#define IDT_THROBBER_DELAY 30 // delay [ms] for one frame of the animation
 extern CIconList* ThrobberFrames;
 
-#define LOCK_WIDTH 8 // rozmery jednoho policka
+#define LOCK_WIDTH 8 // size of one frame
 #define LOCK_HEIGHT 13
 extern CIconList* LockFrames;
 
-extern HICON HGroupIcon;   // skupina pro UserMenu popupy
-extern HICON HFavoritIcon; // hot path
+extern HICON HGroupIcon;   // group icon for UserMenu pop-ups
+extern HICON HFavoritIcon; // hot path icon
 
-#define TILE_LEFT_MARGIN 4 // pocet bodu vlevo pred ikonkou
+#define TILE_LEFT_MARGIN 4 // number of pixels to the left of the icon
 
-extern RGBQUAD ColorTable[256]; // paleta pouzivana pro vsechny toolbary (vcetne pluginu)
+extern RGBQUAD ColorTable[256]; // palette used for all toolbars (including plugins)
 
-// jednotlive pozice imagelistu SymbolsImageList a LargeSymbolsImageList
+// individual indices in the SymbolsImageList and LargeSymbolsImageList image lists
 enum CSymbolsImageListIndexes
 {
     symbolsExecutable,    // 0: exe/bat/pif/com
     symbolsDirectory,     // 1: dir
-    symbolsNonAssociated, // 2: neasociovany soubor
-    symbolsAssociated,    // 3: asociovany soubor
+    symbolsNonAssociated, // 2: unassociated file
+    symbolsAssociated,    // 3: associated file
     symbolsUpDir,         // 4: up-dir ".."
-    symbolsArchive,       // 5: archiv
+    symbolsArchive,       // 5: archive
     symbolsCount          // TERMINATOR
 };
 
-extern HIMAGELIST HFindSymbolsImageList; // symboly pro find
-extern HIMAGELIST HMenuMarkImageList;    // check marky pro menu
-extern HIMAGELIST HGrayToolBarImageList; // toolbar a menu v sedivem provedeni (pocitano z barevneho)
-extern HIMAGELIST HHotToolBarImageList;  // toolbar a menu v barevnem provedeni
+extern HIMAGELIST HFindSymbolsImageList; // symbols for Find
+extern HIMAGELIST HMenuMarkImageList;    // check marks for menus
+extern HIMAGELIST HGrayToolBarImageList; // toolbar and menu in a gray variant (generated from the colored one)
+extern HIMAGELIST HHotToolBarImageList;  // toolbar and menu in color
 extern HIMAGELIST HBottomTBImageList;    // bottom toolbar (F1 - F12)
 extern HIMAGELIST HHotBottomTBImageList; // bottom toolbar (F1 - F12)
 
-extern HPEN HActiveNormalPen; // pera pro ramecek kolem polozky
+extern HPEN HActiveNormalPen; // pens for the rectangle around an item
 extern HPEN HActiveSelectedPen;
 extern HPEN HInactiveNormalPen;
 extern HPEN HInactiveSelectedPen;
 
-extern HPEN HThumbnailNormalPen; // pera pro ramecek kolem thumbnail
+extern HPEN HThumbnailNormalPen; // pens for the rectangle around a thumbnail
 extern HPEN HThumbnailFucsedPen;
 extern HPEN HThumbnailSelectedPen;
 extern HPEN HThumbnailFocSelPen;
@@ -1477,32 +1505,32 @@ extern HPEN BtnFacePen;
 extern HPEN WndFramePen;
 extern HPEN WndPen;
 
-extern HBITMAP HFilter; // bitmapa - panel skryva nejake soubory nebo adresare
+extern HBITMAP HFilter; // bitmap - the panel hides some files or directories
 
-extern HBITMAP HHeaderSort; // sipky pro HeaderLine
+extern HBITMAP HHeaderSort; // arrows for HeaderLine
 
-extern CBitmap ItemBitmap; // devecka pro vsechno mozne: kresleni polozek v panelu, header line, ...
+extern CBitmap ItemBitmap; // helper for various things: drawing items in the panel, header line, etc.
 
-extern HBITMAP HUpDownBitmap; // Sipky pro rolovani uvnitr kratkych popup menu.
-extern HBITMAP HZoomBitmap;   // Zoom panelu
+extern HBITMAP HUpDownBitmap; // arrows for scrolling inside short popup menus
+extern HBITMAP HZoomBitmap;   // panel zoom bitmap
 
 //extern HBITMAP HWorkerBitmap;
 
-extern HCURSOR HHelpCursor; // Context Help cursor - loadi se az kdyz je potreba
+extern HCURSOR HHelpCursor; // context help cursor - loaded only when needed
 
-#define THUMBNAIL_SIZE_DEFAULT 94 // podle XP
-#define THUMBNAIL_SIZE_MIN 48     // pokud budeme chtit podpori mensi nez 48, je potreba zobrazovat mensi ikony
+#define THUMBNAIL_SIZE_DEFAULT 94 // according to Windows XP
+#define THUMBNAIL_SIZE_MIN 48     // to support less than 48 we would need to show smaller icons
 #define THUMBNAIL_SIZE_MAX 1000
 
-extern BOOL DragFullWindows; // pokud je TRUE, mame menit velikost panelu realtime, jinak az po releasu (optimalizace pro remote desktop)
+extern BOOL DragFullWindows; // if TRUE the panel is resized in real time, otherwise only after release (optimization for remote desktop)
 
-// CConfiguration::SizeFormat (format sloupce Size v panelech)
-// !POZOR! nemenit konstanty, jsou vyvezene do pluginu pres SALCFG_SIZEFORMAT
-#define SIZE_FORMAT_BYTES 0 // v bajtech (Open Salamander)
-#define SIZE_FORMAT_KB 1    // v KB (Windows Explorer)
-#define SIZE_FORMAT_MIXED 2 // bajty, KB, MB, GB, ...
+// CConfiguration::SizeFormat (the Size column format in panels)
+// WARNING! Do not change the constants; they are exported to plugins via SALCFG_SIZEFORMAT
+#define SIZE_FORMAT_BYTES 0 // in bytes (Open Salamander)
+#define SIZE_FORMAT_KB 1    // in KB (Windows Explorer)
+#define SIZE_FORMAT_MIXED 2 // bytes, KB, MB, GB, ...
 
-// jmena klicu v registry
+// names of registry keys
 extern const char* SALAMANDER_ROOT_REG;
 extern const char* SALAMANDER_SAVE_IN_PROGRESS;
 extern const char* SALAMANDER_COPY_IS_OK;
@@ -1562,8 +1590,9 @@ extern const char* SALAMANDER_PLUGINSORDER_SHOW;
 extern const char* SALAMANDER_PLUGINS_ISNETHOOD;
 extern const char* SALAMANDER_PLUGINS_USESPASSWDMAN;
 
-// nasledujicich 8 retezcu je jen pro load konfigu verze 6 a nizsi, novejsi verze
-// jiz pouzivaji SALAMANDER_PLUGINS_FUNCTIONS (ulozeni v bitech DWORDove masky funkci)
+// the following eight strings are only for loading configuration version 6 and
+// older; newer versions already use SALAMANDER_PLUGINS_FUNCTIONS (stored in bits
+// of a DWORD mask of functions)
 extern const char* SALAMANDER_PLUGINS_PANELVIEW;
 extern const char* SALAMANDER_PLUGINS_PANELEDIT;
 extern const char* SALAMANDER_PLUGINS_CUSTPACK;
@@ -1573,62 +1602,68 @@ extern const char* SALAMANDER_PLUGINS_LOADSAVE;
 extern const char* SALAMANDER_PLUGINS_VIEWER;
 extern const char* SALAMANDER_PLUGINS_FS;
 
-// clipboard format pro SalIDataObject (znacka naseho IDataObjectu na clipboardu)
+// clipboard format for SalIDataObject (marks our IDataObject on the clipboard)
 extern const char* SALCF_IDATAOBJECT;
-// clipboard format pro CFakeDragDropDataObject (urcuje cestu, ktera se ma po dropu objevit
-// v directory-line, command-line + blokuje drop do usermenu-toolbar); pokud je tazeno
-// vic adresaru/souboru, je cesta prazdny retezec (drop do directory/command-line neni mozny)
+// clipboard format for CFakeDragDropDataObject specifying the path that should
+// appear after drop in the directory line or command line and blocking drop to
+// the user menu toolbar; if multiple folders/files are dragged the path is an
+// empty string (drop to directory/command line is not possible)
 extern const char* SALCF_FAKE_REALPATH;
-// clipboard format pro CFakeDragDropDataObject (urcuje typ zdroje - 1=archiv, 2=FS)
+// clipboard format for CFakeDragDropDataObject specifying the source type
+// (1=archive, 2=FS)
 extern const char* SALCF_FAKE_SRCTYPE;
-// clipboard format pro CFakeDragDropDataObject (jen je-li zdroj FS: zdrojova FS cesta)
+// clipboard format for CFakeDragDropDataObject (only when the source is FS:
+// source FS path)
 extern const char* SALCF_FAKE_SRCFSPATH;
 
-// promenne pro CanChangeDirectory() a AllowChangeDirectory()
-extern int ChangeDirectoryAllowed; // 0 znamena, ze je mozne menit adresar
+// variables for CanChangeDirectory() and AllowChangeDirectory()
+extern int ChangeDirectoryAllowed; // 0 means the directory can be changed
 extern BOOL ChangeDirectoryRequest;
-// funkce obsluhujici automatickou zmenu aktualniho adresare na systemovy
-// - kvuli odmapovavani z jinych softu a mazani adresaru zobrazenych Salamandrem
+// function handling the automatic switch of the current directory to the system
+// one-used when other software unmaps drives or deletes directories shown by
+// Salamander
 BOOL CanChangeDirectory();
 void AllowChangeDirectory(BOOL allow);
 
-// promenna pro BeginStopRefresh() a EndStopRefresh()
+// variable for BeginStopRefresh() and EndStopRefresh()
 extern int StopRefresh;
-// po volani se neprovede zadny refresh adresare
+// after calling no directory refresh will occur
 void BeginStopRefresh(BOOL debugSkipOneCaller = FALSE, BOOL debugDoNotTestCaller = FALSE);
-// uvolni refreshovani -> pripadne posle WM_USER_SM_END_NOTIFY hlavnimu oknu (probehnou promeskane refreshe)
+// releases refreshing -> possibly posts WM_USER_SM_END_NOTIFY to the main window
+// so missed refreshes are processed
 void EndStopRefresh(BOOL postRefresh = TRUE, BOOL debugSkipOneCaller = FALSE, BOOL debugDoNotTestCaller = FALSE);
 
-// promenna kontrolovana v hl. message-loope v "idle" casti, je-li TRUE, vyhleda a unloadne
-// plug-iny s ShouldUnload==TRUE, rebuildne menu pluginum s ShouldRebuildMenu==TRUE + spusti
-// prikazy postnute z pluginu + pozadovane prikazy Salamandera
+// variable checked in the main message loop during the "idle" part; if TRUE, it unloads
+// plugins with ShouldUnload==TRUE, rebuilds menus for plugins with ShouldRebuildMenu==TRUE,
+// and runs commands posted from plugins plus requested Salamander commands
 extern BOOL ExecCmdsOrUnloadMarkedPlugins;
 
-// promenna kontrolovana v hl. message-loope v "idle" casti, je-li TRUE, otevre Pack/Unpack
-// dialog pro pluginy s OpenPackDlg==TRUE nebo OpenUnpackDlg==TRUE
+// variable checked in the main message loop during the "idle" part; if TRUE, it opens the Pack/Unpack
+// dialog for plugins with OpenPackDlg==TRUE or OpenUnpackDlg==TRUE
 extern BOOL OpenPackOrUnpackDlgForMarkedPlugins;
 
-// promenna pro BeginStopIconRepaint() a EndStopIconRepaint()
+// variable for BeginStopIconRepaint() and EndStopIconRepaint()
 extern int StopIconRepaint;
 extern BOOL PostAllIconsRepaint;
-// po volani se neprovede zadny refresh ikony v panelech
+// after calling no icon refresh in the panels takes place
 void BeginStopIconRepaint();
-// uvolni repaint -> pripadne posle WM_USER_REPAINTALLICONS hlavnimu oknu (obnova vsech ikon)
+// releases repaint -> optionally posts WM_USER_REPAINTALLICONS to the main
+// window (refresh of all icons)
 void EndStopIconRepaint(BOOL postRepaint = TRUE);
 
-// promenna pro BeginStopStatusbarRepaint() a EndStopStatusbarRepaint()
+// variable for BeginStopStatusbarRepaint() and EndStopStatusbarRepaint()
 extern int StopStatusbarRepaint;
 extern BOOL PostStatusbarRepaint;
-// po volani se prestane prekreslovat throbber
+// after calling the throbber stops repainting
 void BeginStopStatusbarRepaint();
-// uvolni repaint
+// resumes repainting
 void EndStopStatusbarRepaint();
 
-// v modulu msgbox.cpp - centrovany messagebox podle pra parenta od hParent
+// in module msgbox.cpp - center the message box according to the parent specified by hParent
 int SalMessageBox(HWND hParent, LPCTSTR lpText, LPCTSTR lpCaption, UINT uType);
 int SalMessageBoxEx(const MSGBOXEX_PARAMS* params);
 
-// vykresli ikonky z imagelistu s nastavenyma stylama
+// draws icons from the image list with the specified styles
 #define IMAGE_STATE_FOCUSED 0x00000001
 #define IMAGE_STATE_SELECTED 0x00000002
 #define IMAGE_STATE_HIDDEN 0x00000004
@@ -1640,79 +1675,81 @@ BOOL StateImageList_Draw(CIconList* iconList, int imageIndex, HDC hDC, int xDst,
                          DWORD state, CIconSizeEnum iconSize, DWORD iconOverlayIndex,
                          const RECT* overlayRect, BOOL overlayOnly, BOOL iconOverlayFromPlugin,
                          int pluginIconOverlaysCount, HICON* pluginIconOverlays);
-DWORD GetImageListColorFlags(); // vrati ILC_COLOR??? podle verzi Windows - odladene pro pouziti imagelistu v listviewech
+DWORD GetImageListColorFlags(); // returns the ILC_COLOR flag suitable for the current Windows version when using image lists in list views
 
-// API GetOpenFileName/GetSaveFileName v pripade ze cesta k souboru (OPENFILENAME::lpstrFile)
-// neexistuje (nebo obsahuje napriklad C:\) vrati FALSE a CommDlgExtendedError() == FNERR_INVALIDFILENAME.
-// Proto zavadime jejich "bezpecnou" variantu, ktera tento pripad detekuje a pokusi se otevrit
-// dialog pro Documents nebo Desktop.
+// The GetOpenFileName/GetSaveFileName APIs return FALSE and set
+// CommDlgExtendedError() to FNERR_INVALIDFILENAME when the file path in
+// OPENFILENAME::lpstrFile does not exist (or contains e.g. C:\). To handle this
+// case we introduce "safe" versions that detect the problem and try to open the
+// dialog for Documents or Desktop instead.
 BOOL SafeGetOpenFileName(LPOPENFILENAME lpofn);
 BOOL SafeGetSaveFileName(LPOPENFILENAME lpofn);
 
-extern char DecimalSeparator[5]; // "znaky" (max. 4 znaky) vytazene ze systemu
-extern int DecimalSeparatorLen;  // delka ve znacich bez nuly na konci
+extern char DecimalSeparator[5]; // characters (max. 4) obtained from the system
+extern int DecimalSeparatorLen;  // length in characters without the terminating zero
 extern char ThousandsSeparator[5];
 extern int ThousandsSeparatorLen;
 
-extern DWORD SalamanderStartTime;     // cas startu Salamandera (GetTickCount)
-extern DWORD SalamanderExceptionTime; // cas exceptiony v Salamanderu (GetTickCount) nebo cas posledniho vyvolani Bug Report dialogu
+extern DWORD SalamanderStartTime;     // Salamander start time (GetTickCount)
+extern DWORD SalamanderExceptionTime; // time of the exception in Salamander (GetTickCount) or the last Bug Report dialog time
 
-extern BOOL SkipOneActivateRefresh; // ma se preskocit refresh pri aktivaci hl. okna? (pro interni viewry)
+extern BOOL SkipOneActivateRefresh; // should refresh be skipped when the main window is activated? (for internal viewers)
 
-extern int MenuNewExceptionHasOccured; // spadlo uz menu New? (mozna prepsalo nekde pamet)
-extern int FGIExceptionHasOccured;     // spadlo uz SHGetFileInfo?
-extern int ICExceptionHasOccured;      // spadlo uz InvokeCommand?
-extern int QCMExceptionHasOccured;     // spadlo uz QueryContextMenu?
-extern int OCUExceptionHasOccured;     // spadlo uz OleUninitialize nebo CoUninitialize?
-extern int GTDExceptionHasOccured;     // spadlo uz GetTargetDirectory?
-extern int SHLExceptionHasOccured;     // spadlo uz neco z ShellLib?
-extern int RelExceptionHasOccured;     // spadlo uz nejaky volani IUnknown metody Release()?
+extern int MenuNewExceptionHasOccured; // has the New menu crashed already? (maybe overwrote memory somewhere)
+extern int FGIExceptionHasOccured;     // has SHGetFileInfo crashed?
+extern int ICExceptionHasOccured;      // has InvokeCommand crashed?
+extern int QCMExceptionHasOccured;     // has QueryContextMenu crashed?
+extern int OCUExceptionHasOccured;     // has OleUninitialize or CoUninitialize crashed?
+extern int GTDExceptionHasOccured;     // has GetTargetDirectory crashed?
+extern int SHLExceptionHasOccured;     // has something from ShellLib crashed?
+extern int RelExceptionHasOccured;     // has any IUnknown::Release() call crashed?
 
-extern BOOL SalamanderBusy;          // je Salamander busy?
-extern DWORD LastSalamanderIdleTime; // GetTickCount() z okamziku, kdy SalamanderBusy naposledy presel na TRUE
+extern BOOL SalamanderBusy;          // is Salamander busy?
+extern DWORD LastSalamanderIdleTime; // GetTickCount() from the moment SalamanderBusy last changed to TRUE
 
-extern int PasteLinkIsRunning; // pokud je vetsi nez nula, probiha prave Past Shortcuts prikaz v jednom z panelu
+extern int PasteLinkIsRunning; // when greater than zero a Paste Shortcuts command is in progress in one of the panels
 
-extern BOOL CannotCloseSalMainWnd; // TRUE = nesmi dojit k zavreni hlavniho okna
+extern BOOL CannotCloseSalMainWnd; // TRUE = the main window must not be closed
 
-extern const char* DirColumnStr;      // LoadStr(IDS_DIRCOLUMN) - pouziva se prilis casto, cachujeme
-extern int DirColumnStrLen;           // delka retezce
-extern const char* ColExtStr;         // LoadStr(IDS_COLUMN_NAME_EXT) - pouziva se prilis casto, cachujeme
-extern int ColExtStrLen;              // delka retezce
-extern int TextEllipsisWidth;         // sirka retezce "..." zobrazenho fontem 'Font'
-extern int TextEllipsisWidthEnv;      // sirka retezce "..." zobrazenho fontem 'FontEnv'
-extern const char* ProgDlgHoursStr;   // LoadStr(IDS_PROGDLGHOURS) - pouziva se prilis casto, cachujeme
-extern const char* ProgDlgMinutesStr; // LoadStr(IDS_PROGDLGMINUTES) - pouziva se prilis casto, cachujeme
-extern const char* ProgDlgSecsStr;    // LoadStr(IDS_PROGDLGSECS) - pouziva se prilis casto, cachujeme
+extern const char* DirColumnStr;      // LoadStr(IDS_DIRCOLUMN) - used very often, cached
+extern int DirColumnStrLen;           // string length
+extern const char* ColExtStr;         // LoadStr(IDS_COLUMN_NAME_EXT) - used very often, cached
+extern int ColExtStrLen;              // string length
+extern int TextEllipsisWidth;         // width of "..." drawn with font 'Font'
+extern int TextEllipsisWidthEnv;      // width of "..." drawn with font 'FontEnv'
+extern const char* ProgDlgHoursStr;   // LoadStr(IDS_PROGDLGHOURS) - used very often, cached
+extern const char* ProgDlgMinutesStr; // LoadStr(IDS_PROGDLGMINUTES) - used very often, cached
+extern const char* ProgDlgSecsStr;    // LoadStr(IDS_PROGDLGSECS) - used very often, cached
 
-extern char FolderTypeName[80];         // file-type pro vsechny adresare (ziskany ze systemoveho adresare)
-extern int FolderTypeNameLen;           // delka retezce FolderTypeName
-extern const char* UpDirTypeName;       // LoadStr(IDS_UPDIRTYPENAME) - pouziva se prilis casto, cachujeme
-extern int UpDirTypeNameLen;            // delka retezce
-extern const char* CommonFileTypeName;  // LoadStr(IDS_COMMONFILETYPE) - pouziva se prilis casto, cachujeme
-extern int CommonFileTypeNameLen;       // delka retezce CommonFileTypeName
-extern const char* CommonFileTypeName2; // LoadStr(IDS_COMMONFILETYPE2) - pouziva se prilis casto, cachujeme
+extern char FolderTypeName[80];         // file type for all directories (obtained from the system directory)
+extern int FolderTypeNameLen;           // length of FolderTypeName
+extern const char* UpDirTypeName;       // LoadStr(IDS_UPDIRTYPENAME) - used very often, cached
+extern int UpDirTypeNameLen;            // string length
+extern const char* CommonFileTypeName;  // LoadStr(IDS_COMMONFILETYPE) - used very often, cached
+extern int CommonFileTypeNameLen;       // length of CommonFileTypeName
+extern const char* CommonFileTypeName2; // LoadStr(IDS_COMMONFILETYPE2) - used very often, cached
 
-extern char WindowsDirectory[MAX_PATH]; // cachovany vysledek GetWindowsDirectory
+extern char WindowsDirectory[MAX_PATH]; // cached result of GetWindowsDirectory
 
 //#ifdef MSVC_RUNTIME_CHECKS
-#define RTC_ERROR_DESCRIPTION_SIZE 2000 // buffer pro popis run-time check chyby
+#define RTC_ERROR_DESCRIPTION_SIZE 2000 // buffer for the run-time check error description
 extern char RTCErrorDescription[RTC_ERROR_DESCRIPTION_SIZE];
 //#endif // MSVC_RUNTIME_CHECKS
 
-// cesta, kde vytvorime bug report a minidump, umisteni: do Visty u salamand.exe, ve Viste (a dale) v CSIDL_APPDATA + "\\Open Salamander"
+// path where we create the bug report and minidump: before Vista next to
+// salamand.exe, in Vista and later in CSIDL_APPDATA + "\\Open Salamander"
 extern char BugReportPath[MAX_PATH];
 
-// nazev souboru, ktery bude importovan (pokud existuje) do registry
+// name of the file that will be imported into the registry if it exists
 extern char ConfigurationName[MAX_PATH];
 extern BOOL ConfigurationNameIgnoreIfNotExists;
 
-extern HWND PluginProgressDialog; // pokud si plug-in otevre progress dialog, je zde jeho HWND, jinak NULL
-extern HWND PluginMsgBoxParent;   // parent pro messageboxy plug-inu (hlavni okno, Plugins dialog, atd.)
+extern HWND PluginProgressDialog; // if a plugin opens a progress dialog this is its HWND, otherwise NULL
+extern HWND PluginMsgBoxParent;   // parent for plugin message boxes (main window, Plugins dialog, etc.)
 
-extern BOOL CriticalShutdown; // TRUE = probiha "critical shutdown", neni cas se ptat, rychle koncime, 5s do zabiti
+extern BOOL CriticalShutdown; // TRUE = "critical shutdown" in progress; no time to ask, exiting quickly, 5s until kill
 
-// "preklad" POSIX jmena na MS
+// "translation" of POSIX names to MS
 #define itoa _itoa
 #define stricmp _stricmp
 #define strnicmp _strnicmp
@@ -1722,11 +1759,11 @@ extern BOOL CriticalShutdown; // TRUE = probiha "critical shutdown", neni cas se
 #define SKILL_LEVEL_INTERMEDIATE 1
 #define SKILL_LEVEL_ADVANCED 2
 
-// konvertuje promennou CConfiguration::SkillLevel do SkillLevel pro menu.
+// converts the CConfiguration::SkillLevel variable to the menu SkillLevel
 DWORD CfgSkillLevelToMenu(BYTE cfgSkillLevel);
 
-// atributy, ktere ukazujeme v panelu a kteryma je treba maskovat napriklad pri porovnani adresaru
-// POZOR: FILE_ATTRIBUTE_DIRECTORY nezobrazujeme jako atribut, takze v masce nema co delat
+// Attributes shown in the panel which must also be masked when comparing directories.
+// NOTE: FILE_ATTRIBUTE_DIRECTORY is not displayed as an attribute so it has no place in the mask.
 #define DISPLAYED_ATTRIBUTES (FILE_ATTRIBUTE_READONLY | FILE_ATTRIBUTE_HIDDEN | \
                               FILE_ATTRIBUTE_SYSTEM | \
                               FILE_ATTRIBUTE_ARCHIVE | FILE_ATTRIBUTE_ENCRYPTED | \
@@ -1757,16 +1794,17 @@ DWORD CfgSkillLevelToMenu(BYTE cfgSkillLevel);
 #define IDT_DELAYEDTHROBBER 950
 #define IDT_UPDATETASKLIST 951
 
-// POZOR: skoro vsechny funkce v teto sekci pri chybe zobrazuji hlaseni o LOAD / SAVE
-//        konfigurace, coz z nich dela nevhodne pro bezny pristup do Registry,
-//        reseni viz funkce na zacatku regwork.h: OpenKeyAux, CreateKeyAux, atd.
+// NOTE: nearly all functions in this section display LOAD/SAVE configuration
+//       error messages on failure, which makes them unsuitable for general
+//       registry access. See the functions at the beginning of regwork.h:
+//       OpenKeyAux, CreateKeyAux, etc.
 BOOL ClearKey(HKEY key);
 BOOL CreateKey(HKEY hKey, const char* name, HKEY& createdKey);
 BOOL OpenKey(HKEY hKey, const char* name, HKEY& openedKey);
 void CloseKey(HKEY key);
 BOOL DeleteKey(HKEY hKey, const char* name);
 BOOL DeleteValue(HKEY hKey, const char* name);
-// pro dataSize = -1 si funkce napocita delku stringu pres strlen
+// when dataSize is -1 the function calculates the string length using strlen
 BOOL SetValue(HKEY hKey, const char* name, DWORD type,
               const void* data, DWORD dataSize);
 BOOL GetValue(HKEY hKey, const char* name, DWORD type, void* buffer, DWORD bufferSize);
@@ -1791,30 +1829,30 @@ BOOL ImportConfiguration(HWND hParent, const char* fileName, BOOL ignoreIfNotExi
 class CHighlightMasks;
 void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL processColors, BOOL processMasks);
 
-extern BOOL ImageDragging;                                                // prave se tahne image
-extern BOOL ImageDraggingVisible;                                         // je prave image zobrazeny?
-void ImageDragBegin(int width, int height, int dxHotspot, int dyHotspot); // velikost tazeneho obrazku
-void ImageDragEnd();                                                      // ukonceni tazeni
-BOOL ImageDragInterfereRect(const RECT* rect);                            // rect je v obrazovkovych souradnicich, zjistit, jestli tazena polozka zasahuje do rect
-void ImageDragEnter(int x, int y);                                        // x a y jsou obrazovkove souradnice
-void ImageDragMove(int x, int y);                                         // x a y jsou obrazovkove souradnice
+extern BOOL ImageDragging;                                                // an image is being dragged
+extern BOOL ImageDraggingVisible;                                         // is the image currently visible?
+void ImageDragBegin(int width, int height, int dxHotspot, int dyHotspot); // size of the dragged image
+void ImageDragEnd();                                                      // end dragging
+BOOL ImageDragInterfereRect(const RECT* rect);                            // rect is in screen coordinates, check whether the dragged item intersects it
+void ImageDragEnter(int x, int y);                                        // x and y are screen coordinates
+void ImageDragMove(int x, int y);                                         // x and y are screen coordinates
 void ImageDragLeave();
-void ImageDragShow(BOOL show); // zhasne / rozsviti, neovlivni ImageDragging, pouze ImageDraggingVisible
+void ImageDragShow(BOOL show); // hides/shows; does not affect ImageDragging, only ImageDraggingVisible
 
-// nastavuje kurzor ve tvaru ruky
+// sets the cursor to a hand shape
 HCURSOR SetHandCursor();
 
 //******************************************************************************
 //
 // CreateToolbarBitmaps
 //
-// IN:   hInstance    - instance, ve ktere lezi bitmapa s resID
-//       resID        - identifikator vstupni bitmapy
-//       transparent  - tato barva bude pruhledna
-//       bkColorForAlpha - barva, ktera bude prosvitat pod alpha castma ikonek (WinXP)
-// OUT:  hMaskBitmap  - maska (b&w)
-//       hGrayBitmap  - sedive provedeni
-//       hColorBitmap - barevne provedeni
+// IN:   hInstance       - instance containing the bitmap with resID
+//       resID           - identifier of the input bitmap
+//       transparent     - this color will be transparent
+//       bkColorForAlpha - color showing through the alpha parts of icons (WinXP)
+// OUT:  hMaskBitmap  - mask (b&w)
+//       hGrayBitmap  - grayscale variant
+//       hColorBitmap - color variant
 //
 
 struct CSVGIcon
@@ -1831,9 +1869,8 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
 //
 // CreateGrayscaleAndMaskBitmaps
 //
-// Vytvori novou bitmapu o hloubce 24 bitu, nakopiruje do ni zdrojovou
-// bitmapu a prevede ji na stupne sedi. Zaroven pripravi druhou bitmapu
-// s maskou dle transparentni barvy.
+// Creates a new 24-bit bitmap, copies the source bitmap into it and converts it to grayscale.
+// At the same time prepares another bitmap with a mask based on the transparent color.
 //
 
 BOOL CreateGrayscaleAndMaskBitmaps(HBITMAP hSource, COLORREF transparent,
@@ -1862,83 +1899,82 @@ DWORD UpdateCrc32(const void* buffer, DWORD count, DWORD crcVal);
 
 //******************************************************************************
 //
-// Rizeni Idle procesingu (CMainWindow::OnEnterIdle)
+// Idle processing control (CMainWindow::OnEnterIdle)
 //
-// promenne jsou pro snadnou dostupnost globalni
-// a ne jako atributy tridy CMainWindow
+// variables are global for easy access and not attributes of CMainWindow
 //
 
-extern BOOL IdleRefreshStates;  // pokud je nastavena, budou pri nejblizim CMainWindow::OnEnterIdle vytazeny stavove promenne pro commandy (toolbar, menu)
-extern BOOL IdleForceRefresh;   // je-li nastavena IdleRefreshStates, nastaveni promenne IdleForceRefresh vyradi cache na urovni Salamandera
-extern BOOL IdleCheckClipboard; // pokud je IdleRefreshStates==TRUE a zaroven je nastavena tato promenna, bude se kontrolovat tak clipboard (casove narocne)
+extern BOOL IdleRefreshStates;  // when set, the next CMainWindow::OnEnterIdle will update command states (toolbar, menu)
+extern BOOL IdleForceRefresh;   // if IdleRefreshStates is set, setting IdleForceRefresh bypasses Salamander's cache
+extern BOOL IdleCheckClipboard; // when IdleRefreshStates is TRUE and this flag is set, the clipboard is checked as well (time consuming)
 
-// ".." neni pocitano mezi soubory|adresare
-extern DWORD EnablerUpDir;                // existuje parent directory?
-extern DWORD EnablerRootDir;              // nejsme jeste v rootu? (pozor: UNC root ma updir, ale je to root)
-extern DWORD EnablerForward;              // je v historii dostupny forward?
-extern DWORD EnablerBackward;             // je v historii dostupny backward?
-extern DWORD EnablerFileOnDisk;           // focus je na souboru && panel je disk
-extern DWORD EnablerFileOnDiskOrArchive;  // focus je na souboru && panel je disk nebo archiv
-extern DWORD EnablerFileOrDirLinkOnDisk;  // focus je na souboru nebo adresari linku && panel je disk
-extern DWORD EnablerFiles;                // focus|select je na souborech|adresarich
-extern DWORD EnablerFilesOnDisk;          // focus|select je na souborech|adresarich && panel je disk
-extern DWORD EnablerFilesOnDiskCompress;  // focus|select je na souborech|adresarich && panel je disk && je podporovana komprese
-extern DWORD EnablerFilesOnDiskEncrypt;   // focus|select je na souborech|adresarich && panel je disk && je podporovano sifrovani
-extern DWORD EnablerFilesOnDiskOrArchive; // focus|select je na souborech|adresarich && panel je disk nebo archiv
-extern DWORD EnablerOccupiedSpace;        // panel je disk nebo archiv s VALID_DATA_SIZE a zaroven plati EnablerFilesOnDiskOrArchive
-extern DWORD EnablerFilesCopy;            // focus|select je na souborech|adresarich && panel je disk, archiv nebo FS s podporou "copy from fs"
-extern DWORD EnablerFilesMove;            // focus|select je na souborech|adresarich && panel je disk nebo FS s podporou "move from fs"
-extern DWORD EnablerFilesDelete;          // focus|select je na souborech|adresarich && (panel je disk, editovatelny archiv nebo FS s podporou "delete")
-extern DWORD EnablerFileDir;              // focus je na souboru|adresari
-extern DWORD EnablerFileDirANDSelected;   // focus je na souboru|adresari && jsou oznaceny nejake soubory|adresare
-extern DWORD EnablerQuickRename;          // focus je na souboru|adresari && panel je disk nebo FS (s podporou quick-rename)
-extern DWORD EnablerOnDisk;               // panel je disk
-extern DWORD EnablerCalcDirSizes;         // panel je disk nebo archiv s VALID_DATA_SIZE
-extern DWORD EnablerPasteFiles;           // je mozne provest Paste? (soubory na clipboardu) (vyuzite jako pamet posledniho stavu clipboardu pro 'pasteFiles' v CMainWindow::RefreshCommandStates())
-extern DWORD EnablerPastePath;            // je mozne provest Paste? (text cesty na clipboardu) (vyuzite jako pamet posledniho stavu clipboardu pro 'pastePath' v CMainWindow::RefreshCommandStates())
-extern DWORD EnablerPasteLinks;           // je mozne provest Paste Links? (soubory pres "copy" na clipboardu) (vyuzite jako pamet posledniho stavu clipboardu pro 'pasteLinks' v CMainWindow::RefreshCommandStates())
-extern DWORD EnablerPasteSimpleFiles;     // jsou na clipboardu soubory/adresare z jedine cesty? (aneb: je sance na Paste do archivu nebo FS?)
-extern DWORD EnablerPasteDefEffect;       // jaky je defaultni paste-effect, muze byt i kombinace DROPEFFECT_COPY+DROPEFFECT_MOVE (aneb: slo o Copy nebo Cut?)
-extern DWORD EnablerPasteFilesToArcOrFS;  // je mozny Paste souboru do archivu/FS v aktualnim panelu? (v panelu je archiv/FS && EnablerPasteSimpleFiles && operace podle EnablerPasteDefEffect je mozna)
-extern DWORD EnablerPaste;                // je mozne provest Paste? (soubory na clipboardu && panel je disk || je mozne provest paste do archivu nebo FS || text cesty na clipboardu)
-extern DWORD EnablerPasteLinksOnDisk;     // je mozne provest Paste Links a panel je disk?
-extern DWORD EnablerSelected;             // jsou oznaceny nejake soubory|adresare
-extern DWORD EnablerUnselected;           // existuje alespon jeden neoznaceny soubor|adresar (UpDir ".." se neuvazuje)
-extern DWORD EnablerHiddenNames;          // pole HiddenNames obsahuje nejake nazvy
-extern DWORD EnablerSelectionStored;      // je ulozena selection v OldSelection aktivniho panelu?
-extern DWORD EnablerGlobalSelStored;      // je ulozena selection v GlobalSelection?
-extern DWORD EnablerSelGotoPrev;          // existuje pred focusem vybrana polozka?
-extern DWORD EnablerSelGotoNext;          // existuje za focusem vybrana polozka?
-extern DWORD EnablerLeftUpDir;            // existuje v levem panelu parent directory?
-extern DWORD EnablerRightUpDir;           // existuje v pravem panelu parent directory?
-extern DWORD EnablerLeftRootDir;          // nejsme jeste v levem panelu v rootu? (pozor: UNC root ma updir, ale je to root)
-extern DWORD EnablerRightRootDir;         // nejsme jeste v pravem panelu v rootu? (pozor: UNC root ma updir, ale je to root)
-extern DWORD EnablerLeftForward;          // je v historii leveho panelu dostupny forward?
-extern DWORD EnablerRightForward;         // je v historii praveho panelu dostupny forward?
-extern DWORD EnablerLeftBackward;         // je v historii leveho panelu dostupny backward?
-extern DWORD EnablerRightBackward;        // je v historii praveho panelu dostupny backward?
-extern DWORD EnablerFileHistory;          // je v view/edit historii dostupny soubor?
-extern DWORD EnablerDirHistory;           // je v directory historii dostupny adresar?
-extern DWORD EnablerCustomizeLeftView;    // je mozne konfigurovat sloupce pro levy pohled?
-extern DWORD EnablerCustomizeRightView;   // je mozne konfigurovat sloupce pro pravy pohled?
-extern DWORD EnablerDriveInfo;            // je mozne zobrazit Drive Info?
-extern DWORD EnablerCreateDir;            // panel je disk nebo FS (s podporou create-dir)
-extern DWORD EnablerViewFile;             // focus je na souboru && panel je disk, archiv nebo FS (s podporou view-file)
-extern DWORD EnablerChangeAttrs;          // focus|select je na souborech|adresarich && panel je disk nebo FS (s podporou change-attributes)
-extern DWORD EnablerShowProperties;       // focus|select je na souborech|adresarich && panel je disk nebo FS (s podporou show-properties)
-extern DWORD EnablerItemsContextMenu;     // focus|select je na souborech|adresarich && panel je disk nebo FS (s podporou context-menu)
-extern DWORD EnablerOpenActiveFolder;     // panel je disk nebo FS (s podporou open-active-folder)
-extern DWORD EnablerPermissions;          // focus|select je na souborech|adresarich && panel je disk, bezime nejmene na W2K, disk umi ACL (NTFS)
+// ".." is not counted among files/directories
+extern DWORD EnablerUpDir;                // is a parent directory available?
+extern DWORD EnablerRootDir;              // are we already at the root? (note: UNC roots have an updir but are still roots)
+extern DWORD EnablerForward;              // is forward available in history?
+extern DWORD EnablerBackward;             // is backward available in history?
+extern DWORD EnablerFileOnDisk;           // focus is on a file and the panel is disk-based
+extern DWORD EnablerFileOnDiskOrArchive;  // focus is on a file and the panel is disk or archive
+extern DWORD EnablerFileOrDirLinkOnDisk;  // focus is on a file or directory link and the panel is disk
+extern DWORD EnablerFiles;                // focus/selection is on files/directories
+extern DWORD EnablerFilesOnDisk;          // focus/selection is on files/directories and the panel is a disk
+extern DWORD EnablerFilesOnDiskCompress;  // focus/selection is on files/directories and the panel is a disk that supports compression
+extern DWORD EnablerFilesOnDiskEncrypt;   // focus/selection is on files/directories and the panel is a disk that supports encryption
+extern DWORD EnablerFilesOnDiskOrArchive; // focus/selection is on files/directories and the panel is disk or archive
+extern DWORD EnablerOccupiedSpace;        // panel is disk or archive with VALID_DATA_SIZE and EnablerFilesOnDiskOrArchive holds
+extern DWORD EnablerFilesCopy;            // focus/selection is on files/directories and the panel is disk, archive or FS supporting "copy from fs"
+extern DWORD EnablerFilesMove;            // focus/selection is on files/directories and the panel is disk or FS supporting "move from fs"
+extern DWORD EnablerFilesDelete;          // focus/selection is on files/directories and the panel is a disk, an editable archive, or an FS supporting "delete"
+extern DWORD EnablerFileDir;              // focus is on a file/directory
+extern DWORD EnablerFileDirANDSelected;   // focus is on a file/directory and some files/directories are selected
+extern DWORD EnablerQuickRename;          // focus is on a file/directory and the panel is disk or FS (with quick-rename support)
+extern DWORD EnablerOnDisk;               // panel is a disk
+extern DWORD EnablerCalcDirSizes;         // panel is a disk or archive with VALID_DATA_SIZE
+extern DWORD EnablerPasteFiles;           // can Paste be performed? (files on the clipboard) used as memory of the last clipboard state for 'pasteFiles' in CMainWindow::RefreshCommandStates()
+extern DWORD EnablerPastePath;            // can Paste be performed? (path text on the clipboard) used as memory of the last clipboard state for 'pastePath' in CMainWindow::RefreshCommandStates()
+extern DWORD EnablerPasteLinks;           // can Paste Links be performed? (files copied to the clipboard) used as memory of the last clipboard state for 'pasteLinks' in CMainWindow::RefreshCommandStates()
+extern DWORD EnablerPasteSimpleFiles;     // are there files/directories from a single path on the clipboard? (chance to Paste into an archive or FS)
+extern DWORD EnablerPasteDefEffect;       // what is the default paste effect; may be a combination of DROPEFFECT_COPY+DROPEFFECT_MOVE (Copy or Cut?)
+extern DWORD EnablerPasteFilesToArcOrFS;  // can files be pasted into the archive/FS in the current panel? (the panel is archive/FS && EnablerPasteSimpleFiles && the operation according to EnablerPasteDefEffect is allowed)
+extern DWORD EnablerPaste;                // can Paste be performed? (files on clipboard && panel is disk || paste into archive/FS is possible || path text on clipboard)
+extern DWORD EnablerPasteLinksOnDisk;     // can Paste Links be performed and the panel is a disk?
+extern DWORD EnablerSelected;             // are any files/directories selected
+extern DWORD EnablerUnselected;           // is there at least one unselected file/directory (UpDir ".." not considered)
+extern DWORD EnablerHiddenNames;          // the HiddenNames array contains some names
+extern DWORD EnablerSelectionStored;      // is a selection stored in OldSelection of the active panel?
+extern DWORD EnablerGlobalSelStored;      // is a selection stored in GlobalSelection?
+extern DWORD EnablerSelGotoPrev;          // is there a selected item before the focus?
+extern DWORD EnablerSelGotoNext;          // is there a selected item after the focus?
+extern DWORD EnablerLeftUpDir;            // does the left panel have a parent directory?
+extern DWORD EnablerRightUpDir;           // does the right panel have a parent directory?
+extern DWORD EnablerLeftRootDir;          // are we not yet at the root in the left panel? (UNC roots have an updir but are still roots)
+extern DWORD EnablerRightRootDir;         // are we not yet at the root in the right panel? (UNC roots have an updir but are still roots)
+extern DWORD EnablerLeftForward;          // is forward available in the left panel history?
+extern DWORD EnablerRightForward;         // is forward available in the right panel history?
+extern DWORD EnablerLeftBackward;         // is backward available in the left panel history?
+extern DWORD EnablerRightBackward;        // is backward available in the right panel history?
+extern DWORD EnablerFileHistory;          // is a file available in the view/edit history?
+extern DWORD EnablerDirHistory;           // is a directory available in the directory history?
+extern DWORD EnablerCustomizeLeftView;    // can columns be configured for the left view?
+extern DWORD EnablerCustomizeRightView;   // can columns be configured for the right view?
+extern DWORD EnablerDriveInfo;            // can Drive Info be displayed?
+extern DWORD EnablerCreateDir;            // panel is disk or FS (supports create-dir)
+extern DWORD EnablerViewFile;             // focus is on a file and the panel is disk, archive or FS (supports view-file)
+extern DWORD EnablerChangeAttrs;          // focus/selection is on files/directories and the panel is disk or FS (supports change-attributes)
+extern DWORD EnablerShowProperties;       // focus/selection is on files/directories and the panel is disk or FS (supports show-properties)
+extern DWORD EnablerItemsContextMenu;     // focus/selection is on files/directories and the panel is disk or FS (supports context menu)
+extern DWORD EnablerOpenActiveFolder;     // panel is a disk or an FS (with open-active-folder support)
+extern DWORD EnablerPermissions;          // focus/selection is on files/directories and the panel is a disk; running at least on W2K with NTFS supporting ACLs
 
 //******************************************************************************
 //
 // ToolBar Bitmap indexes
 //
-// Polozky lze pridavat do pole.
-// Pole je rozdeleno na dve casti. V Prnim jsou indexy, ke kterym se v bitmape
-// opravdu nachazeji obrazky.
-// Pak nasleduji indexy, na ktere jsou vytazeny ikonky z shell32.dll.
-// Tyto dve skupiny musi byt vzdy celistve a neni mozne indexy stridat.
+// Items can be added to the array.
+// The array is divided into two parts. The first contains indexes with real
+// images in the bitmap. After that come indexes with icons pulled from
+// shell32.dll. These two groups must always be contiguous and the indexes cannot
+// be mixed.
 //
 
 #define IDX_TB_CONNECTNET 0    // Connect Network Drive
@@ -1996,8 +2032,8 @@ extern DWORD EnablerPermissions;          // focus|select je na souborech|adresa
 #define IDX_TB_UNSELECTALL 52       // Unselect all
 #define IDX_TB_VIEW_MODE 53         // View Mode
 #define IDX_TB_HOTPATHS 54          // Hot Paths
-#define IDX_TB_FOCUS 55             // Focus (zelena sipka)
-#define IDX_TB_STOP 56              // Stop (cervene kolecko s krizkem)
+#define IDX_TB_FOCUS 55             // Focus (green arrow)
+#define IDX_TB_STOP 56              // Stop (red circle with a cross)
 #define IDX_TB_EMAIL 57             // Email Files
 #define IDX_TB_EDITNEW 58           // Edit New
 #define IDX_TB_PASTESHORTCUT 59     // Paste Shortcut
@@ -2020,9 +2056,9 @@ extern DWORD EnablerPermissions;          // focus|select je na souborech|adresa
 #define IDX_TB_SHOW_ALL 76          // Show All Names
 #define IDX_TB_SMART_COLUMN_MODE 77 // Smart Column Mode
 
-#define IDX_TB_FD 78 // first "dynamic added" index
-// nasledujici ikony budou pridany k bitmape dynamicky
-// a nektere budou nacteny z shell32.dll
+#define IDX_TB_FD 78 // first "dynamically added" index
+// the following icons will be added to the bitmap dynamically
+// and some will be loaded from shell32.dll
 
 #define IDX_TB_CHANGEDRIVEL IDX_TB_FD + 0 // Change Drive Left
 #define IDX_TB_CHANGEDRIVER IDX_TB_FD + 1 // Change Drive Right
@@ -2036,242 +2072,220 @@ extern DWORD EnablerPermissions;          // focus|select je na souborech|adresa
 #define IDX_TB_OPENFONTS IDX_TB_FD + 9    // Open Fonts
 #define IDX_TB_OPENMYDOC IDX_TB_FD + 10   // Open Documents
 
-#define IDX_TB_COUNT IDX_TB_FD + 11 // pocet bitmap vcetne tahanych z shell32.dll
+#define IDX_TB_COUNT IDX_TB_FD + 11 // number of bitmaps including those pulled from shell32.dll
 
 //******************************************************************************
 //
 // Custom Exceptions
 //
 
-#define OPENSAL_EXCEPTION_RTC 0xE0EA4321   // vyvolame v rtc callbacku
-#define OPENSAL_EXCEPTION_BREAK 0xE0EA4322 // vyvolame v pripade breaku (z jineho salama nebo promoci salbreak)
+#define OPENSAL_EXCEPTION_RTC 0xE0EA4321   // raised in the RTC callback
+#define OPENSAL_EXCEPTION_BREAK 0xE0EA4322 // raised when breaking from another Salamander or via salbreak
 
 //******************************************************************************
 //
-// Sada promennych a funkci pro otevirani asociaci pomoci SalOpen.exe
+// Set of variables and functions for opening associations via SalOpen.exe
 //
 
-// sdilena pamet
+// shared memory
 extern HANDLE SalOpenFileMapping;
 extern void* SalOpenSharedMem;
 
-// uvolneni sluzby
+// release the service
 void ReleaseSalOpen();
 
-// spusteni salopen.exe a predani 'fileName' pres sdilenou pamet
-// vraci TRUE pokud se to povedlo, jinak FALSE (asociace by se mela spustit jinak)
+// launch salopen.exe and pass 'fileName' via shared memory
+// returns TRUE on success, otherwise FALSE (the association should be launched another way)
 BOOL SalOpenExecute(HWND hWindow, const char* fileName);
 
 //******************************************************************************
 
-// mapovani salCmd (cislo prikazu Salamandera spousteneho z plug-inu, viz SALCMD_XXX)
-// na cislo prikazu pro WM_COMMAND
+// mapping salCmd (the Salamander command number from a plugin, see SALCMD_XXX)
+// to the command number for WM_COMMAND
 int GetWMCommandFromSalCmd(int salCmd);
 
 //******************************************************************************
 
-// pocet polozek v poli SalamanderConfigurationRoots
+// number of items in the SalamanderConfigurationRoots array
 #define SALCFG_ROOTS_COUNT 83
 
-// id hlavniho threadu (platne az po vstupu do WinMain())
+// ID of the main thread (valid only after entering WinMain())
 extern DWORD MainThreadID;
 
-extern BOOL IsNotAlphaNorNum[256]; // pole TRUE/FALSE pro znaky (TRUE = neni pismeno ani cislice)
-extern BOOL IsAlpha[256];          // pole TRUE/FALSE pro znaky (TRUE = pismeno)
+extern BOOL IsNotAlphaNorNum[256]; // TRUE/FALSE array for characters (TRUE = not a letter or digit)
+extern BOOL IsAlpha[256];          // TRUE/FALSE array for characters (TRUE = letter)
 
-extern int UserCharset; // defaultni useruv charset pro fonty
+extern int UserCharset; // user's default charset for fonts
 
-// granularita alokaci (potreba pro pouzivani souboru mapovanych do pameti)
+// allocation granularity (needed when using memory-mapped files)
 extern DWORD AllocationGranularity;
 
-// ma se cekat na pusteni ESC pred zacatkem listovani cesty v panelu?
+// should we wait for ESC to be released before starting to list the path in the panel?
 extern BOOL WaitForESCReleaseBeforeTestingESC;
 
-// vrati pozici v screen coord., kde se ma vybalit context menu
-// pouziva se pri vybalovani contextoveho menu pomoci klavesnice (Shift+F10 nebo VK_APP)
+// returns the screen coordinates where the context menu should appear
+// used when invoking the context menu via keyboard (Shift+F10 or VK_APP)
 void GetListViewContextMenuPos(HWND hListView, POINT* p);
 
-// na zaklade barevne hloubky displeje urci, jestli pouzivat 256 barevne
-// nebo 16 barevne bitmapy.
+// based on the display color depth decides whether to use 256-color
+// or 16-color bitmaps
 BOOL Use256ColorsBitmap();
 
-// obnovi focus ve zdrojovem panelu (pouziva se pokud mizi focus - po disablovani hl. okna, atp.)
+// restores focus in the source panel (used when focus disappears after disabling the main window, etc.)
 void RestoreFocusInSourcePanel();
 
 #define ISSLGINCOMPLETE_SIZE 200
 extern char IsSLGIncomplete[ISSLGINCOMPLETE_SIZE];
 
 //******************************************************************************
-// enumerace jmen souboru z panelu/Findu pro viewery
+// enumeration of file names from panels/Find for viewers
 
-// init+release dat spojenych s enumeraci
+// initialization and release of data associated with enumeration
 void InitFileNamesEnumForViewers();
 void ReleaseFileNamesEnumForViewers();
 
 enum CFileNamesEnumRequestType
 {
-    fnertFindNext,     // hledame dalsi soubor ve zdroji
-    fnertFindPrevious, // hledame predchozi soubor ve zdroji
-    fnertIsSelected,   // zjistujeme oznaceni souboru ve zdroji
-    fnertSetSelection, // nastavujeme oznaceni souboru ve zdroji
+    fnertFindNext,     // look for the next file in the source
+    fnertFindPrevious, // look for the previous file in the source
+    fnertIsSelected,   // query whether the file is selected in the source
+    fnertSetSelection, // set the selection state of the file in the source
 };
 
 struct CFileNamesEnumData
 {
-    // pozadavek:
-    int RequestUID;                        // cislo pozadavku
-    CFileNamesEnumRequestType RequestType; // typ pozadavku
+    // request:
+    int RequestUID;                        // request ID
+    CFileNamesEnumRequestType RequestType; // type of request
     int SrcUID;
     int LastFileIndex;
     char LastFileName[MAX_PATH];
     BOOL PreferSelected;
     BOOL OnlyAssociatedExtensions;
-    CPluginInterfaceAbstract* Plugin; // pouziva se pri 'OnlyAssociatedExtensions'==TRUE, oznacuje pro jaky plugin filtrovat jmena souboru ('Plugin'==NULL = interni viewer)
+    CPluginInterfaceAbstract* Plugin; // used when 'OnlyAssociatedExtensions'==TRUE; designates which plugin to filter file names for ('Plugin'==NULL = internal viewer)
     char FileName[MAX_PATH];
     BOOL Select;
-    BOOL TimedOut; // TRUE pokud uz na vysledek nikdo neceka (zbytecne provadet hledani jmena)
+    BOOL TimedOut; // TRUE when nobody is waiting for the result anymore (searching the name would be pointless)
 
-    // vysledek:
-    BOOL Found; // TRUE pokud bylo nalezeno pozadovane jmeno souboru
+    // result:
+    BOOL Found; // TRUE when the desired file name was found
     BOOL NoMoreFiles;
     BOOL SrcBusy;
     BOOL IsFileSelected;
 };
 
-// sekce pro praci s daty spojenymi s enumeraci (FileNamesEnumSources, FileNamesEnumData,
-// FileNamesEnumDone, NextRequestUID a NextSourceUID)
+// section for handling enumeration data (FileNamesEnumSources, FileNamesEnumData,
+// FileNamesEnumDone, NextRequestUID and NextSourceUID)
 extern CRITICAL_SECTION FileNamesEnumDataSect;
-// struktura s pozadavkem+vysledky enumerace
+// structure containing the enumeration request and results
 extern CFileNamesEnumData FileNamesEnumData;
-// event je "signaled" jakmile zdroj naplni vysledek do FileNamesEnumData
+// the event is signaled once the source fills FileNamesEnumData with the result
 extern HANDLE FileNamesEnumDone;
 
-#define FILENAMESENUM_TIMEOUT 1000 // timeout pro doruceni zpravy WM_USER_ENUMFILENAMES oknu zdroje
+#define FILENAMESENUM_TIMEOUT 1000 // timeout for delivering WM_USER_ENUMFILENAMES to the source window
 
-// vraci TRUE pokud je zdroj enumerace panel, v 'panel' pak vraci PANEL_LEFT nebo
-// PANEL_RIGHT; pokud nebyl zdroj enumerace nalezen nebo jde o Find okno, vraci FALSE
+// returns TRUE when the enumeration source is a panel and 'panel' receives
+// PANEL_LEFT or PANEL_RIGHT; returns FALSE if the source cannot be found or it
+// is a Find window
 BOOL IsFileEnumSourcePanel(int srcUID, int* panel);
 
-// vraci dalsi jmeno souboru pro viewer ze zdroje (levy/pravy panel nebo Findy);
-// 'srcUID' je unikatni identifikator zdroje (predava se jako parametr pri otevirani
-// vieweru); 'lastFileIndex' (nesmi byt NULL) je IN/OUT parametr, ktery by plugin mel
-// menit jen pokud chce vratit jmeno prvniho souboru, v tomto pripade nastavit 'lastFileIndex'
-// na -1; pocatecni hodnota 'lastFileIndex' se predava jako parametr pri otevirani
-// vieweru; 'lastFileName' je plne jmeno aktualniho souboru (prazdny retezec pokud neni
-// zname, napr. je-li 'lastFileIndex' -1); je-li 'preferSelected' TRUE a aspon jedno
-// jmeno oznacene, budou se vracet oznacena jmena; je-li 'onlyAssociatedExtensions'
-// TRUE, vraci jen soubory s priponou asociovanou s viewerem tohoto pluginu (F3 na tomto
-// souboru by se pokusilo otevrit viewer tohoto pluginu + ignoruje pripadne zastineni
-// viewerem jineho pluginu); 'fileName' je buffer pro ziskane jmeno (velikost alespon
-// MAX_PATH); vraci TRUE pokud se podari jmeno ziskat; vraci FALSE pri chybe: zadne
-// dalsi jmeno souboru ve zdroji neni (neni-li 'noMoreFiles' NULL, vraci se v nem TRUE),
-// zdroj je zaneprazdnen (nezpracovava zpravy; neni-li 'srcBusy' NULL, vraci se v nem
-// TRUE), jinak zdroj prestal existovat (zmena cesty v panelu, zmena razeni, atp.)
+// Retrieves the next file name for the viewer from the given source
+// (left/right panel or Find window). 'srcUID' uniquely identifies the source.
+// 'lastFileIndex' is an IN/OUT value used to track the current file and should
+// be set to -1 when requesting the first file. 'lastFileName' contains the full
+// name of the current file (empty if unknown). When 'preferSelected' is TRUE and
+// at least one name is selected, only selected names are returned. If
+// 'onlyAssociatedExtensions' is TRUE, only files associated with this plugin's
+// viewer are returned (ignoring other plugins). 'fileName' receives the next file
+// name (buffer size at least MAX_PATH). The function returns TRUE on success or
+// FALSE on error: no more names (if 'noMoreFiles' is not NULL it becomes TRUE),
+// the source is busy (if 'srcBusy' is not NULL it becomes TRUE), or the source no
+// longer exists (path or sorting changed).
 BOOL GetNextFileNameForViewer(int srcUID, int* lastFileIndex, const char* lastFileName,
                               BOOL preferSelected, BOOL onlyAssociatedExtensions,
                               char* fileName, BOOL* noMoreFiles, BOOL* srcBusy,
                               CPluginInterfaceAbstract* plugin);
 
-// vraci predchozi jmeno souboru pro viewer ze zdroje (levy/pravy panel nebo Findy);
-// 'srcUID' je unikatni identifikator zdroje (predava se jako parametr pri otevirani
-// vieweru); 'lastFileIndex' (nesmi byt NULL) je IN/OUT parametr, ktery by plugin mel
-// menit jen pokud chce vratit jmeno posledniho souboru, v tomto pripade nastavit 'lastFileIndex'
-// na -1; pocatecni hodnota 'lastFileIndex' se predava jako parametr pri otevirani
-// vieweru; 'lastFileName' je plne jmeno aktualniho souboru (prazdny retezec pokud neni
-// zname, napr. je-li 'lastFileIndex' -1); je-li 'preferSelected' TRUE a aspon jedno
-// jmeno oznacene, budou se vracet oznacena jmena; je-li 'onlyAssociatedExtensions' TRUE,
-// vraci jen soubory s priponou asociovanou s viewerem tohoto pluginu (F3 na tomto
-// souboru by se pokusilo otevrit viewer tohoto pluginu + ignoruje pripadne zastineni
-// viewerem jineho pluginu); 'fileName' je buffer pro ziskane jmeno (velikost alespon
-// MAX_PATH); vraci TRUE pokud se podari jmeno ziskat; vraci FALSE pri chybe: zadne
-// predchozi jmeno souboru ve zdroji neni (neni-li 'noMoreFiles' NULL, vraci se v nem
-// TRUE), zdroj je zaneprazdnen (nezpracovava zpravy; neni-li 'srcBusy' NULL, vraci
-// se v nem TRUE), jinak zdroj prestal existovat (zmena cesty v panelu, zmena
-// razeni, atp.)
+// Retrieves the previous file name for the viewer from the given source.
+// Usage and return values are equivalent to GetNextFileNameForViewer but walk
+// backwards through the list of files.
 BOOL GetPreviousFileNameForViewer(int srcUID, int* lastFileIndex, const char* lastFileName,
                                   BOOL preferSelected, BOOL onlyAssociatedExtensions,
                                   char* fileName, BOOL* noMoreFiles, BOOL* srcBusy,
                                   CPluginInterfaceAbstract* plugin);
 
-// zjisti, jestli je aktualni soubor z vieweru oznaceny (selected) ve zdroji (levy/pravy
-// panel nebo Findy); 'srcUID' je unikatni identifikator zdroje (predava se jako parametr
-// pri otevirani vieweru); 'lastFileIndex' je parametr, ktery by plugin nemel menit,
-// pocatecni hodnota 'lastFileIndex' se predava jako parametr pri otevirani vieweru;
-// 'lastFileName' je plne jmeno aktualniho souboru; vraci TRUE pokud se podarilo zjistit,
-// jestli je aktialni soubor oznaceny, vysledek je v 'isFileSelected' (nesmi byt NULL);
-// vraci FALSE pri chybe: zdroj prestal existovat (zmena cesty v panelu, atp.) nebo soubor
-// 'lastFileName' uz ve zdroji neni (pri techto dvou chybach, neni-li 'srcBusy' NULL,
-// vraci se v nem FALSE), zdroj je zaneprazdnen (nezpracovava zpravy; pri teto chybe,
-// neni-li 'srcBusy' NULL, vraci se v nem TRUE)
+// Checks whether the current viewer file is selected in the source (left/right
+// panel or Find window). 'srcUID' uniquely identifies the source. 'lastFileIndex'
+// should not be modified by the plugin except when requesting the last file
+// (set it to -1). 'lastFileName' is the full name of the current file. Returns
+// TRUE on success and stores the result in 'isFileSelected' (must not be NULL).
+// Returns FALSE if the source no longer exists or the file is missing (and sets
+// 'srcBusy' to FALSE if provided) or if the source is busy processing messages
+// (sets 'srcBusy' to TRUE).
 BOOL IsFileNameForViewerSelected(int srcUID, int lastFileIndex, const char* lastFileName,
                                  BOOL* isFileSelected, BOOL* srcBusy);
 
-// nastavi oznaceni (selectionu) na aktualnim souboru z vieweru ve zdroji (levy/pravy
-// panel nebo Findy); 'srcUID' je unikatni identifikator zdroje (predava se jako parametr
-// pri otevirani vieweru); 'lastFileIndex' je parametr, ktery by plugin nemel menit,
-// pocatecni hodnota 'lastFileIndex' se predava jako parametr pri otevirani vieweru;
-// 'lastFileName' je plne jmeno aktualniho souboru; 'select' je TRUE/FALSE pokud se ma
-// aktualni soubor oznacit/odznacit; vraci TRUE pri uspechu; vraci FALSE pri chybe:
-// zdroj prestal existovat (zmena cesty v panelu, atp.) nebo soubor 'lastFileName' uz
-// ve zdroji neni (pri techto dvou chybach, neni-li 'srcBusy' NULL, vraci se v nem FALSE),
-// zdroj je zaneprazdnen (nezpracovava zpravy; pri teto chybe, neni-li 'srcBusy' NULL,
-// vraci se v nem TRUE)
+// Sets or clears the selection state of the current viewer file in the source
+// (left/right panel or Find window). Parameters match
+// IsFileNameForViewerSelected. Returns TRUE on success or FALSE if the source no
+// longer exists, the file is missing, or the source is busy. When FALSE is
+// returned 'srcBusy' indicates whether the source was busy.
 BOOL SetSelectionOnFileNameForViewer(int srcUID, int lastFileIndex, const char* lastFileName,
                                      BOOL select, BOOL* srcBusy);
 
-// zmeni zdroji (panelu nebo Findu) UID (negeneruje nove, aktualizuje pole
-// FileNamesEnumSources a vrati nove UID v 'srcUID')
+// Changes the UID assigned to a source panel or Find window without generating
+// a new one. The FileNamesEnumSources array is updated and the new UID is
+// returned in 'srcUID'.
 void EnumFileNamesChangeSourceUID(HWND hWnd, int* srcUID);
 
-// prida zdroji (panelu nebo Findu) UID (negeneruje nove, prida dvojici
-// hWnd+UID do pole FileNamesEnumSources a vrati nove UID v 'srcUID')
+// Adds a source to FileNamesEnumSources without creating a new UID. The pair
+// hWnd+UID is stored and the new UID is returned in 'srcUID'.
 void EnumFileNamesAddSourceUID(HWND hWnd, int* srcUID);
 
-// vyradi zdroj (panelu nebo Findu) z pole FileNamesEnumSources
+// Removes the specified source from FileNamesEnumSources
 void EnumFileNamesRemoveSourceUID(HWND hWnd);
 
 //******************************************************************************
-// neblokujici cteni volume-name CD drivu
+// non-blocking reading of the volume name of a CD drive
 
-extern CRITICAL_SECTION ReadCDVolNameCS;   // kriticka sekce pro pristup k datum
-extern UINT_PTR ReadCDVolNameReqUID;       // UID pozadavku (pro rozpoznani jestli na vysledek jeste nekdo ceka)
+extern CRITICAL_SECTION ReadCDVolNameCS;   // critical section for access to data
+extern UINT_PTR ReadCDVolNameReqUID;       // request UID (to detect if someone still waits for the result)
 extern char ReadCDVolNameBuffer[MAX_PATH]; // IN/OUT buffer (root/volume_name)
 
 //******************************************************************************
-// funkce pro praci s historiemi posledne pouzitych hodnot v comboboxech
+// functions for handling histories of recently used values in combo boxes
 
-// prida do sdilene historie ('historyArr'+'historyItemsCount') naalokovanou kopii
-// nove hodnoty 'value'; je-li 'caseSensitiveValue' TRUE, hleda se hodnota (retezec)
-// v poli historie pomoci case-sensitive porovnani (FALSE = case-insensitive porovnani),
-// nalezena hodnota se pouze presouva na prvni misto v poli historie
+// adds an allocated copy of the new value 'value' to the shared history ('historyArr'+'historyItemsCount');
+// if 'caseSensitiveValue' is TRUE the value is looked up in the history using a case-sensitive comparison
+// (FALSE = case-insensitive); when found, the existing value is just moved to the first position
 void AddValueToStdHistoryValues(char** historyArr, int historyItemsCount,
                                 const char* value, BOOL caseSensitiveValue);
 
-// prida do comboboxu ('combo') texty ze sdilene historie ('historyArr'+'historyItemsCount');
-// pred pridavanim provede reset obsahu comboboxu (viz CB_RESETCONTENT)
+// adds the texts from the shared history ('historyArr'+'historyItemsCount') to the combo box 'combo';
+// before adding it resets the combo box content (see CB_RESETCONTENT)
 void LoadComboFromStdHistoryValues(HWND combo, char** historyArr, int historyItemsCount);
 
 //******************************************************************************
 
-// funkce pro pridani vsech dosud neznamych aktivnich (naloadenych) modulu procesu
+// function for adding all yet unknown loaded modules of the process
 void AddNewlyLoadedModulesToGlobalModulesStore();
 
 //******************************************************************************
 
-// quicksort s porovnavanim pres StrICmp
+// quicksort using StrICmp for comparisons
 void SortNames(char* files[], int left, int right);
 
-// hleda retezec 'name' v poli 'usedNames' (pole je serazene pomoci StrICmp);
-// vraci TRUE pri nalezeni + nalezeny index v 'index' (neni-li NULL); vraci
-// FALSE pokud prvek nebyl nalezen + index pro vlozeni v 'index' (neni-li NULL)
+// searches for the string 'name' in the 'usedNames' array (sorted via StrICmp);
+// returns TRUE when found and the found index in 'index' (if not NULL); returns
+// FALSE when the item is missing and provides the insertion index in 'index' (if not NULL)
 BOOL ContainsString(TIndirectArray<char>* usedNames, const char* name, int* index = NULL);
 
 //******************************************************************************
 
-// v pripade uspechu vrati TRUE a cestu na "Documents", pripadne na "Desktop"
-// v pripade neuspechu vrati FALSE
-// 'pathLen' udava velikost bufferu 'path'; funkce zajisti terminovani retezce i v
-// pripade zkraceni
+// returns TRUE on success and stores the path to "Documents" or "Desktop"
+// returns FALSE on failure
+// 'pathLen' specifies the size of the 'path' buffer; the function ensures the
+// string is null-terminated even if truncated
 BOOL GetMyDocumentsOrDesktopPath(char* path, int pathLen);
 
 // To optimize performance, it is good practice for applications to detect whether they
@@ -2285,30 +2299,30 @@ BOOL GetMyDocumentsOrDesktopPath(char* path, int pathLen);
 // application is running on the console.
 BOOL IsRemoteSession(void);
 
-// vraci TRUE, pokud je uzivatel mezi Administratory
-// v pripade chyby vraci FALSE
+// returns TRUE if the user is a member of the Administrators group
+// returns FALSE on error
 BOOL IsUserAdmin();
 
 //******************************************************************************
 
-// pro zajisteni uniku z odstranenych drivu na fixed drive (po vysunuti device - USB flash disk, atd.)
-extern BOOL ChangeLeftPanelToFixedWhenIdleInProgress; // TRUE = prave se meni cesta, nastaveni ChangeLeftPanelToFixedWhenIdle na TRUE je zbytecne
+// ensures we escape from removed drives to a fixed drive (after ejecting a device such as a USB flash disk)
+extern BOOL ChangeLeftPanelToFixedWhenIdleInProgress; // TRUE when the path is currently being changed; setting ChangeLeftPanelToFixedWhenIdle to TRUE is unnecessary
 extern BOOL ChangeLeftPanelToFixedWhenIdle;
-extern BOOL ChangeRightPanelToFixedWhenIdleInProgress; // TRUE = prave se meni cesta, nastaveni ChangeRightPanelToFixedWhenIdle na TRUE je zbytecne
+extern BOOL ChangeRightPanelToFixedWhenIdleInProgress; // TRUE when the path is currently being changed; setting ChangeRightPanelToFixedWhenIdle to TRUE is unnecessary
 extern BOOL ChangeRightPanelToFixedWhenIdle;
-extern BOOL OpenCfgToChangeIfPathIsInaccessibleGoTo; // TRUE = v idle otevre konfiguraci na Drives a focusne "If path in panel is inaccessible, go to:"
+extern BOOL OpenCfgToChangeIfPathIsInaccessibleGoTo; // TRUE = open configuration on Drives during idle and focus "If path in panel is inaccessible, go to:"
 
-// root drivu (i UNC), pro ktery je zobrazen messagebox "drive not ready" s Retry+Cancel
-// tlacitky (pouziva se pro automaticke Retry po vlozeni media do drivu)
+// drive root (including UNC) for which the "drive not ready" message box with Retry+Cancel buttons is shown
+// used for automatic Retry after inserting media into the drive
 extern char CheckPathRootWithRetryMsgBox[MAX_PATH];
-// dialog "drive not ready" s Retry+Cancel tlacitky (pouziva se pro automaticke Retry po
-// vlozeni media do drivu)
+// dialog "drive not ready" with Retry+Cancel buttons (used for automatic Retry after
+// inserting media into the drive)
 extern HWND LastDriveSelectErrDlgHWnd;
 
 // GetDriveFormFactor returns the drive form factor.
 //  It returns 350 if the drive is a 3.5" floppy drive.
 //  It returns 525 if the drive is a 5.25" floppy drive.
-//  It returns 800 if the drive is a 8" floppy drive.
+//  It returns 800 if the drive is an 8" floppy drive.
 //  It returns   1 if the drive supports removable media other than 3.5", 5.25", and 8" floppies.
 //  It returns   0 on error.
 //  iDrive is 1 for drive A:, 2 for drive B:, etc.
@@ -2316,44 +2330,43 @@ DWORD GetDriveFormFactor(int iDrive);
 
 //******************************************************************************
 
-// seradi pole pluginu podle PluginFSCreateTime (pro zobrazeni v Alt+F1/F2 a Disconnect dialogu)
+// sorts the array of plugins by PluginFSCreateTime (for display in Alt+F1/F2 and the Disconnect dialog)
 void SortPluginFSTimes(CPluginFSInterfaceEncapsulation** list, int left, int right);
 
-// vraci poradove cislo pro text polozky do change drive menu a Disconnect dialog;
-// viz CPluginFSInterfaceEncapsulation::ChngDrvDuplicateItemIndex
+// returns the index for the item text in the Change Drive menu and Disconnect dialog;
+// see CPluginFSInterfaceEncapsulation::ChngDrvDuplicateItemIndex
 int GetIndexForDrvText(CPluginFSInterfaceEncapsulation** fsList, int count,
                        CPluginFSInterfaceAbstract* fsIface, int currentIndex);
 
 //******************************************************************************
 
-// pomoci TweakUI si mohou uzivatele menit ikonku shortcuty (default, custom, zadna)
-// tato funkce vytahne HShortcutOverlayXX
-// existujici zahodi
+// using TweakUI users can change the shortcut icon (default, custom or none)
+// this function obtains HShortcutOverlayXX and discards any existing one
 BOOL GetShortcutOverlay();
 
-// vraci textovou podobou 'hotKey' (LOBYTE=vk, HIBYTE=mods), 'buff' musi mit nejmene 50 znaku
+// returns a textual representation of 'hotKey' (LOBYTE=vk, HIBYTE=mods); 'buff' must have at least 50 characters
 void GetHotKeyText(WORD hotKey, char* buff);
 
-// vraci bits per pixel displeje
+// returns the display bits per pixel
 int GetCurrentBPP(HDC hDC = NULL);
 
-// iteruje pres parenty smerem k tomu nejparentovanejsimu
+// iterates through parents up to the topmost one
 HWND GetTopLevelParent(HWND hWindow);
 
 //******************************************************************************
 
-// promenne pouzite behem ukladani konfigurace pri shutdownu, log-offu nebo restartu (musime
-// pumpovat zpravy, aby nas system nesestrelil jako "not responding" softik)
+// variables used while saving the configuration during shutdown, logoff, or restart
+// we must pump messages so the system does not kill us as a "not responding" application
 class CWaitWindow;
-extern CWaitWindow* GlobalSaveWaitWindow; // pokud existuje globalni wait okenko pro Save, je zde (jinak je zde NULL)
-extern int GlobalSaveWaitWindowProgress;  // aktualni hodnota progresu globalniho wait okenka pro Save
+extern CWaitWindow* GlobalSaveWaitWindow; // if a global wait window for Save exists, it is stored here (otherwise NULL)
+extern int GlobalSaveWaitWindowProgress;  // current progress value of the global wait window for Save
 
-extern BOOL IsSetSALAMANDER_SAVE_IN_PROGRESS; // TRUE = v registry je vytvorena hodnota SALAMANDER_SAVE_IN_PROGRESS (detekce preruseni ukladani konfigurace)
+extern BOOL IsSetSALAMANDER_SAVE_IN_PROGRESS; // TRUE if the SALAMANDER_SAVE_IN_PROGRESS value exists in the registry (used to detect interrupted configuration saving)
 
 //******************************************************************************
 
-// podpurna struktura a funkce pro otevreni kontextoveho menu + spousteni jeho polozek
-// v CSalamanderGeneral::OpenNetworkContextMenu()
+// helper structure and functions for opening a context menu and executing its items
+// in CSalamanderGeneral::OpenNetworkContextMenu()
 
 struct CTmpEnumData
 {
@@ -2369,70 +2382,70 @@ void ShellActionAux6(CFilesWindow* panel);
 
 //******************************************************************************
 
-// vraci v 'path' (buffer aspon MAX_PATH znaku) cestu Configuration.IfPathIsInaccessibleGoTo;
-// zohlednuje nastaveni Configuration.IfPathIsInaccessibleGoToIsMyDocs
+// returns in 'path' (buffer at least MAX_PATH characters) the path Configuration.IfPathIsInaccessibleGoTo;
+// respects the setting Configuration.IfPathIsInaccessibleGoToIsMyDocs
 void GetIfPathIsInaccessibleGoTo(char* path, BOOL forceIsMyDocs = FALSE);
 
-// nacte z konfigurace v registry konfiguraci icon overlay handleru
+// loads icon overlay handler configuration from the registry
 void LoadIconOvrlsInfo(const char* root);
 
-// vraci TRUE pokud je icon overlay handler zakazany (nebo jsou zakazane vsechny)
+// returns TRUE if the icon overlay handler is disabled (or if all icon overlay handlers are disabled)
 BOOL IsDisabledCustomIconOverlays(const char* name);
 
-// vraci TRUE pokud je icon overlay handler v seznamu zakazanych icon overlay handleru
+// returns TRUE if the icon overlay handler is in the list of disabled icon overlay handlers
 BOOL IsNameInListOfDisabledCustomIconOverlays(const char* name);
 
-// vycisti seznam zakazanych icon overlay handleru
+// clears the list of disabled icon overlay handlers
 void ClearListOfDisabledCustomIconOverlays();
 
-// prida 'name' do seznamu zakazanych icon overlay handleru
+// adds 'name' to the list of disabled icon overlay handlers
 BOOL AddToListOfDisabledCustomIconOverlays(const char* name);
 
-// nacte ikonu z ImageResDLL
+// loads an icon from ImageResDLL
 HICON SalLoadImage(int vistaResID, int otherResID, int cx, int cy, UINT flags);
 
-// nacte ikonu pro archivy
+// loads an icon for archives
 HICON LoadArchiveIcon(int cx, int cy, UINT flags);
 
-// ziska login pro zadanou sitovou cestu, pripadne obnovi jeji mapovani
+// obtains login credentials for the given network path and optionally restores its mapping
 BOOL RestoreNetworkConnection(HWND parent, const char* name, const char* remoteName, DWORD* retErr = NULL,
                               LPNETRESOURCE lpNetResource = NULL);
 
-// sestavi text do sloupce Type v panelu pro neasociovany soubor (napr. "AAA File" nebo "File")
+// builds the text for the Type column in the panel for an unassociated file (e.g. "AAA File" or "File")
 void GetCommonFileTypeStr(char* buf, int* resLen, const char* ext);
 
-// najde zdvojene separatory a vymaze ty nadbytecne (na Viste se mi objevily zdvojene
-// separatory v kontextovem menu na .bar souborech)
+// finds duplicate separators and removes the redundant ones (on Vista duplicate
+// separators appeared in the context menu on .bar files)
 void RemoveUselessSeparatorsFromMenu(HMENU h);
 
-// vraci adresar "Open Salamander" na ceste CSIDL_APPDATA do 'buf' (buffer o velikosti MAX_PATH)
+// returns the "Open Salamander" directory in the CSIDL_APPDATA path in 'buf' (buffer of size MAX_PATH)
 BOOL GetOurPathInRoamingAPPDATA(char* buf);
 
-// vytvori adresar "Open Salamander" na ceste CSIDL_APPDATA; vraci TRUE pokud se cesta
-// vejde do MAX_PATH (jeji existence neni zarucena, vysledek CreateDirectory se nekontroluje);
-// neni-li 'buf' NULL, jde o buffer o velikosti MAX_PATH, ve kterem se vraci tato cesta
-// POZOR: pouziti jen Vista+
+// creates the "Open Salamander" directory in the CSIDL_APPDATA path; returns TRUE if the path
+// fits into MAX_PATH (its existence is not guaranteed and the result of CreateDirectory is not checked);
+// if 'buf' is not NULL it is a buffer of size MAX_PATH that receives this path
+// NOTE: Vista+ only
 BOOL CreateOurPathInRoamingAPPDATA(char* buf);
 
 #ifndef _WIN64
 
-// jen 32-bitova verze pod jen Win64: zjistuje jestli jde o cestu, kterou redirector presmeruje do
-// SysWOW64 nebo naopak zpet do System32
+// 32-bit version on Win64 only: checks whether the path is redirected by the
+// file system redirector to SysWOW64 or back to System32
 BOOL IsWin64RedirectedDir(const char* path, char** lastSubDir, BOOL failIfDirWithSameNameExists);
 
-// jen 32-bitova verze pod Win64: zjistuje jestli selectiona obsahuje pseudo-adresar, ktery redirector
-// presmeruje do SysWOW64 nebo naopak zpet do System32 a zaroven na disku neexistuje stejne pojmenovany
-// adresar (pseudo-adresar pridany jen na zaklade AddWin64RedirectedDir)
+// 32-bit build on Win64 only: tests whether the selection contains a pseudo
+// directory that the redirector sends to SysWOW64 or back to System32 while no
+// real directory with the same name exists on disk (pseudo-directories are
+// added only via AddWin64RedirectedDir)
 BOOL ContainsWin64RedirectedDir(CFilesWindow* panel, int* indexes, int count, char* redirectedDir,
                                 BOOL onlyAdded);
 
 #endif // _WIN64
 
-// nase varianty funkci RegQueryValue a RegQueryValueEx, narozdil od API variant
-// zajistuji pridani null-terminatoru pro typy REG_SZ, REG_MULTI_SZ a REG_EXPAND_SZ
-// POZOR: pri zjistovani potrebne velikosti bufferu vraci o jeden nebo dva (dva
-//        jen u REG_MULTI_SZ) znaky vic pro pripad, ze by string bylo potreba
-//        zakoncit nulou/nulami
+// our variants of RegQueryValue and RegQueryValueEx add a null terminator for
+// REG_SZ, REG_MULTI_SZ and REG_EXPAND_SZ values unlike their API counterparts.
+// WARNING: when calculating the required buffer size they return one extra
+// character (two for REG_MULTI_SZ) in case the string needs terminating nulls
 extern "C"
 {
     LONG SalRegQueryValue(HKEY hKey, LPCSTR lpSubKey, LPSTR lpData, PLONG lpcbData);
@@ -2440,16 +2453,17 @@ extern "C"
                             LPDWORD lpType, LPBYTE lpData, LPDWORD lpcbData);
 }
 
-// Win7 a novejsi OS - notifikace od taskbar, ze doslo k vytvoreni tlacitka pro okno
-// nastavuje se pri startu Salamandera, testovat zda je nenulova
+// Notification from the taskbar on Win7 and newer that a button was created for
+// our window. Set at startup, check that it is non-zero
 extern UINT TaskbarBtnCreatedMsg;
 
-// vrati rozmer ikony s ohledem na promennou SystemDPI
-// pokud je 'large' TRUE, vraci rozmer pro velkou ikonu, jinak pro malou
+// returns the icon size with respect to SystemDPI
+// if 'large' is TRUE returns the size for a large icon, otherwise for a small one
 int GetIconSizeForSystemDPI(CIconSizeEnum iconSize);
 
-// vraci aktualni systemove DPI (96, 120, 144, ...)
+// returns the current system DPI (96, 120, 144, ...)
 int GetSystemDPI();
 
-// vraci scale odpovidajici aktualnimu DPI; misto 1.0 vraci 100, pro 1.25 vraci 125, atd
+// returns the scale corresponding to the current DPI; instead of 1.0 returns
+// 100, for 1.25 returns 125, etc.
 int GetScaleForSystemDPI();


### PR DESCRIPTION
This PR brings the translated `src/consts.h` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/consts.h`.
