### PR TITLE
[translation] Fix src/md5.cpp comments

### DIFF
--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -56,12 +56,12 @@ void MD5::update(uint1* input, uint4 input_length)
              input_index += 64)
             transform(input + input_index);
 
-        buffer_index = 0; // so we can buffer remaining
+        buffer_index = 0; // so we can buffer the remaining input
     }
     else
         input_index = 0; // so we can buffer the whole input
 
-    // and here we do the buffering:
+    // Buffer the input here:
     memcpy(buffer + buffer_index, input + input_index, input_length - input_index);
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/md5.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 104 comment units, 104 review results, 104 resolved results, and 104 apply results.
- Branch-target comment guard passed for `src/md5.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/md5.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 10 provider calls, 164814 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 98133 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 5 calls, 66681 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
