### PR TITLE
[translation] Fix src/tooltip.h comments

### DIFF
--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -55,7 +55,7 @@ protected:
     POINT LastCursorPos;
     BOOL IsModal;     // is our message loop running right now?
     BOOL ExitASAP;    // close as soon as possible and stop being modal
-    UINT_PTR TimerID; // returned from SetTimer, we need it for KillTimer
+    UINT_PTR TimerID; // returned by SetTimer; needed for KillTimer
 
 public:
     CToolTip(CObjectOrigin origin = ooStatic);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/tooltip.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 16 comment units, 16 review results, 16 resolved results, and 16 apply results.
- Branch-target comment guard passed for `src/tooltip.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/tooltip.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 28137 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 28137 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
