### PR TITLE
[translation] Fix src/tooltip.cpp comments

### DIFF
--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -124,8 +124,8 @@ CToolTip::GetTime(BOOL init)
         return (GetDoubleClickTime() * 10) / 100;
 }
 
-// The only method I devised for detecting cursor height
-// is drawing the cursor mask into a DIB and then scanning the bit field.
+// The only method found for detecting the cursor height
+// is to draw the cursor mask into a DIB and then scan the bit array.
 BOOL GetCursorHeight(HCURSOR hCursor)
 {
     if (hCursor == 0)
@@ -224,8 +224,8 @@ void CToolTip::MessageLoop()
     ShowWindow(HWindow, SW_HIDE);
     IsModal = FALSE;
 
-    // our window captured the input; we received all messages
-    // now we need to deliver the last message to the recipient
+    // our window had captured the input, so all messages were delivered to us
+    // now we need to deliver the last message to its target
     if (msg.message == WM_LBUTTONDOWN || msg.message == WM_RBUTTONDOWN ||
         msg.message == WM_MBUTTONDOWN)
     {
@@ -533,9 +533,9 @@ void CToolTip::OnTimer()
         POINT p;
         GetCursorPos(&p);
         HWND hWnd = WindowFromPoint(p);
-        if (hWnd == HNotifyWindow) // we must still be on the notify window
+        if (hWnd == HNotifyWindow) // the cursor must still be over the notify window
         {
-            if (HasActiveParent(hWnd)) // the root window must also be active
+            if (HasActiveParent(hWnd)) // its root window must also be active
             {
                 if (Show(p.x, p.y, TRUE, FALSE, HNotifyWindow))
                 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/tooltip.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 50 comment units, 50 review results, 50 resolved results, and 50 apply results.
- Branch-target comment guard passed for `src/tooltip.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/tooltip.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 23208 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 19091 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 4117 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
