### PR TITLE
[translation] Initial src/toolbar1.cpp comments translation

### DIFF
--- a/src/toolbar1.cpp
+++ b/src/toolbar1.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -115,7 +116,7 @@ CToolBar::CToolBar(HWND hNotifyWindow, CObjectOrigin origin)
 CToolBar::~CToolBar()
 {
     CALL_STACK_MESSAGE1("CToolBar::~CToolBar()");
-    // destrukce je jeste v WM_DESTROY
+    // Destruction also runs in WM_DESTROY.
     if (CacheBitmap != NULL)
     {
         delete CacheBitmap;
@@ -229,7 +230,7 @@ int CToolBar::GetNeededHeight()
     {
         if (HasIconDirty)
         {
-            // koukneme, jestli drzime nejakou ikonu
+            // Check whether we still hold any icon.
             HasIcon = FALSE;
             HasIconDirty = FALSE;
             int i;
@@ -361,7 +362,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
 {
     CALL_STACK_MESSAGE3("CToolBar::InsertItem2(0x%X, %d, )", position, byPosition);
     int newPos;
-    // vyhledame pozici, kam prijde nova polozka
+    // Find the position where the new item will go.
     if (byPosition)
     {
         if (position == -1 || position > (DWORD)Items.Count)
@@ -379,7 +380,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         }
     }
 
-    // naalokujeme polozku
+    // Allocate the item.
     CToolBarItem* item = new CToolBarItem();
     if (item == NULL)
     {
@@ -387,7 +388,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         return FALSE;
     }
 
-    // vlozime polozku do pole
+    // Insert the item into the array.
     Items.Insert(newPos, item);
     if (!Items.IsGood())
     {
@@ -396,7 +397,7 @@ BOOL CToolBar::InsertItem2(DWORD position, BOOL byPosition, const TLBI_ITEM_INFO
         return FALSE;
     }
 
-    // nastavime data
+    // Set the data.
     if (!SetItemInfo2(newPos, TRUE, tii))
     {
         Items.Delete(newPos);
@@ -459,7 +460,7 @@ BOOL CToolBar::SetItemInfo2(DWORD position, BOOL byPosition, const TLBI_ITEM_INF
         }
         else if (hadIcon)
         {
-            HasIconDirty = TRUE; // nevime, jestli jeste nejaka ikona zbyla - bude treba to zjistit
+            HasIconDirty = TRUE; // We do not know whether any icon remains; it must be checked.
         }
     }
 
@@ -487,14 +488,14 @@ BOOL CToolBar::SetItemInfo2(DWORD position, BOOL byPosition, const TLBI_ITEM_INF
             tii->Mask & TLBI_MASK_IMAGEINDEX || tii->Mask & TLBI_MASK_ICON ||
             (tii->Mask & TLBI_MASK_WIDTH && item->Style & TLBI_STYLE_FIXEDWIDTH))
         {
-            // tato zmena muze mit dopad na celou toolbaru
+            // This change can affect the entire toolbar.
             DirtyItems = TRUE;
             if (HWindow != NULL)
                 InvalidateRect(HWindow, NULL, FALSE);
         }
         else
         {
-            // nechame prekreslit pouze jedno tlacitko, ktere se menilo
+            // Redraw only the button that changed.
             if ((tii->Mask & TLBI_MASK_STATE) && HWindow != NULL)
             {
                 RECT r;
@@ -752,7 +753,7 @@ void CToolBar::SetStyle(DWORD style)
     }
     DWORD oldStyle = Style;
     Style = style;
-    // pokud se zmenilo zobrazovani textu, prealokuju si
+    // If text display changed, update the font settings.
     if ((oldStyle & TLB_STYLE_TEXT) != (Style & TLB_STYLE_TEXT))
         SetFont();
     DirtyItems = TRUE;
@@ -800,7 +801,7 @@ void CToolBar::UpdateItemsState()
 
         if (item->Enabler != NULL)
         {
-            // bit TLBI_STATE_GRAYED je rizen
+            // TLBI_STATE_GRAYED is controlled externally.
             BOOL enabled = (item->State & TLBI_STATE_GRAYED) == 0;
             BOOL enabledSrc = *item->Enabler != 0;
             if (enabled != enabledSrc)
@@ -822,7 +823,7 @@ void CToolBar::UpdateItemsState()
 
 void CToolBar::OnColorsChanged()
 {
-    // pokud existuje barevna bitmapa, nechame ji prebuildit pro aktualni barevnou hloubku
+    // If a color bitmap exists, rebuild it for the current color depth.
     if (CacheBitmap != NULL)
         CacheBitmap->ReCreateForScreenDC();
 }
@@ -835,7 +836,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
     case WM_DESTROY:
     {
-        // destrukce je jeste v destruktoru
+        // Destruction is also handled in the destructor.
         if (CacheBitmap != NULL)
         {
             delete CacheBitmap;
@@ -870,7 +871,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_ERASEBKGND:
     {
-        if (WindowsVistaAndLater) // pod vistou blika rebar
+        if (WindowsVistaAndLater) // Rebar flickers under Vista.
             return TRUE;
         RECT r;
         GetClientRect(HWindow, &r);
@@ -896,7 +897,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_CANCELMODE:
     {
         MouseIsTracked = FALSE;
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         if (!MonitorCapture)
             break;
         if (HotIndex != -1)
@@ -969,7 +970,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (newHotIndex != HotIndex)
         {
-            // vykreslime zmeny
+            // Draw the changes.
             int oldHotIndex = HotIndex;
             HotIndex = newHotIndex;
             if (oldHotIndex != -1)
@@ -989,19 +990,19 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     case WM_LBUTTONDOWN:
     case WM_LBUTTONDBLCLK:
     {
-        // pokud kliknuti prislo do 25ms po odmacknuti drop downu, zahodime ho, aby nedoslo
-        // ke zbytecnemu novemu zamacknuti
+        // If the click arrives within 25 ms of releasing the drop-down, ignore it
+        // to avoid an unnecessary new press.
         if (GetTickCount() - DropDownUpTime <= 25)
             break;
 
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         int xPos = (short)LOWORD(lParam);
         int yPos = (short)HIWORD(lParam);
 
         int index;
         BOOL dropDown;
-        // Pokud je otevrene windows popup menu a klikneme do toolbary, prijde rovnou
-        // WM_LBUTTONDOWN takze HotIndex == -1, proto vyrazuji podminku index == HotIndex.
+        // If a Windows pop-up menu is open and we click the toolbar, WM_LBUTTONDOWN
+        // arrives immediately, so HotIndex == -1 and we ignore the index == HotIndex condition.
         if (HitTest(xPos, yPos, index, dropDown) /*&& index == HotIndex*/)
         {
             CToolBarItem* item = Items[index];
@@ -1040,7 +1041,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                     DownIndex = -1;
                     SendMessage(HWindow, WM_MOUSEMOVE, 0, MAKELPARAM(p.x, p.y));
                     if (HotIndex == index)
-                        DrawItem(HotIndex); // pokud nedoslo ke zmene, musim prekreslit stav
+                        DrawItem(HotIndex); // If nothing changed, force a redraw of the state.
                     RelayToolTip = TRUE;
                     DropDownUpTime = GetTickCount();
                 }
@@ -1056,7 +1057,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_LBUTTONUP:
     {
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         if (DownIndex != -1)
         {
             int xPos = (short)LOWORD(lParam);
@@ -1087,8 +1088,8 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
                 DrawItem(DownIndex);
             DownIndex = -1;
         }
-        // musim uvolnit capture, aby chodily WM_SYSCOMMAND generovane na
-        // zaklade kliknuti na tlacitko v toolbare
+        // We must release capture so WM_SYSCOMMAND generated by clicking
+        // toolbar buttons can be delivered.
         if (GetCapture() == HWindow)
             ReleaseCapture();
         break;
@@ -1096,7 +1097,7 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_RBUTTONUP:
     {
-        SetCurrentToolTip(NULL, 0); // vykopneme tooltip
+        SetCurrentToolTip(NULL, 0); // Dismiss the tooltip.
         NMHDR nmhdr;
         nmhdr.hwndFrom = HWindow;
         nmhdr.idFrom = (UINT_PTR)GetMenu(HWindow);
@@ -1108,13 +1109,13 @@ CToolBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_USER_TTGETTEXT:
     {
-        DWORD index = (DWORD)wParam; // FIXME_X64 - overit pretypovani na (DWORD)
+        DWORD index = (DWORD)wParam; // FIXME_X64 - verify the cast to (DWORD).
         char* text = (char*)lParam;
         if (index >= 0 && index < (DWORD)Items.Count)
         {
             CToolBarItem* item = Items[index];
             if (item->Style & TLBI_STYLE_SEPARATOR)
-                return 0; // separator nema tooltip
+                return 0; // Separators have no tooltip.
             TOOLBAR_TOOLTIP tt;
             tt.HToolBar = HWindow;
             tt.ID = item->ID;


### PR DESCRIPTION
This PR brings the translated `src/toolbar1.cpp` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/toolbar1.cpp`.