### PR TITLE
[translation] Fix src/tasklist.h comments

### DIFF
--- a/src/tasklist.h
+++ b/src/tasklist.h
@@ -134,7 +134,7 @@ public:
 
     // Fills the task-list items; 'items' is an array of at least MAX_TL_ITEMS CProcessListItem structures; returns the number of items
     // 'items' can be NULL if only 'itemsStateUID' is needed
-    // Returns the "version" of the process list; the version increases with every change to the list (when an item is added or removed)
+    // 'itemsStateUID' returns the "version" of the process list; the version increases with every change to the list (when an item is added or removed)
     // Used by the dialog to know when to refresh the list; 'itemsStateUID' can be NULL
     // If 'timeouted' is not NULL, it is set to indicate whether the failure was caused by a timeout while waiting for shared memory
     int GetItems(CProcessListItem* items, DWORD* itemsStateUID, BOOL* timeouted = NULL);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/tasklist.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 59 comment units, 59 review results, 59 resolved results, and 59 apply results.
- Branch-target comment guard passed for `src/tasklist.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/tasklist.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 20287 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 20287 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
