### PR TITLE
[translation] Initial src/tasklist.h comments translation

### DIFF
--- a/src/tasklist.h
+++ b/src/tasklist.h
@@ -1,49 +1,52 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
 //
 // ****************************************************************************
 
-// TRUE = prvni bezici instance verze 3.0 nebo novejsi
-// urcuje se na zaklade mutexu v globalnim namespace, takze se vidi s mutexty
-// z ostatnich sessions (remote desktop, fast user switching)
+// TRUE = first running instance of version 3.0 or later
+// Determined using a mutex in the global namespace, so it is visible across sessions
+// (remote desktop, fast user switching)
 extern BOOL FirstInstance_3_or_later;
 
-// sdilena pamet obsahuje:
-//  DWORD                  - PID procesu, ktery se ma breaknout
-//  DWORD                  - pocet polozek v listu
-//  MAX_TL_ITEMS * CTLItem - list polozek
+// Shared memory contains:
+//  DWORD                  - PID of the process that should be broken into
+//  DWORD                  - number of items in the list
+//  MAX_TL_ITEMS * CTLItem - list of items
 
-#define MAX_TL_ITEMS 500 // maximalni pocet polozek ve sdilene pameti, nelze menit!
+#define MAX_TL_ITEMS 500 // maximum number of items in shared memory, cannot be changed!
 
-#define TASKLIST_TODO_HIGHLIGHT 1 // okno procesu daneho v 'PID' se ma vysvitit
-#define TASKLIST_TODO_BREAK 2     // proces dany v 'PID' se ma breaknout
-#define TASKLIST_TODO_TERMINATE 3 // proces dany v 'PID' se ma terminovat
-#define TASKLIST_TODO_ACTIVATE 4  // proces dany v 'PID' se ma aktivovat
+#define TASKLIST_TODO_HIGHLIGHT 1 // window of the process in 'PID' is to be highlighted
+#define TASKLIST_TODO_BREAK 2     // the process specified by 'PID' is to be broken into
+#define TASKLIST_TODO_TERMINATE 3 // process given in 'PID' is to be terminated
+#define TASKLIST_TODO_ACTIVATE 4  // process given in 'PID' is to be activated
 
-#define TASKLIST_TODO_TIMEOUT 5000 // 5 vterin, ktere maji procesy pro zpracovani todo
+#define TASKLIST_TODO_TIMEOUT 5000 // 5 seconds that processes have to process the todo entry
 
-#define PROCESS_STATE_STARTING 1 // nas proces startuje, jeste neexistuje hlavni okno
-#define PROCESS_STATE_RUNNING 2  // nas proces bezi, mame hlavni okno
-#define PROCESS_STATE_ENDING 3   // nas proces konci, nemame uz hlavni okno
+#define PROCESS_STATE_STARTING 1 // our process is starting, the main window does not exist yet
+#define PROCESS_STATE_RUNNING 2  // our process is running, we have the main window
+#define PROCESS_STATE_ENDING 3   // our process is ending, we no longer have the main window
 
-#pragma pack(push, enter_include_tasklist) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_tasklist) // make the structures independent of the current alignment setting
 #pragma pack(4)
 
 extern HANDLE HSalmonProcess;
 
-// POZOR, pomoci struktury komunikuji x64 a x86 procesy, pozor na typy (napr. HANDLE), ktere maji ruzne sirky
+// WARNING, x64 and x86 processes communicate through the structure; mind the types
+// (e.g. HANDLE) that have different widths
 struct CProcessListItem
 {
-    DWORD PID;            // ProcessID, unikatni po dobu behu procesu, pak muze byt znovu pouzito
-    SYSTEMTIME StartTime; // Kdy byl proces nastartovan
-    DWORD IntegrityLevel; // Integrity Level procesu, slouzi k rozliseni procesu spustenych na ruzne urovni opravneni
-    BYTE SID_MD5[16];     // MD5 napocitana ze SID procesu, slouzi nam k rozliseni procesu bezicich pod ruznymi uzivateli; SID ma neznamou delku, proto tato obezlicka
-    DWORD ProcessState;   // Stav v jakem se Salamander nachazi, viz PROCESS_STATE_xxx
-    UINT64 HMainWindow;   // (x64 friendly) Handle hlavniho okna, pokud jiz/jeste existuje (nastavuje se pri jeho vytvareni/destrukci)
-    DWORD SalmonPID;      // ProcessID salmonu, aby mu brakujici proces mohl garantovat pravo pro SetForegroundWindow
+    DWORD PID;            // ProcessID, unique for the lifetime of the process, after which it can be reused
+    SYSTEMTIME StartTime; // When the process was started
+    DWORD IntegrityLevel; // Integrity Level of the process, distinguishes processes running at different privilege levels
+    BYTE SID_MD5[16];     // MD5 calculated from the process SID, distinguishes processes running under different users; SID has an unknown length, hence this workaround
+    DWORD ProcessState;   // State Salamander is currently in; see PROCESS_STATE_xxx
+    UINT64 HMainWindow;   // (x64 friendly) Handle of the main window, if it already/still exists (set during creation/destruction)
+    DWORD SalmonPID;      // Salmon ProcessID, so the process that breaks in can guarantee it has
+                          // permission to call SetForegroundWindow
 
     CProcessListItem()
     {
@@ -55,31 +58,32 @@ struct CProcessListItem
         HMainWindow = NULL;
         SalmonPID = 0;
         if (HSalmonProcess != NULL)
-            SalmonPID = SalGetProcessId(HSalmonProcess); // v tuto dobu jiz Salmon bezi
+            SalmonPID = SalGetProcessId(HSalmonProcess); // at this moment Salmon is already running
     }
 };
 
