### PR TITLE
[translation] Initial src/keyboard.cpp comments translation

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -986,12 +987,12 @@ BOOL IsSalHotKey(WORD hotKey)
         break;
     }
 
-    case 0xDC: // '\'
+    case 0xDC: // '\\'
     {
         switch (mods)
         {
         case NONE:    // quick search/type in command line
-        case CONTROL: // root dir
+        case CONTROL: // go to the root directory
             found = TRUE;
         }
         break;


### PR DESCRIPTION
This PR brings the translated `src/keyboard.cpp` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/keyboard.cpp`.