### PR TITLE
[translation] Fix src/thumbnl.cpp comments

### DIFF
--- a/src/thumbnl.cpp
+++ b/src/thumbnl.cpp
@@ -57,7 +57,7 @@ BOOL CShrinkImage::Alloc(DWORD origWidth, DWORD origHeight,
     // allocate and initialize the coefficients
     RowCoeff = CreateCoeff(origWidth, newWidth, NormCoeffX);
     ColCoeff = CreateCoeff(origHeight, newHeight, NormCoeffY);
-    // allocate and clear the accumulation buffer
+    // allocate and clear the buffer
     Buff = (DWORD*)malloc(3 * newWidth * sizeof(DWORD));
     if (RowCoeff == NULL || ColCoeff == NULL || Buff == NULL)
     {
@@ -120,7 +120,7 @@ CShrinkImage::CreateCoeff(DWORD origLen, WORD newLen, DWORD& norm)
         boundary = sum / newLen;
         // how much of the previous boundary belongs to the left part of this section
         lCoeff = norm - rCoeff;
-        // and finally the weight of the pixel at the section's right edge
+        // Weight of the pixel at the right edge of the section
         modulo = sum % newLen;
         if (modulo == 0)
         {
@@ -424,8 +424,8 @@ void CSalamanderThumbnailMaker::Clear(int thumbnailMaxSize)
     Shrinker.Destroy();
 }
 
-// returns TRUE when the entire thumbnail is ready in this object (obtained
-// successfully from the plugin)
+// returns TRUE if the entire thumbnail is ready in this object (it was
+// successfully obtained from the plugin)
 BOOL CSalamanderThumbnailMaker::ThumbnailReady()
 {
     return OriginalHeight != 0 && NextLine >= OriginalHeight && !Error;
@@ -519,7 +519,7 @@ void CSalamanderThumbnailMaker::TransformThumbnail()
     }
 }
 
-// convert the thumbnail we hold into a DDB and store its data into CThumbnailData
+// Convert the held thumbnail to a DDB and store its data in CThumbnailData
 BOOL CSalamanderThumbnailMaker::RenderToThumbnailData(CThumbnailData* data)
 {
     // create a DDB and let it initialize with the thumbnail's RGB data


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/thumbnl.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 99 comment units, 99 review results, 99 resolved results, and 99 apply results.
- Branch-target comment guard passed for `src/thumbnl.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/thumbnl.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 26929 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 16681 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 10248 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