-// POZOR, ke strukture lze pouze pridavat polozky, protoze na ni chodi i starsi verze Salamandera
-// POZOR, pomoci struktury komunikuji x64 a x86 procesy, pozor na typy (napr. HANDLE), ktere maji ruzne sirky
-// POZOR, nejspis nema smysl zvedat verzi a rozsirovat strukturu, protoze pridana data v tom pripade
-//        nebudou vzdy k dispozici (stara verze Salama nahozena jako prvni = ve sdilene pameti nove
-//        polozky vubec nebudou) => spravne reseni je nejspis zmena AS_PROCESSLIST_NAME a spol. +
-//        uprava dat dle libosti (klidne zvetsovani, promazavani, zmena poradi, atd.)
+// WARNING, only new items can be added to the structure because older Salamander versions use it
+// WARNING, x64 and x86 processes communicate using the structure; mind the types (e.g. HANDLE) that have different widths
+// WARNING, increasing the version and expanding the structure probably makes no sense because
+//        the added data would not always be available (if an older Salamander version is
+//        launched first, the new items will not exist in shared memory)
+//        => the proper solution is likely to change AS_PROCESSLIST_NAME and similar constants
+//        and then adjust the data as desired (feel free to enlarge, prune, reorder, etc.)
 struct CCommandLineParams
 {
-    DWORD Version;               // novejsi verze Salamandera mohou zvysovat 'Version' a zacit vyuzivat promenne ReservedX
-    DWORD RequestUID;            // unikatni (zvysujici se) ID pozadavku o aktivaci
-    DWORD RequestTimestamp;      // GetTickCount() hodnota ze chvile, kdy byl zakladan pozadavek pro aktivaci
-    char LeftPath[2 * MAX_PATH]; // cesty do panelu (levy, pravy, pripadne aktivni); pokud jsou prazdne, nemaji se nastavit
+    DWORD Version;               // newer Salamander versions can increase 'Version' and start using ReservedX variables
+    DWORD RequestUID;            // unique (monotonically increasing) ID of the activation request
+    DWORD RequestTimestamp;      // GetTickCount() value from the moment the activation request was created
+    char LeftPath[2 * MAX_PATH]; // panel paths (left, right, possibly active); if empty, leave them unset
     char RightPath[2 * MAX_PATH];
     char ActivePath[2 * MAX_PATH];
-    DWORD ActivatePanel;         // ktery panel se ma aktivovat 0-zadny, 1-levy, 2-pravy
-    BOOL SetTitlePrefix;         // pokud je TRUE, nastavi se prefix titulku podle TitlePrefix
-    char TitlePrefix[MAX_PATH];  // prefix titulku, pokud je prazdny, nemenit; delku radeji deklaruji na MAX_PATH, misto TITLE_PREFIX_MAX, ktery by se mohl pod rukama zmenit
-    BOOL SetMainWindowIconIndex; // pokud je TRUE, nastavi se ikona hlavniho okna podle MainWindowIconIndex
-    DWORD MainWindowIconIndex;   // 0: prvni ikona, 1: druha ikona, ...
-    // POZOR, strukturu lze rozsirovat pouze v pripade, ze je stale zadeklarovana jako posledni v CProcessList,
-    // jinak uz je pozde a nesmi se ji dotknout
+    DWORD ActivatePanel;         // which panel to activate: 0-none, 1-left, 2-right
+    BOOL SetTitlePrefix;         // if TRUE, set the title prefix according to TitlePrefix
+    char TitlePrefix[MAX_PATH];  // title prefix; if empty, leave unchanged; I prefer to declare the length as MAX_PATH instead of TITLE_PREFIX_MAX, which might change unexpectedly
+    BOOL SetMainWindowIconIndex; // if TRUE, set the main window icon according to MainWindowIconIndex
+    DWORD MainWindowIconIndex;   // 0: first icon, 1: second icon, ...
+    // WARNING, the structure can only be expanded if it is still declared as the last one in CProcessList;
+    // otherwise it is already too late and it must not be touched
 
     CCommandLineParams()
     {
@@ -88,22 +92,22 @@ struct CCommandLineParams
 };
 
 // Open Salamander Process List
-// !!! POZOR, ke strukture lze pouze pridavat polozky, protoze na ni chodi i starsi verze Salamandera
+// !!! WARNING, only new items can be added to the structure because older Salamander versions use it
 struct CProcessList
 {
-    DWORD Version; // novejsi verze Salamandera mohou zvysovat 'Version' a zacit vyuzivat promenne ReservedX
+    DWORD Version; // newer Salamander versions can increase 'Version' and start using ReservedX variables
 
-    DWORD ItemsCount;    // pocet validnich polozek v poli Items
-    DWORD ItemsStateUID; // "verze" Items seznamu; zvysuje se s kazdou zmenou; slouzi pro Tasks dialog jako signal, ze se ma refreshnout
+    DWORD ItemsCount;    // number of valid items in the Items array
+    DWORD ItemsStateUID; // "version" of the Items list; increases with every change; used by the Tasks dialog as a signal to refresh
     CProcessListItem Items[MAX_TL_ITEMS];
 
-    DWORD Todo;                           // urcuje co se ma delat po odpaleni eventu pomoci FireEvent, obsahuje jednu z hodnot TASKLIST_TODO_*
-    DWORD TodoUID;                        // poradi zaslaneho pozadavku, pro kazdy dalsi pozadavek ze zvysuje
-    DWORD TodoTimestamp;                  // GetTickCount() hodnota ze chvile, kdy byl zakladan Todo pozadavek
-    DWORD PID;                            // PID, pro ktery se ma provest cinnost z Todo
-    CCommandLineParams CommandLineParams; // cesty pro panely a dalsi parametry pro aktivaci
-                                          // POZOR, pokud bude potreba rozsirovat tuto strukturu, bylo by rozumne napred rozsirit CCommandLineParams, napriklad
-                                          // reservovat nejake MAX_PATH buffery a par DWORDu, pokud bychom chteli predavat nove command line parametry
+    DWORD Todo;                           // specifies what to do after FireEvent signals the event; contains one of the TASKLIST_TODO_* values
+    DWORD TodoUID;                        // sequence number of the submitted request; increases with every subsequent request
+    DWORD TodoTimestamp;                  // GetTickCount() value from the moment the Todo request was created
+    DWORD PID;                            // PID for which the Todo action should be performed
+    CCommandLineParams CommandLineParams; // panel paths and other parameters for activation
+                                          // WARNING, if this structure needs to be extended, it makes sense to extend CCommandLineParams first, for example
+                                          // reserve a few MAX_PATH buffers and some DWORDs if we want to pass new command-line parameters
 };
 
 #pragma pack(pop, enter_include_tasklist)
@@ -111,16 +115,16 @@ struct CProcessList
 class CTaskList
 {
 protected:
-    HANDLE FMO;                // file-mapping-object, sdilena pamet
-    CProcessList* ProcessList; // ukazatel do sdilene pameti
-    HANDLE FMOMutex;           // mutex pro reseni pristupu k FMO
-    HANDLE Event;              // event, je-li signaled, mely by se ostatni procesy podivat,
-                               // jestli se nemaji provest cinnost danou v Todo
-    HANDLE EventProcessed;     // pokud jeden z procesu provede cinnost v Todo, nastavi tento
-                               // event na signaled na znameni ridicimu procesu, ze je hotovo
-    HANDLE TerminateEvent;     // event pro ukonceni break-threadu
-    HANDLE ControlThread;      // control-thread (ceka na eventy, ktere obratem odbavi)
-    BOOL OK;                   // probehla konstrukce o.k.?
+    HANDLE FMO;                // file-mapping-object, shared memory
+    CProcessList* ProcessList; // pointer into shared memory
+    HANDLE FMOMutex;           // mutex used to control access to the FMO
+    HANDLE Event;              // event; when it becomes signaled, other processes should check
+                               // whether they should perform the activity specified in Todo
+    HANDLE EventProcessed;     // if one of the processes performs the Todo activity, it sets this
+                               // event to signaled to let the controlling process know it is finished
+    HANDLE TerminateEvent;     // event for terminating the break thread
+    HANDLE ControlThread;      // control thread (waits for events and services them immediately)
+    BOOL OK;                   // did construction finish OK?
 
 public:
     CTaskList();
@@ -128,28 +132,28 @@ public:
 
     BOOL Init();
 
-    // naplni polozky task-listu, items - pole alespon MAX_TL_ITEMS struktur CTLItem, vraci pocet polozek
-    // 'items' muze byt NULL, pokud nas zajima pouze 'itemsStateUID'
-    // vrati "verzi" sestavy procesu; verze se zvysuje s kazdou zmenou v seznamu (pokud je pridana nebo odebrana polozka)
-    // slouzi pro dialog jako informace, ze ma refreshnout seznam; 'itemsStateUID' muze byt NULL
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // Fills the task-list items; 'items' is an array of at least MAX_TL_ITEMS CProcessListItem structures; returns the number of items
+    // 'items' can be NULL if only 'itemsStateUID' is needed
+    // Returns the "version" of the process list; the version increases with every change to the list (when an item is added or removed)
+    // Used by the dialog to know when to refresh the list; 'itemsStateUID' can be NULL
+    // If 'timeouted' is not NULL, it is set to indicate whether the failure was caused by a timeout while waiting for shared memory
     int GetItems(CProcessListItem* items, DWORD* itemsStateUID, BOOL* timeouted = NULL);
 
-    // pozada proces 'pid' o provedeni akce dle 'todo' (mimo TASKLIST_TODO_ACTIVATE)
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // Requests process 'pid' to perform the action defined by 'todo' (except TASKLIST_TODO_ACTIVATE)
+    // if 'timeouted' is not NULL, it sets whether the failure was caused by a timeout when waiting for shared memory
     BOOL FireEvent(DWORD todo, DWORD pid, BOOL* timeouted = NULL);
 
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // If 'timeouted' is not NULL, it is set to indicate whether the failure was caused by a timeout while waiting for shared memory
     BOOL ActivateRunningInstance(const CCommandLineParams* cmdLineParams, BOOL* timeouted = NULL);
 
-    // v seznamu procesu dohleda nas a nastavi 'ProcessState' a 'HMainWindow'; vraci TRUE v pripade uspechu, jinak FALSE
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // Searches the process list for our entry and sets 'ProcessState' and 'HMainWindow'; returns TRUE on success, otherwise FALSE
+    // if 'timeouted' is not NULL, it sets whether the failure was caused by a timeout when waiting for shared memory
     BOOL SetProcessState(DWORD processState, HWND hMainWindow, BOOL* timeouted = NULL);
 
 protected:
-    // projde seznam procesu a vytridi neexistujici polozky
-    // nutne volat po uspesnem vstupu kriticke sekce 'FMOMutex'!
-    // nastavi 'changed' na TRUE, pokud byla nejaka polozka zahozena, jinak na FALSE
+    // Walks the process list and removes entries whose processes no longer exist
+    // Call only after successfully entering the 'FMOMutex' critical section!
+    // Sets 'changed' to TRUE if it discarded any item, otherwise to FALSE
     BOOL RemoveKilledItems(BOOL* changed);
 
     friend DWORD WINAPI FControlThread(void* param);
@@ -157,9 +161,9 @@ protected:
 
 extern CTaskList TaskList;
 
-// ochrana pristupu do CommandLineParams
+// protection for access to CommandLineParams
 extern CRITICAL_SECTION CommandLineParamsCS;
-// slouzi k predani parametru pro aktivaci Salamander z Control threadu do hlavniho thradu
+// used to hand off activation parameters from the Control thread to the main thread
 extern CCommandLineParams CommandLineParams;
-// event je "signaled" jakmile hlavni thread prevezme paramtery
+// event becomes "signaled" as soon as the main thread takes over the parameters
 extern HANDLE CommandLineParamsProcessed;


### PR DESCRIPTION
This PR brings the translated `src/tasklist.h` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/tasklist.h`.