### PR TITLE
[translation] Initial src/menu.h comments translation

### DIFF
--- a/src/menu.h
+++ b/src/menu.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
@@ -15,22 +16,22 @@ class CMenuBar;
 class CBitmap;
 
 /*
-Posilane zpravy:
+Sent messages:
   WM_INITMENUPOPUP
     hmenuPopup = (HMENU) wParam;         // handle to submenu
     uPos = (UINT) LOWORD(lParam);        // submenu item position
     fSystemMenu = (BOOL) HIWORD(lParam); // window menu flag
 
-    Tato zprava je posilana pouze v pripade windows menu popupu.
+    This message is sent only for Windows menu popups.
 
   WM_USER_INITMENUPOPUP
   WM_USER_UNINITMENUPOPUP
-    menuPopup = (CGUIMenuPopupAbstract*) wParam; // ukazatel na submenu
+    menuPopup = (CGUIMenuPopupAbstract*) wParam; // pointer to submenu
     uPos =      LOWORD(lParam);                // submenu item position
     uID =       HIWORD(lParam);                // submenu ID
 
-    Tyto dve zpravy jsou posilane vzdy - i pro menu postavene nad windows
-    menu popup.
+    These two messages are always sent, even for menus implemented
+    on top of a Windows popup.
 */
 
 //*****************************************************************************
@@ -42,16 +43,16 @@ class CMenuWindowQueue
 {
 private:
     TDirectArray<HWND> Data;
-    CRITICAL_SECTION DataCriticalSection; // kriticka sekce pro pristup k datum
+    CRITICAL_SECTION DataCriticalSection; // critical section for data access
     BOOL UsingData;
 
 public:
     CMenuWindowQueue();
     ~CMenuWindowQueue();
 
-    BOOL Add(HWND hWindow);    // prida polozku do fronty, vraci uspech
-    void Remove(HWND hWindow); // odstrani polozku z fronty
-    void DispatchCloseMenu();  // posle vsem otevrenym oknum menu zpravu WM_USER_CLOSEMENU
+    BOOL Add(HWND hWindow);    // adds an item to the queue, returns success
+    void Remove(HWND hWindow); // removes an item from the queue
+    void DispatchCloseMenu();  // sends WM_USER_CLOSEMENU to all open menu windows
 };
 
 extern CMenuWindowQueue MenuWindowQueue;
@@ -77,15 +78,15 @@ extern COldMenuHookTlsAllocator OldMenuHookTlsAllocator;
 //
 // CMenuSharedResources
 //
