### PR TITLE
[translation] Fix src/thumbnl.h comments

### DIFF
--- a/src/thumbnl.h
+++ b/src/thumbnl.h
@@ -75,7 +75,7 @@ protected:
     DWORD PictureFlags;
     BOOL ProcessTopDown;
 
-    CShrinkImage Shrinker; // Handles the actual image shrinking.
+    CShrinkImage Shrinker; // Handles image shrinking.
     BOOL ShrinkImage;
 
 public:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/thumbnl.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 24 comment units, 24 review results, 24 resolved results, and 24 apply results.
- Branch-target comment guard passed for `src/thumbnl.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/thumbnl.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 7792 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 7792 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
