### PR TITLE
[translation] Initial src/md5.h comments translation

### DIFF
--- a/src/md5.h
+++ b/src/md5.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -8,15 +9,15 @@ class MD5
 
 public:
     // methods for controlled operation:
-    MD5(); // simple initializer
+    MD5(); // default constructor
     void update(unsigned char* input, unsigned int input_length);
     void finalize();
 
 public:
     // first, some types:
-    typedef unsigned int uint4;       // assumes integer is 4 words long
-    typedef unsigned short int uint2; // assumes short integer is 2 words long
-    typedef unsigned char uint1;      // assumes char is 1 word long
+    typedef unsigned int uint4;       // assumes integer is 4 bytes long
+    typedef unsigned short int uint2; // assumes short integer is 2 bytes long
+    typedef unsigned char uint1;      // assumes char is 1 byte long
 
     // next, the private data:
     uint4 state[4];


### PR DESCRIPTION
This PR brings the translated `src/md5.h` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/md5.h`.