### PR TITLE
[translation] Fix src/usermenu.h comments

### DIFF
--- a/src/usermenu.h
+++ b/src/usermenu.h
@@ -132,17 +132,17 @@ struct CUserMenuItem
 
     ~CUserMenuItem();
 
-    // Tries to retrieve the icon handle in this order
+    // Tries to retrieve the icon handle in this order:
     // a) the Icon variable
     // b) SHGetFileInfo
-    // c) takes the system default
-    // Reading icons in the background: if 'bkgndReaderData' is NULL, we read immediately; otherwise the icons
-    // are read in the background. If 'getIconsFromReader' is FALSE, we collect what to load into 'bkgndReaderData'.
-    // If it is TRUE, the icons are already loaded and we simply take over the handles of the loaded icons
-    // from 'bkgndReaderData'.
+    // c) the system default icon
+    // Background icon loading: if 'bkgndReaderData' is NULL, read immediately; otherwise the icons
+    // are read in the background. If 'getIconsFromReader' is FALSE, collect what should be loaded into
+    // 'bkgndReaderData'. If it is TRUE, the icons are already loaded and we only take the loaded icon
+    // handles from 'bkgndReaderData'.
     BOOL GetIconHandle(CUserMenuIconDataArr* bkgndReaderData, BOOL getIconsFromReader);
 
-    // Searches ItemName for '&' and returns HotKey; returns TRUE if one is found.
+    // Searches ItemName for '&' and returns the hot key in key; returns TRUE if one is found.
     BOOL GetHotKey(char* key);
 
     BOOL Set(char* name, char* umCommand, char* arguments, char* initDir, char* icon);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/usermenu.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 33 comment units, 33 review results, 33 resolved results, and 33 apply results.
- Branch-target comment guard passed for `src/usermenu.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/usermenu.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 34243 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 34243 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
