### PR TITLE
[translation] Fix src/toolbar5.cpp comments

### DIFF
--- a/src/toolbar5.cpp
+++ b/src/toolbar5.cpp
@@ -48,7 +48,7 @@ public:
     }
 
     STDMETHOD(QueryInterface)
-    (REFIID refiid, void FAR* FAR* ppv)
+    (REFIID refiid, void FAR * FAR * ppv)
     {
         if (refiid == IID_IUnknown || refiid == IID_IDropTarget)
         {

--- a/src/toolbar5.cpp
+++ b/src/toolbar5.cpp
@@ -441,7 +441,7 @@ public:
                     }
                     MainWindow->UserMenuItems->Insert(i, item);
 
-                    if (UserMenuIconBkgndReader.IsReadingIcons()) // icon loading is in progress, so restart it because the user menu item count changed (as a side effect this drops the icon just read for the dropped file, but that's acceptable)
+                    if (UserMenuIconBkgndReader.IsReadingIcons()) // icon loading is in progress, so restart it because the number of items in the user menu has changed (as a side effect, this drops the icon just loaded for the dropped file, but that is acceptable)
                     {
                         CUserMenuIconDataArr* bkgndReaderData = new CUserMenuIconDataArr();
                         for (int i2 = 0; i2 < MainWindow->UserMenuItems->Count; i2++)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/toolbar5.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 26 comment units, 26 review results, 26 resolved results, and 26 apply results.
- Branch-target comment guard passed for `src/toolbar5.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/toolbar5.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 5 provider calls, 93611 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 68656 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 24955 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
