### PR TITLE
[translation] Initial src/toolbar7.cpp comments translation

### DIFF
--- a/src/toolbar7.cpp
+++ b/src/toolbar7.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -35,8 +36,8 @@ CHotPathsBar::CHotPathsBar(HWND hNotifyWindow, CObjectOrigin origin)
 
     SetStyle(TLB_STYLE_IMAGE | TLB_STYLE_TEXT);
 
-    // naleju ikonky do vlastni toolbary
-    // vlozim pouze itemy a submenu z nejvyssi urovne; ostatni se bude rozbalovat jako submenu
+    // Load icons into the toolbar.
+    // Insert only top-level items and submenus; the rest expand as nested submenus.
     int level = 0;
     TLBI_ITEM_INFO2 tii;
     int i;
@@ -106,7 +107,7 @@ CHotPathsBar::CHotPathsBar(HWND hNotifyWindow, CObjectOrigin origin)
 int CHotPathsBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // Return the correct height even when no icon is loaded.
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -118,7 +119,7 @@ int CHotPathsBar::GetNeededHeight()
 void CHotPathsBar::Customize()
 {
     CALL_STACK_MESSAGE_NONE
-    // nechame vybalit stranku HotPaths
+    // Open the HotPaths page.
     PostMessage(MainWindow->HWindow, WM_USER_CONFIGURATION, 1, -1);
 }
 
@@ -153,7 +154,7 @@ CHotPathsBar::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         {
           TRACE_E("RegisterDragDrop error.");
         }
-        dropTarget->Release();  // RegisterDragDrop volala AddRef()
+        dropTarget->Release();  // RegisterDragDrop called AddRef().
       }
       break;
     }


### PR DESCRIPTION
This PR brings the translated `src/toolbar7.cpp` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/toolbar7.cpp`.