### PR TITLE
[translation] Fix src/toolbar4.cpp comments

### DIFF
--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -255,8 +255,9 @@ CButtonData ToolBarButtons[TBBE_TERMINATOR] =
 //
 // TopToolbar
 //
-// Represents all buttons that TopToolbar can contain.
-// The order defines how buttons appear in the toolbar configuration dialog and can be changed freely.
+// Represents all possible buttons that TopToolbar can contain.
+// The order determines the order of buttons in the toolbar configuration dialog and can
+// be changed freely.
 //
 
 DWORD TopToolBarButtons[] =
@@ -357,7 +358,7 @@ DWORD TopToolBarButtons[] =
         NIB2(TBBE_HELP_CONTENTS)
             NIB2(TBBE_HELP_CONTEXT)
 
-                TBBE_TERMINATOR // terminator - must remain here!
+                TBBE_TERMINATOR // terminator - must be here
 };
 
 DWORD LeftToolBarButtons[] =
@@ -399,7 +400,7 @@ DWORD RightToolBarButtons[] =
         TBBE_REFRESH,
         TBBE_SMART_COLUMN_MODE,
 
-        TBBE_TERMINATOR // terminator - must remain here!
+        TBBE_TERMINATOR // terminator - must be here
 };
 
 void GetSVGIconsMainToolbar(CSVGIcon** svgIcons, int* svgIconsCount)
@@ -743,8 +744,8 @@ BOOL CreateToolbarBitmaps(HINSTANCE hInstance, int resID, COLORREF transparent, 
     int iconSize = GetIconSizeForSystemDPI(ICONSIZE_16); // small icon size
     int iconCount = 0;
 
-    // Windows XP and newer use transparent icons. Render them into this temporary bitmap
-    // so the area beneath their transparent parts uses the toolbar gray instead of our purple mask color.
+    // Windows XP and newer use transparent icons; render them into this temporary bitmap
+    // so that the area under the transparent parts uses the toolbar gray instead of our purple mask color.
     HBITMAP hTmpBitmap = NULL;
     HDC hTmpMemDC = NULL;
     HBITMAP hOldTmpBitmap = NULL;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/toolbar4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 278 comment units, 278 review results, 278 resolved results, and 278 apply results.
- Branch-target comment guard passed for `src/toolbar4.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/toolbar4.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 11 provider calls, 199868 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 153275 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 46593 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
