### PR TITLE
[translation] Fix src/toolbar6.cpp comments

### DIFF
--- a/src/toolbar6.cpp
+++ b/src/toolbar6.cpp
@@ -56,8 +56,8 @@ BOOL CDriveBar::CreateDriveButtons(CDriveBar* copyDrivesListFrom)
     if (HWindow == NULL)
         return FALSE;
 
-    // Suppress painting to avoid the checked item blinking (opening and closing the plugins manager would make it flicker).
-    // This also prevented flicker during Salamander startup.
+    // Suppress painting to prevent the checked item from flickering (for example, when opening and closing the Plugins Manager).
+    // It also flickered during Salamander startup.
     SendMessage(HWindow, WM_SETREDRAW, FALSE, 0);
     RemoveAllItems();
     SetStyle(TLB_STYLE_IMAGE | TLB_STYLE_TEXT);
@@ -295,7 +295,7 @@ BOOL CDriveBar::OnContextMenu()
             FromContextMenu = FALSE;
             const char* dllName = NULL;
             List->OnContextMenu(TRUE, indexInList, panel == MainWindow->LeftPanel ? PANEL_LEFT : PANEL_RIGHT, &dllName);
-            if (PostCmd != 0) // set only for drvtPluginFS and drvtPluginCmd, and drvtPluginFS cannot be on the Drive bar
+            if (PostCmd != 0) // PostCmd is set only for drvtPluginFS and drvtPluginCmd, and drvtPluginFS cannot be on the Drive bar
             {
                 UpdateWindow(MainWindow->HWindow);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/toolbar6.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 19 comment units, 19 review results, 19 resolved results, and 19 apply results.
- Branch-target comment guard passed for `src/toolbar6.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/toolbar6.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 53129 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 50617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 2512 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
