### PR TITLE
[translation] Fix src/keyboard.cpp comments

### DIFF
--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -149,7 +149,7 @@ BOOL IsSalHotKey(WORD hotKey)
         {
         case NONE:    // up
         case CONTROL: // scroll up, keep cursor
-        case ALT:     // up to selected item
+        case ALT:     // move to the selected item
         case SHIFT:   // select + up
             found = TRUE;
         }
@@ -176,7 +176,7 @@ BOOL IsSalHotKey(WORD hotKey)
         {
         case NONE:    // down
         case CONTROL: // scroll down, keep cursor
-        case ALT:     // down to selected item
+        case ALT:     // move down to the selected item
         case SHIFT:   // select + down
             found = TRUE;
         }
@@ -513,7 +513,7 @@ BOOL IsSalHotKey(WORD hotKey)
         switch (mods)
         {
         case NONE:    // quick search/type in command line
-        case CONTROL: // files list
+        case CONTROL: // file list
         case ALT:     // enter menu
         case SHIFT:   // change drive
             found = TRUE;
@@ -786,8 +786,8 @@ BOOL IsSalHotKey(WORD hotKey)
         case NONE:          // edit
         case CONTROL:       // sort by extension
         case ALT:           // exit
-        case SHIFT:         // edit new
-        case CONTROL_SHIFT: // edit width
+        case SHIFT:         // edit new file
+        case CONTROL_SHIFT: // edit in wide mode
             found = TRUE;
         }
         break;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/keyboard.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 340 comment units, 340 review results, 340 resolved results, and 340 apply results.
- Branch-target comment guard passed for `src/keyboard.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/keyboard.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 23 provider calls, 355511 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 14 calls, 158060 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 9 calls, 197451 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