-// Pro jeden strom sub menu existuje pouze jedna instance techto prostredku.
-// Jsou zalozeny napriklad ve funkci Track.
-// Vsechny sub menu pak pouze dostavaji ukazatel na tyto sdilene prostredky.
+// Only one instance of these resources exists for a given submenu tree.
+// They are created for example in the Track function.
+// All submenus then simply receive a pointer to these shared resources.
 //
 
 class CMenuSharedResources
 {
 public:
-    // barvy
+    // colors
     COLORREF NormalBkColor;
     COLORREF SelectedBkColor;
     COLORREF NormalTextColor;
@@ -98,30 +99,30 @@ public:
     CBitmap* MonoBitmap;
 
     // temp DC
-    HDC HTempMemDC;  // memory dc pro docasne presuny
-    HDC HTemp2MemDC; // memory dc pro docasne presuny
+    HDC HTempMemDC;  // memory DC for temporary transfers
+    HDC HTemp2MemDC; // memory DC for temporary transfers
 
     // fonts
-    HFONT HNormalFont; // prubezne je vybran v HCacheMemoryDC
-    HFONT HBoldFont;   // je vybiran pouze docasne
+    HFONT HNormalFont; // continuously selected in HCacheMemoryDC
+    HFONT HBoldFont;   // selected only temporarily
 
     // menu bitmaps
-    HBITMAP HMenuBitmaps; // vytazeno ze systemu: poradi dle CMenuBitmapEnum
+    HBITMAP HMenuBitmaps; // retrieved from the system: order according to CMenuBitmapEnum
     int MenuBitmapWidth;
 
     // other
-    HWND HParent;          // okno, ze ktereho bylo menu vyvolano
-    int TextItemHeight;    // vyska polozky z textu
-    BOOL BitmapsZoom;      // nasobek puvodni velikost bitmap
-    DWORD ChangeTickCount; // hodnota GetTickCount z doby, kdy doslo ke zmene vybrane polozky
+    HWND HParent;          // window from which the menu was invoked
+    int TextItemHeight;    // item height based on text
+    BOOL BitmapsZoom;      // bitmap scaling relative to the original size
+    DWORD ChangeTickCount; // GetTickCount value from the time the selected item changed
     POINT LastMouseMove;
-    CMenuBar* MenuBar; // okno je aktivovano z MenuBar; jinak je rovno NULL
-    DWORD SkillLevel;  // honodta pro retezec popupu -- urcuje, kerer itemy budou zobrazeny
-    BOOL HideAccel;    // maji se skryt akceleratory
+    CMenuBar* MenuBar; // MenuBar from which the window was activated; otherwise NULL
+    DWORD SkillLevel;  // value determining which items will be displayed
+    BOOL HideAccel;    // should accelerators be hidden
 
-    const RECT* ExcludeRect; // tento obdelnik nesmime prekryt
+    const RECT* ExcludeRect; // this rectangle must not be covered
 
-    HANDLE HCloseEvent; // slouzi pro rozbehnuti message queue
+    HANDLE HCloseEvent; // used to start the message queue
 
 public:
     CMenuSharedResources();
@@ -151,28 +152,28 @@ protected:
     HICON HOverlay;
     ULONG_PTR CustomData;
     DWORD SkillLevel; // MENU_LEVEL_BEGINNER, MENU_LEVEL_INTERMEDIATE, MENU_LEVEL_ADVANCED
-    // tyto hodnoty se pouzivaji pro optimalizovany pristup je stavum polozek
-    DWORD* Enabler; // Ukazuje na promennou, ktera ridi stav polozky.
-                    // Hodnote ruzne od nuly odpovida nulovany bit MENU_STATE_GRAYED.
-                    // Nule odpovida nastaveny bit MENU_STATE_GRAYED.
+    // these values are used for optimized access to item states
+    DWORD* Enabler; // Points to a variable controlling the state of the item.
+                    // A nonzero value corresponds to the MENU_STATE_GRAYED bit cleared.
+                    // Zero corresponds to the MENU_STATE_GRAYED bit set.
     DWORD Flags;    // MENU_FLAG_xxx
-    DWORD Temp;     // pomocna promenna pro nektere metody
+    DWORD Temp;     // helper variable for some methods
 
-    // vypocitane hodnoty
+    // calculated values
     int Height;
     int MinWidth;
     int YOffset;
 
-    const char* ColumnL1; // text prvniho sloupce
-    int ColumnL1Len;      // pocet znaku
+    const char* ColumnL1; // text of the first column
+    int ColumnL1Len;      // number of characters
     int ColumnL1Width;
     int ColumnL1X;
-    const char* ColumnL2; // text druheho sloupce (muze byt rovno NULL)
-    int ColumnL2Len;      // pocet znaku
+    const char* ColumnL2; // text of the second column (can be NULL)
+    int ColumnL2Len;      // number of characters
     int ColumnL2Width;
     int ColumnL2X;
-    const char* ColumnR; // text praveho sloupce (muze byt rovno NULL)
-    int ColumnRLen;      // pocet znaku
+    const char* ColumnR; // text of the right column (can be NULL)
+    int ColumnRLen;      // number of characters
     int ColumnRWidth;
     int ColumnRX;
 
@@ -182,8 +183,8 @@ public:
 
     BOOL SetText(const char* text, int len = -1);
 
-    // projede retezec TypeData a podle oddelovacu a promenne threeCol
-    // nastavi promenne ColumnL1 - ColumnR, ColumnL1Len - ColumnRLen,
+    // walks through the TypeData string and according to separators and the threeCol variable
+    // sets the variables ColumnL1 - ColumnR, ColumnL1Len - ColumnRLen,
     // ColumnL1Width - ColumnRWidth
     void DecodeSubTextLenghtsAndWidths(CMenuSharedResources* sharedRes, BOOL threeCol);
 
@@ -206,30 +207,28 @@ enum CMenuBitmapEnum
 
 enum CMenuPopupHittestEnum
 {
-    mphItem,            // na polozce, userData = index polozky
-    mphUpArrow,         // na sipce Up
-    mphDownArrow,       // na sipce Down
-    mphBorderOrOutside, // na ramecku nebo mimo
-    //  mphOutside, // mimo okno
+    mphItem,            // on an item, userData = item index
+    mphUpArrow,         // on the Up arrow
+    mphDownArrow,       // on the Down arrow
+    mphBorderOrOutside, // on the border or outside
+    //  mphOutside, // outside the window
 };
 
 /*
 Items
-  Seznam polozek obsazenych v pop-up menu.
+  List of items contained in the pop-up menu.
 
 HParent
-  Okno, kteremu se budou dorucovat notifikacni message.
+  Window that receives notification messages.
 
 HImageList
-  Ikonky zobrazovane pred polozkama. Ikona je urcovana promennou
-  CMenuItem::ImageIndex.
+  Icons displayed before items. The icon is chosen by CMenuItem::ImageIndex.
 
 HWindowsMenu
-  Handle windowsackeho popup menu. Pred otevrenim tohoto submenu
-  se provede enumerace jeho polozek. Ty jsou pak transformovany do docasneho
-  objetku CMenuPopup. Po zavreni tohoto submenu je docasny objekt zrusen.
-  Pro takove menu jsou posilany notifikacni message WM_INITPOPUP, WM_DRAWITEM
-  a WM_MEASUREITEM.
+  Handle of the Windows popup menu. Before opening this submenu its items are
+  enumerated and transformed into a temporary CMenuPopup object. After the
+  submenu is closed the temporary object is destroyed. Notifications
+  WM_INITPOPUP, WM_DRAWITEM and WM_MEASUREITEM are sent for such menus.
 */
 
 class CMenuPopup : public CWindow, public CGUIMenuPopupAbstract
@@ -239,46 +238,46 @@ protected:
     HMENU HWindowsMenu;
 
     RECT WindowRect;
-    int TotalHeight; // celkova vyska menu; nemusi byt cela zobrazena
-    int Width;       // rozmery client area
+    int TotalHeight; // total menu height; it may not be fully visible
+    int Width;       // dimensions of the client area
     int Height;
-    int TopItemY;           // y souradnice prvni polozky
-    BOOL UpArrowVisible;    // je zobrazena sipka nahoru?
-    BOOL UpDownTimerRunnig; // bezi nam timer?
-    BOOL DownArrowVisible;  // je zobrazena sipka dolu?
+    int TopItemY;           // y-coordinate of the first item
+    BOOL UpArrowVisible;    // is the Up arrow displayed?
+    BOOL UpDownTimerRunnig; // is our timer running?
+    BOOL DownArrowVisible;  // is the Down arrow displayed?
     DWORD Style;            // MENU_POPUP_xxxx
     DWORD TrackFlags;       // MENU_TRACK_xxxx
     CMenuSharedResources* SharedRes;
-    CMenuPopup* OpenedSubMenu; // je-li otevreny nejaky submenu, ukazuje na nej
-    CMenuPopup* FirstPopup;    // pokud nejde o prvni okno, ukazuje na nej; v pripade prvniho okna ukazuje na sebe samo
-    int SelectedItemIndex;     // -1 == zadna
+    CMenuPopup* OpenedSubMenu; // if a submenu is open, points to it
+    CMenuPopup* FirstPopup;    // if this is not the first window, points to it; otherwise points to itself
+    int SelectedItemIndex;     // -1 == none
     BOOL SelectedByMouse;      // TRUE->ByMouse FALSE->ByKeyboard
     HIMAGELIST HImageList;
     HIMAGELIST HHotImageList;
-    int ImageWidth; // rozmery jednoho obrazku z HImageList
+    int ImageWidth; // dimensions of one image from HImageList
     int ImageHeight;
-    DWORD ID;                  // kopie ID z CMenuItem
-    BOOL Closing;              // bylo zavolano HideAll a hned jak bude mozne, koncime
-    int MinWidth;              // pri rozvrhovani sirky nebude sirka mensi, nez tato hodnota
-    BOOL ModifyMode;           // pokud je menu zobrazeno, neni mozne nad nim provadet zmeny, neni-li v ModifyMode
-    DWORD SkillLevel;          // urcuje, ktere polozky budou v tomto popupu zobrazeny
+    DWORD ID;                  // copy of ID from CMenuItem
+    BOOL Closing;              // HideAll was called and we finish as soon as possible
+    int MinWidth;              // during layout the width will not be smaller than this value
+    BOOL ModifyMode;           // if the menu is visible, changes are allowed only in ModifyMode
+    DWORD SkillLevel;          // determines which items will be shown in this popup
     int MouseWheelAccumulator; // vertical
 
 public:
     //
-    // Vlastni metody
+    // custom methods
     //
 
     CMenuPopup(DWORD id = 0);
     BOOL LoadFromTemplate2(HINSTANCE hInstance, const MENU_TEMPLATE_ITEM* menuTemplate, DWORD* enablersOffset, HIMAGELIST hImageList, HIMAGELIST hHotImageList, int* addedRows);
 
     //
-    // Implementace metod CGUIMenuPopupAbstract
+    // implementation of CGUIMenuPopupAbstract methods
     //
 
     virtual BOOL WINAPI LoadFromTemplate(HINSTANCE hInstance, const MENU_TEMPLATE_ITEM* menuTemplate, DWORD* enablersOffset, HIMAGELIST hImageList = NULL, HIMAGELIST hHotImageList = NULL);
 
-    virtual void WINAPI SetSelectedItemIndex(int index); // slouzi k prednastaveni vybrane polozky (musi byt nastaven flag MENU_TRACK_SELECT, jinak se nepouzije)
+    virtual void WINAPI SetSelectedItemIndex(int index); // used to preset the selected item (MENU_TRACK_SELECT must be set or it is ignored)
     virtual int WINAPI GetSelectedItemIndex() { return SelectedItemIndex; }
 
     virtual void WINAPI SetTemplateMenu(HMENU hWindowsMenu) { HWindowsMenu = hWindowsMenu; }
@@ -316,12 +315,12 @@ public:
     virtual void WINAPI RemoveAllItems();
     virtual BOOL WINAPI RemoveItemsRange(int firstIndex, int lastIndex);
 
-    // umoznuje provadet zmeny nad otevrenym menu popupem
-    virtual BOOL WINAPI BeginModifyMode(); // zahajeni editacniho rezimu
-    virtual BOOL WINAPI EndModifyMode();   // ukonceni rezimu - menu se prekresli
+    // allows making changes while the menu popup is open
+    virtual BOOL WINAPI BeginModifyMode(); // begins edit mode
+    virtual BOOL WINAPI EndModifyMode();   // ends the mode - the menu is redrawn
 
-    // urci polozky, kter budou v menu zobrazeny
-    // 'skillLevel' muze byt jedna z hodnot MENU_LEVEL_BEGINNER, MENU_LEVEL_INTERMEDIATE a MENU_LEVEL_ADVANCED
+    // determines which items will be displayed in the menu
+    // 'skillLevel' can be MENU_LEVEL_BEGINNER, MENU_LEVEL_INTERMEDIATE or MENU_LEVEL_ADVANCED
     virtual void WINAPI SetSkillLevel(DWORD skillLevel);
 
     // The FindItemPosition method finds a menu item position.
@@ -339,7 +338,7 @@ public:
 
     virtual BOOL WINAPI FillMenuHandle(HMENU hMenu);
     virtual BOOL WINAPI GetStatesFromHWindowsMenu(HMENU hMenu);
-    virtual void WINAPI SetImageList(HIMAGELIST hImageList, BOOL subMenu = FALSE); // pokud je subMenu==TRUE, nastavi se hadle i do submenu
+    virtual void WINAPI SetImageList(HIMAGELIST hImageList, BOOL subMenu = FALSE); // if subMenu==TRUE, the image list handle is also set for submenus
     virtual HIMAGELIST WINAPI GetImageList();
     virtual void WINAPI SetHotImageList(HIMAGELIST hHotImageList, BOOL subMenu = FALSE);
     virtual HIMAGELIST WINAPI GetHotImageList();
@@ -378,11 +377,11 @@ public:
     //   is nonzero if the function succeeds and zero if it fails.
     virtual DWORD WINAPI Track(DWORD trackFlags, int x, int y, HWND hwnd, const RECT* exclude);
 
-    virtual BOOL WINAPI GetItemRect(int index, RECT* rect); // vrati obsany obdelnik kolem polozky v screen souradnicich
+    virtual BOOL WINAPI GetItemRect(int index, RECT* rect); // returns bounding rectangle of the item in screen coordinates
 
-    // obehne vsechny polozky a pokud maji nastaveny ukazatel 'EnablerData'
-    // porovnaja hodnotu (na kterou ukazuji) se skutecnym stavem polozky.
-    // Pokud se stav lisi, zmeni ho.
+    // iterates through all items and if they have the 'EnablerData' pointer set
+    // compares the pointed value with the actual item state.
+    // If the state differs, it is updated.
     virtual void WINAPI UpdateItemsState();
 
     virtual void WINAPI SetMinWidth(int minWidth);
@@ -392,28 +391,28 @@ public:
     virtual void WINAPI AssignHotKeys();
 
 protected:
-    void Cleanup(); // inicializuje objekt
+    void Cleanup(); // initializes the object
     BOOL LoadFromHandle();
-    void LayoutColumns(); // probehne polozky a podle jejich rozmeru nastavi hodnoty
+    void LayoutColumns(); // iterates over items and sets values according to their size
     DWORD GetOwnerDrawItemState(const CMenuItem* item, BOOL selected);
-    void DrawCheckBitmapVista(HDC hDC, CMenuItem* item, int yOffset, BOOL selected); // veze s alpha blendem
-    void DrawCheckBitmap(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);      // check marky dodane uzivatelem (HBmpChecked a HBmpUnchecked)
-    void DrawCheckImage(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);       // standardni checkmarky, ImageIndex, HIcon
-    void DrawCheckMark(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);        // vola odpovidajici funkci
-    void DrawItem(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);             // vykresli jednu polozku
-    void DrawUpDownItem(HDC hDC, BOOL up);                                           // vykresli polozku obsahujici sipku nahoru nebo dolu
+    void DrawCheckBitmapVista(HDC hDC, CMenuItem* item, int yOffset, BOOL selected); // Vista version with alpha blend
+    void DrawCheckBitmap(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);      // user-supplied check marks (HBmpChecked and HBmpUnchecked)
+    void DrawCheckImage(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);       // standard check marks, ImageIndex, HIcon
+    void DrawCheckMark(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);        // calls the appropriate function
+    void DrawItem(HDC hDC, CMenuItem* item, int yOffset, BOOL selected);             // draws a single item
+    void DrawUpDownItem(HDC hDC, BOOL up);                                           // draws the item containing the up or down arrow
     CMenuPopupHittestEnum HitTest(const POINT* point, int* userData);
 
     BOOL FindNextItemIndex(int fromIndex, BOOL topToDown, int* index);
-    inline CMenuPopup* FindActivePopup();       // najde posledni otevreny popup; vrati ukazatel na objekt
-    inline CMenuPopup* FindPopup(HWND hWindow); // hleda od nas az po posledniho childa; vrati ukazatel na objekt nnebo NULL
+    inline CMenuPopup* FindActivePopup();       // finds the last opened popup; returns a pointer to the object
+    inline CMenuPopup* FindPopup(HWND hWindow); // searches from this popup down to the last child; returns a pointer to the object or NULL
     inline void DoDispatchMessage(MSG* msg, BOOL* leaveMenu, DWORD* retValue, BOOL* dispatchLater);
     void OnTimerTimeout();
-    void CheckSelectedPath(CMenuPopup* terminator); // probehne celou vetev a nastavi SelectedItemy tak, aby vedly k poslednimu popupu
+    void CheckSelectedPath(CMenuPopup* terminator); // traverses the whole branch and sets SelectedItems so they lead to the last popup
 
-    // k Track pridava [in] menuBar
-    //                 [in] delayedMsg
-    //                 [in] dispatchDelayedMsg: Ma se delayedMsg dorucit po navratu z teto metodu?
+    // Compared to Track, adds [in] menuBar
+    //                    [in] delayedMsg
+    //                    [in] dispatchDelayedMsg: should delayedMsg be delivered after this method returns?
     //
     DWORD TrackInternal(DWORD trackFlags, int x, int y, HWND hwnd, const RECT* exclude,
                         CMenuBar* menuBar, MSG& delayedMsg, BOOL& dispatchDelayedMsg);
@@ -428,32 +427,32 @@ protected:
     void OnChar(char key, BOOL* leaveMenu, DWORD* retValue);
     int FindNextItemIndex(int firstIndex, char key);
 
-    // pro navigaci pomoci PgDn/PgUp, hleda index prvni polozky
-    // za separatorem; pokud je 'down' TRUE, hleda smerem dolu
-    // od polozky 'firstIndex', jinak smerem nahoru
+    // for navigation using PgDn/PgUp, searches for the index of the first item
+    // after a separator; if 'down' is TRUE it searches downward from 'firstIndex',
+    // otherwise upward
     int FindGroupIndex(int firstIndex, BOOL down);
 
-    // pokud je 'byMouse' TRUE, jde o zmenu pomoci mysi, jinak jde o zmenu z klavesnice
-    // select nastaveny z klavesnice "drzi", pokud uzivatel pohybuje mysi mimo popupy
+    // if 'byMouse' is TRUE, it is a mouse change, otherwise a keyboard change
+    // selection set by keyboard "sticks" while the user moves the mouse outside popups
     void SelectNewItemIndex(int newItemIndex, BOOL byMouse);
 
-    void EnsureItemVisible(int index); // pokud polozka lezi mimo zobrazenou oblast, zajisti
-                                       // odrolovani a vykresleni polozek tak, aby byla cela
-                                       // viditelna
+    void EnsureItemVisible(int index); // if the item lies outside the visible area,
+                                       // scroll and repaint so the item becomes
+                                       // fully visible
 
     void OnMouseWheel(WPARAM wParam, LPARAM lParam);
 
-    // x, y jsou souradnice leveho horniho rohu okna
-    // submenuItemPos slouzi k zaslani notifikace aplikaci
+    // x, y are coordinates of the upper left corner of the window
+    // submenuItemPos is used to send a notification to the application
     BOOL CreatePopupWindow(CMenuPopup* firstPopup, int x, int y, int submenuItemPos, const RECT* exclude);
 
-    // Vrati handle popup window pod kurzorem; pokud je pod kurzorem child window,
-    // bude dohledan jeho parent.
+    // Returns the handle of the popup window under the cursor; if a child window
+    // is under the cursor, its parent is found.
     //
-    // Zavedeno kvuli PicaView, ktere vklada do kontextoveho menu child window,
-    // do ktereho renderuje se spozdenim obrazek. V Salamu 2.0 pri najeti na takovy
-    // obrazek doslo k odvybrani polozky v menu, protoze WindowFromPoint vratilo
-    // jine okno nez popup.
+    // Introduced because of PicaView, which inserts a child window into the context
+    // menu and renders an image there with a delay. In Salamander 2.0 moving the
+    // cursor over such an image deselected the item because WindowFromPoint returned
+    // a window other than the popup.
     HWND PopupWindowFromPoint(POINT point);
 
     void ResetMouseWheelAccumulator() { MouseWheelAccumulator = 0; }
@@ -473,56 +472,57 @@ class CMenuBar : public CWindow, public CGUIMenuBarAbstract
 {
 protected:
     CMenuPopup* Menu;
-    int Width; // rozmery celeho okna
+    int Width; // dimensions of the entire window
     int Height;
     HFONT HFont;
     int FontHeight;
-    int HotIndex;       // polozka, ktera je bud vysunuta nebo zamackla (zadna = -1)
-    HWND HNotifyWindow; // kam budeme dorucovat notifikace
-    BOOL MenuLoop;      // jsou rozbalovana submenu
-    DWORD RetValue;     // ktery command mame poslat do okna aplikace
+    int HotIndex;       // item that is either expanded or pressed (-1 = none)
+    HWND HNotifyWindow; // where notifications will be delivered
+    BOOL MenuLoop;      // are submenus expanded
+    DWORD RetValue;     // which command should be sent to the application window
     MSG DelayedMsg;
     BOOL DispatchDelayedMsg;
-    BOOL HotIndexIsTracked; // je otevren popup pod HotIndex?
+    BOOL HotIndexIsTracked; // is a popup open under HotIndex?
     BOOL HandlingVK_MENU;
     BOOL WheelDuringMenu;
     POINT LastMouseMove;
-    BOOL Closing;        // bylo zavolano WM_USER_CLOSEMENU hned jak bude mozne, koncime
-    HANDLE HCloseEvent;  // slouzi pro rozbehnuti message queue
-    BOOL MouseIsTracked; // je mys sledovana pomoci TrackMouseEvent?
-    BOOL HelpMode;       // jsme v rezimu Context Help (Shift+F1)?
+    BOOL Closing;        // WM_USER_CLOSEMENU was called and we exit as soon as possible
+    HANDLE HCloseEvent;  // used to start the message queue
+    BOOL MouseIsTracked; // is the mouse tracked using TrackMouseEvent?
+    BOOL HelpMode;       // are we in Context Help mode (Shift+F1)?
 
-    // tyto dve promenne slouzi pro kooperaci MenuBar a MenuPopup
-    // jsou nastavovany v CMenuPopup::TrackInternal a urcuji dalsi chovani
-    // MenuBar po zavreni Popupu
-    int IndexToOpen;     // pokud bude nastavena na -1, nema se otevrit dalsi Popup,
-                         // jinak obsahuje index popupu, ktery se ma otevrit
-    BOOL OpenWithSelect; // ma se v otevrenem menu vybrat prvni polozka?
-    BOOL OpenByMouse;    // otevirano pomoci mysi nebo klavesnice?
-    BOOL ExitMenuLoop;   // Pokud je TRUE, ukoncime MenuLoop
-    BOOL HelpMode2;      // obdrzeli jmse WM_USER_HELP_MOUSEMOVE a cekame na WM_USER_HELP_MOUSELEAVE? (musime vysvecovat polozku pod kurzorem)
-    WORD UIState;        // zobrazovani akceleratoru
+    // these two variables are used for cooperation between MenuBar and MenuPopup
+    // they are set in CMenuPopup::TrackInternal and determine further behavior
+    // of MenuBar after the popup is closed
+    int IndexToOpen;     // -1 means no additional popup should be opened,
+                         // otherwise the index of the popup to open
+    BOOL OpenWithSelect; // should the first item be selected when the menu opens?
+    BOOL OpenByMouse;    // opened via mouse or keyboard?
+    BOOL ExitMenuLoop;   // TRUE to exit MenuLoop
+    BOOL HelpMode2;      // did we receive WM_USER_HELP_MOUSEMOVE and wait for
+                         // WM_USER_HELP_MOUSELEAVE? (we must highlight the item under the cursor)
+    WORD UIState;        // accelerator display state
     BOOL ForceAccelVisible;
 
 public:
     //
-    // Vlastni metody
+    // custom methods
     //
     CMenuBar(CMenuPopup* menu, HWND hNotifyWindow, CObjectOrigin origin = ooStatic);
     ~CMenuBar();
 
     //
-    // Implementace metod CGUIMenuBarAbstract
+    // implementation of CGUIMenuBarAbstract methods
     //
 
     virtual BOOL WINAPI CreateWnd(HWND hParent);
     virtual HWND WINAPI GetHWND() { return HWindow; }
 
-    virtual int WINAPI GetNeededWidth();                 // vrati sirku, ktera bude pro okno potreba
-    virtual int WINAPI GetNeededHeight();                // vrati vysku, ktera bude pro okno potreba
-    virtual void WINAPI SetFont();                       // vytahne font pro menu bar ze systemu
-    virtual BOOL WINAPI GetItemRect(int index, RECT& r); // vrati umisteni polozky ve screen souradnicich
-    virtual void WINAPI EnterMenu();                     // user stisknul VK_MENU
+    virtual int WINAPI GetNeededWidth();                 // returns the width needed for the window
+    virtual int WINAPI GetNeededHeight();                // returns the height needed for the window
+    virtual void WINAPI SetFont();                       // obtains the menu bar font from the system
+    virtual BOOL WINAPI GetItemRect(int index, RECT& r); // Returns the item's rectangle in screen coordinates.
+    virtual void WINAPI EnterMenu();                     // user pressed VK_MENU
     virtual BOOL WINAPI IsInMenuLoop() { return MenuLoop; }
     virtual void WINAPI SetHelpMode(BOOL helpMode) { HelpMode = helpMode; }
 
@@ -535,17 +535,17 @@ protected:
     void DrawItem(int index);
     void DrawItem(HDC hDC, int index, int x);
     void DrawAllItems(HDC hDC);
-    void RefreshMinWidths(); // obehne vsechny polozky a napocit si k nim 'MinWidth'
+    void RefreshMinWidths(); // iterates all items and computes the 'MinWidth' of each
 
-    void TrackHotIndex();                                                  // zamackne HotIndex a zavola TrackPopup; vrati se po jeho zavreni
-    void EnterMenuInternal(int index, BOOL openWidthSelect, BOOL byMouse); // byMouse rika, zda jde o otevreni pres mys nebo klavesnici
+    void TrackHotIndex();                                                  // presses HotIndex and calls TrackPopup; returns once it closes
+    void EnterMenuInternal(int index, BOOL openWidthSelect, BOOL byMouse); // byMouse indicates whether the menu was opened by mouse or keyboard
 
-    // vraci TRUE, pokud je na pozici polozka; pak take nastavi 'index'
-    // jinak vraci FALSE
+    // returns TRUE if there is an item at the position and sets 'index';
+    // otherwise returns FALSE
     BOOL HitTest(int xPos, int yPos, int& index);
 
-    // prohleda vlozene submenu a vrati TRUE, pokud mezi nima najde nejaky s horkou
-    // klavesou 'hotKey'; zaroven vrati jeho index
+    // searches inserted submenus and returns TRUE if one with the hot key 'hotKey' is found;
+    // the index of the item is returned as well
     BOOL HotKeyIndexLookup(char hotKey, int& itemIndex);
 
     friend class CMenuPopup;
@@ -558,14 +558,14 @@ extern CMenuPopup MainMenu;
 extern CMenuPopup ArchiveMenu;
 extern CMenuPopup ArchivePanelMenu;
 
-BOOL BuildSalamanderMenus();           // sestavi globalni menu pro Salamandera
-BOOL BuildFindMenu(CMenuPopup* popup); // sestavi instanci menu pro find
+BOOL BuildSalamanderMenus();           // builds the global menu for Salamander
+BOOL BuildFindMenu(CMenuPopup* popup); // builds an instance of the find menu
 
-// Prida do 'popup' polozky vytvorene na zaklade pole 'buttonsID'.
-// 'hWindow' je parent tlacitek, na ktere odkazuji konstanty pole 'buttonsID'.
-// Pole 'buttonsID' muze obsahovat libovolne mnozstvi cisel zakoncene 0.
-// Cislo -1 je vyhrazene pro separator a cislo -2 pro default polozku (nasledujici
-// polozka bude mit nastaven default state). Ostatni cisla jsou povazovana
-// za id tlacitek. Jejich text je vytazen a pridan do menu. Zaroven je
-// vytazen jejich Enabled stav, ktery je take promitnut do polozky v menu.
+// Adds to 'popup' items created from the 'buttonsID' array.
+// 'hWindow' is the parent of the buttons referenced by the 'buttonsID' array.
+// The 'buttonsID' array may contain any number of IDs terminated by 0.
+// ID -1 denotes a separator and -2 marks the default item (the next item will
+// have the default state set). Other numbers are treated as button IDs; their
+// text is extracted and added to the menu and their enabled state is mirrored in
+// the menu item.
 void FillContextMenuFromButtons(CMenuPopup* popup, HWND hWindow, int* buttonsID);


### PR DESCRIPTION
This PR brings the translated `src/menu.h` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/menu.h`.