### PR TITLE
[translation] Initial src/toolbar8.cpp comments translation

### DIFF
--- a/src/toolbar8.cpp
+++ b/src/toolbar8.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 
@@ -70,7 +71,7 @@ BOOL CPluginsBar::CreatePluginButtons()
     tii.Mask = TLBI_MASK_STYLE | TLBI_MASK_IMAGEINDEX | TLBI_MASK_ID;
     tii.Style = TLBI_STYLE_WHOLEDROPDOWN | TLBI_STYLE_DROPDOWN;
     tii.ImageIndex = i;
-    tii.ID = CM_PLUGINCMD_MIN + i; // do mainwnd3 prijde jako WM_USER_TBDROPDOWN
+    tii.ID = CM_PLUGINCMD_MIN + i; // mainwnd3 receives it as WM_USER_TBDROPDOWN.
     InsertItem2(0xFFFFFFFF, TRUE, &tii);
   }
   */
@@ -81,7 +82,7 @@ BOOL CPluginsBar::CreatePluginButtons()
 int CPluginsBar::GetNeededHeight()
 {
     CALL_STACK_MESSAGE_NONE
-    // i v pripade, ze nedrzime zadnou ikonu budeem vracet spravnou vysku
+    // Return the correct height even when no icon is loaded.
     int height = CToolBar::GetNeededHeight();
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16);
     int minH = 3 + iconSize + 3;
@@ -93,7 +94,7 @@ int CPluginsBar::GetNeededHeight()
 void CPluginsBar::Customize()
 {
     CALL_STACK_MESSAGE_NONE
-    // zobrazim okno Plugins
+    // Open the Plugins window.
     PostMessage(MainWindow->HWindow, WM_COMMAND, CM_CUSTOMIZEPLUGINS, 0);
 }
 


### PR DESCRIPTION
This PR brings the translated `src/toolbar8.cpp` comment set from `comments-translation-v2` as a single-file change against `main`.

It includes the translated comments and the `CommentsTranslationProject: TRANSLATED` header marker.

Validation: diff checked against `main` and limited to `src/toolbar8.cpp`.