### PR TITLE
[translation] Fix src/toolbar.h comments

### DIFF
--- a/src/toolbar.h
+++ b/src/toolbar.h
@@ -132,7 +132,7 @@ public:
     virtual void WINAPI SetHotImageList(HIMAGELIST hImageList);
     virtual HIMAGELIST WINAPI GetHotImageList();
 
-    // Toolbar style accessors.
+    // Toolbar style
     virtual void WINAPI SetStyle(DWORD style);
     virtual DWORD WINAPI GetStyle();
 
@@ -141,7 +141,7 @@ public:
 
     virtual int WINAPI GetItemCount() { return Items.Count; }
 
-    // Opens the configuration dialog.
+    // Opens the Customize dialog.
     virtual void WINAPI Customize();
 
     virtual void WINAPI SetPadding(const TOOLBAR_PADDING* padding);
@@ -155,10 +155,10 @@ public:
     // otherwise returns a negative value.
     virtual int WINAPI HitTest(int xPos, int yPos);
 
-    // Returns TRUE if the point lies on an item boundary; in that case it sets 'index'
-    // to that item and the 'after' flag to indicate whether it is the left or right side.
-    // Returns FALSE if the point lies over an item. If the point does not lie over any item,
-    // it returns TRUE and sets 'index' to -1.
+    // Returns TRUE if the point lies on an item boundary; in that case, it sets 'index'
+    // to that item and the 'after' flag to indicate whether the insertion mark is before or
+    // after it. Returns FALSE if the point lies over an item. If the point does not lie over
+    // any item, it returns TRUE and sets 'index' to -1.
     virtual BOOL WINAPI InsertMarkHitTest(int xPos, int yPos, int& index, BOOL& after);
 
     // Sets the insert mark to the given index (before or after).


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/toolbar.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 89 comment units, 89 review results, 89 resolved results, and 89 apply results.
- Branch-target comment guard passed for `src/toolbar.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/toolbar.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 10 provider calls, 116301 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 8 calls, 74141 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 42160 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
