### PR TITLE
Fix comment audit residue

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -24,6 +24,11 @@
   - `uv run comment-code-guard --base-repo-path \salamander_code_guard --sub-path src\plugins\zip`  
 - `uv run` ensures the command uses the environment defined by `uv sync`.
 
+### Notes for comment-audit utilities
+- `comment-translation-status` classifies extracted comments as Czech or English and also writes `comments_czech_residue.csv` for mixed comments that still contain untranslated Czech phrases.
+- `comment-find-czech-words` scans extracted comments only; it no longer reports Czech-looking identifiers or unrelated code tokens outside comments.
+- `comment-word-counter` counts target words only inside comments that still contain Czech residue, which keeps the output aligned with translation cleanup work instead of code identifiers.
+
 ## Managing Dependencies
 - Add or update dependencies with `uv add <package>` and then commit the updated `pyproject.toml` and `uv.lock`.
 - To remove a dependency use `uv remove <package>` followed by `uv sync`.

--- a/tools/comments/find_czech_words.py
+++ b/tools/comments/find_czech_words.py
@@ -1,4 +1,4 @@
-"""Utilities for listing Czech words (normalized) that appear in source files."""
+"""Utilities for listing Czech words (normalized) that still remain in comments."""
 
 from __future__ import annotations
 
@@ -10,12 +10,10 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-from unidecode import unidecode
-
 from .translation_status import (
     DEFAULT_EXTENSIONS,
-    WORD_RE,
-    _load_word_sets,
+    detect_czech_residue_tokens,
+    extract_comment_records_from_file,
     _path_is_excluded,
     _path_sort_key,
 )
@@ -25,7 +23,7 @@ REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Locate unique Czech words (without diacritics) used in comments or identifiers.",
+        description="Locate unique Czech words (without diacritics) that still remain in comments.",
     )
     parser.add_argument(
         "--project-root",
@@ -177,15 +175,11 @@ def _iter_source_files(
             yield file_path
 
 
-def _collect_words(text: str, cs_words: frozenset[str], en_words: frozenset[str]) -> set[str]:
-    """Return normalised Czech words appearing in *text* while ignoring English tokens."""
+def _collect_words(file_path: Path) -> set[str]:
+    """Return normalized Czech words still present in extracted comments from *file_path*."""
     found: set[str] = set()
-    for token in WORD_RE.findall(text):
-        candidate = unidecode(token).lower()
-        if candidate in en_words:
-            continue
-        if candidate in cs_words:
-            found.add(candidate)
+    for comment in extract_comment_records_from_file(file_path):
+        found.update(detect_czech_residue_tokens(comment.text))
     return found
 
 
@@ -204,7 +198,6 @@ def main(argv: list[str] | None = None) -> int:
         else None
     )
 
-    cs_words, en_words = _load_word_sets()
     files_with_words: dict[Path, set[str]] = {}
     unique_words: set[str] = set()
 
@@ -215,13 +208,7 @@ def main(argv: list[str] | None = None) -> int:
         exclude_patterns=exclude_patterns,
         no_recursion=args.no_recursion,
     ):
-        try:
-            content = file_path.read_text(encoding="utf-8", errors="ignore")
-        except Exception as exc:
-            print(f"Failed to read {file_path.relative_to(project_root)}: {exc}", file=sys.stderr)
-            continue
-
-        words = _collect_words(content, cs_words, en_words)
+        words = _collect_words(file_path)
         if words:
             files_with_words[file_path] = words
             unique_words.update(words)
@@ -253,7 +240,5 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
-
 
 

--- a/tools/comments/test_comment_audit.py
+++ b/tools/comments/test_comment_audit.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import contextlib
+import io
+import tempfile
+import unittest
+from pathlib import Path
+
+from comments.find_czech_words import main as find_czech_words_main
+from comments.translation_status import detect_czech_residue_tokens
+from comments.word_counter import main as word_counter_main
+
+
+class CommentAuditTests(unittest.TestCase):
+    def test_detect_czech_residue_in_mixed_comment(self) -> None:
+        comment = (
+            "// TRUE, mel by viewer vratit system-event 'lock' v nonsignaled stavu, "
+            "do signaled stavu 'lock'"
+        )
+        tokens = detect_czech_residue_tokens(comment)
+        self.assertIn("vratit", tokens)
+        self.assertIn("stavu", tokens)
+
+    def test_ignore_single_false_positive_token(self) -> None:
+        self.assertEqual(detect_czech_residue_tokens("// hitem"), [])
+
+    def test_ignore_short_non_czech_token_clusters(self) -> None:
+        self.assertEqual(detect_czech_residue_tokens("// bej chv dzo khm smj votic zho"), [])
+
+    def test_find_czech_words_uses_comments_only(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "mixed.cpp").write_text(
+                'int hitem = 0;\n'
+                '// POZOR: volat HANDLES_CAN_USE_TRACE() tesne po inicializaci "dbg.h" modulu\n',
+                encoding="utf-8",
+            )
+            (root / "identifier_only.cpp").write_text("int windir = 0;\n", encoding="utf-8")
+            (root / "false_positive_comment.cpp").write_text("// hitem\n", encoding="utf-8")
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = find_czech_words_main(["--project-root", str(root)])
+
+            output = stdout.getvalue()
+            self.assertEqual(exit_code, 0)
+            self.assertIn("--- mixed.cpp ---", output)
+            self.assertIn("pozor", output)
+            self.assertNotIn("--- identifier_only.cpp ---", output)
+            self.assertNotIn("--- false_positive_comment.cpp ---", output)
+
+    def test_word_counter_counts_only_residue_comments(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp)
+            (root / "sample.cpp").write_text(
+                'int windir = 0;\n'
+                '// pokud je vetsi nez nula, probiha prave prikaz\n'
+                '// hitem\n',
+                encoding="utf-8",
+            )
+            (root / "words.txt").write_text("pokud\nprave\nhitem\nwindir\n", encoding="utf-8")
+
+            stdout = io.StringIO()
+            with contextlib.redirect_stdout(stdout):
+                exit_code = word_counter_main(
+                    ["--project-root", str(root), "--words-file", str(root / "words.txt")]
+                )
+
+            output = stdout.getvalue()
+            self.assertEqual(exit_code, 0)
+            self.assertIn("pokud: 1", output)
+            self.assertIn("prave: 1", output)
+            self.assertIn("hitem: 0", output)
+            self.assertIn("windir: 0", output)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/comments/translation_status.py
+++ b/tools/comments/translation_status.py
@@ -4,6 +4,7 @@ import fnmatch
 import os
 import re
 import sys
+from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
 from typing import Iterable
@@ -21,30 +22,96 @@ import tree_sitter_cpp as ts_cpp
 from tree_sitter import Language, Parser
 
 WORD_RE = re.compile(r"[A-Za-z]+")
+DIACRITIC_RE = re.compile(r"[áčďéěíňóřšťúůýžÁČĎÉĚÍŇÓŘŠŤÚŮÝŽ]")
+
+CZECH_RESIDUE_MARKERS = frozenset(
+    {
+        "aby",
+        "alokovana",
+        "alokovano",
+        "antivir",
+        "bitmapa",
+        "bitmapy",
+        "cekame",
+        "cesta",
+        "cesty",
+        "delka",
+        "dialogu",
+        "hlavni",
+        "ikona",
+        "ikony",
+        "inicializaci",
+        "jmena",
+        "klavesa",
+        "komprimace",
+        "modulu",
+        "misto",
+        "navic",
+        "neni",
+        "nepodporuji",
+        "okno",
+        "oznacenych",
+        "panelu",
+        "polozka",
+        "polozky",
+        "pokud",
+        "poznamka",
+        "pozor",
+        "projekty",
+        "prikaz",
+        "sestaveni",
+        "soubor",
+        "souboru",
+        "stavu",
+        "tesne",
+        "trida",
+        "ukazatel",
+        "unikatni",
+        "vieweru",
+        "volat",
+        "vraci",
+        "vratit",
+        "zbytku",
+        "zdroje",
+        "znatelne",
+        "znamka",
+        "zkusime",
+    }
+)
 
 
 MANUAL_ENGLISH_WORDS = frozenset(
     {
         "arton",
+        "ashampoo",
         "bzip",
+        "cleartype",
         "cvut",
         "dpb",
         "filezilla",
         "ftps",
+        "hitem",
+        "himl",
+        "hkm",
         "hlist",
         "isel",
         "mkdir",
         "msie",
         "ocsp",
+        "pacl",
         "partl",
         "pecl",
+        "psz",
         "ramdisk",
         "regedit",
         "srand",
         "tgz",
+        "templ",
         "ubyte",
         "ulong",
+        "vko",
         "winapi",
+        "windir",
         "winscp",
     }
 )
@@ -94,6 +161,13 @@ C_PARSER = Parser(C_LANGUAGE)
 DEFAULT_EXTENSIONS = (".h", ".rh", ".c", ".cpp", ".rc")
 
 
+@dataclass(frozen=True)
+class CommentRecord:
+    text: str
+    start_line: int
+    end_line: int
+
+
 def get_parser(file_path: Path) -> Parser:
     """Return a tree-sitter parser based on file suffix."""
     if file_path.suffix == ".c":
@@ -101,22 +175,27 @@ def get_parser(file_path: Path) -> Parser:
     return CPP_PARSER
 
 
-def extract_comments_from_file(file_path: Path) -> list[str]:
-    """Return every comment found in *file_path*."""
+def extract_comment_records_from_file(file_path: Path) -> list[CommentRecord]:
+    """Return every comment found in *file_path* together with its line span."""
     parser = get_parser(file_path)
     try:
-        with file_path.open("r", encoding="utf-8", errors="ignore") as handle:
-            code = handle.read()
+        code_bytes = file_path.read_bytes()
     except Exception as exc:  # pragma: no cover - defensive I/O guard
         print(f"Error reading file {file_path}: {exc}", file=sys.stderr)
         return []
 
-    tree = parser.parse(code.encode("utf-8"))
-    comments: list[str] = []
+    tree = parser.parse(code_bytes)
+    comments: list[CommentRecord] = []
 
     def visit(node) -> None:
         if "comment" in node.type:
-            comments.append(code[node.start_byte : node.end_byte])
+            comments.append(
+                CommentRecord(
+                    text=code_bytes[node.start_byte : node.end_byte].decode("utf-8", errors="ignore"),
+                    start_line=code_bytes.count(b"\n", 0, node.start_byte) + 1,
+                    end_line=code_bytes.count(b"\n", 0, node.end_byte) + 1,
+                )
+            )
         for child in node.children:
             visit(child)
 
@@ -124,17 +203,47 @@ def extract_comments_from_file(file_path: Path) -> list[str]:
     return comments
 
 
-def _token_counts(text: str) -> tuple[int, int]:
-    """Return counts of (czech_like, english_like) tokens in *text*."""
+def extract_comments_from_file(file_path: Path) -> list[str]:
+    """Return every comment found in *file_path*."""
+    return [record.text for record in extract_comment_records_from_file(file_path)]
+
+
+def _tokenize_with_languages(text: str) -> tuple[list[str], list[str]]:
+    """Return normalized Czech-like and English-like tokens found in *text*."""
     cs_words, en_words = _load_word_sets()
-    cs_total = en_total = 0
+    cs_hits: list[str] = []
+    en_hits: list[str] = []
     for token in WORD_RE.findall(text):
         normalized = unidecode(token).lower()
         if normalized in cs_words:
-            cs_total += 1
+            cs_hits.append(normalized)
         elif normalized in en_words:
-            en_total += 1
-    return cs_total, en_total
+            en_hits.append(normalized)
+    return cs_hits, en_hits
+
+
+def _token_counts(text: str) -> tuple[int, int]:
+    """Return counts of (czech_like, english_like) tokens in *text*."""
+    cs_hits, en_hits = _tokenize_with_languages(text)
+    return len(cs_hits), len(en_hits)
+
+
+def detect_czech_residue_tokens(comment: str) -> list[str]:
+    """Return Czech-like tokens when *comment* still contains untranslated Czech residue."""
+    cs_hits, _en_hits = _tokenize_with_languages(comment)
+    unique_cs = sorted(set(cs_hits))
+    if not unique_cs:
+        return []
+
+    long_unique_cs = sorted({token for token in unique_cs if len(token) >= 4})
+
+    if DIACRITIC_RE.search(comment):
+        return unique_cs
+
+    if len(long_unique_cs) >= 2 and CZECH_RESIDUE_MARKERS.intersection(unique_cs):
+        return unique_cs
+
+    return []
 
 
 def classify_language(comment: str) -> str:
@@ -273,8 +382,10 @@ def main(argv: list[str] | None = None) -> int:
     # Optional glob patterns let us limit scanning to a subset of files.
     name_filters = tuple(args.name_filter) if args.name_filter else None
     output_file_path = output_dir / "comments.txt"
+    residue_csv_path = output_dir / "comments_czech_residue.csv"
 
     file_stats: dict[str, dict[str, int]] = {}
+    residue_stats: dict[str, dict[str, object]] = {}
     print(f"Starting comment extraction from '{project_root}'...")
 
     with output_file_path.open("w", encoding="utf-8") as out_file:
@@ -314,12 +425,15 @@ def main(argv: list[str] | None = None) -> int:
 
                 out_file.write(f"--- File: {relative_display} ---\n")
 
-                comments = extract_comments_from_file(file_path)
+                comments = extract_comment_records_from_file(file_path)
                 file_cs_size = 0
                 file_en_size = 0
+                file_residue_bytes = 0
+                file_residue_blocks = 0
+                file_residue_words: set[str] = set()
 
                 for comment in comments:
-                    comment_text = comment.strip()
+                    comment_text = comment.text.strip()
                     if not comment_text:
                         continue
 
@@ -327,14 +441,26 @@ def main(argv: list[str] | None = None) -> int:
 
                     language = classify_language(comment_text)
                     comment_size = len(comment_text.encode("utf-8"))
+                    residue_tokens = detect_czech_residue_tokens(comment_text)
 
                     if language == "cs":
                         file_cs_size += comment_size
                     elif language == "en":
                         file_en_size += comment_size
 
+                    if residue_tokens:
+                        file_residue_bytes += comment_size
+                        file_residue_blocks += 1
+                        file_residue_words.update(residue_tokens)
+
                 if file_cs_size > 0 or file_en_size > 0:
                     file_stats[relative_path] = {"cs": file_cs_size, "en": file_en_size}
+                if file_residue_blocks > 0:
+                    residue_stats[relative_path] = {
+                        "bytes": file_residue_bytes,
+                        "blocks": file_residue_blocks,
+                        "words": sorted(file_residue_words),
+                    }
 
                 out_file.write("\n")
 
@@ -346,11 +472,35 @@ def main(argv: list[str] | None = None) -> int:
     total_bytes = total_cs_bytes + total_en_bytes
     files_with_comments = len(file_stats)
     translated_pct = (total_en_bytes / total_bytes * 100) if total_bytes else 0.0
+    residue_total_bytes = sum(int(stats["bytes"]) for stats in residue_stats.values())
+    residue_total_blocks = sum(int(stats["blocks"]) for stats in residue_stats.values())
     print("\nOverall statistics:")
     print(f"  Files with comments: {files_with_comments}")
     print(f"  Czech comments: {total_cs_bytes} bytes")
     print(f"  English comments: {total_en_bytes} bytes")
     print(f"  Translated to English: {translated_pct:.1f}%")
+    print(f"  Czech residue comments: {residue_total_bytes} bytes across {residue_total_blocks} comment blocks")
+
+    try:
+        with residue_csv_path.open("w", newline="", encoding="utf-8") as csvfile:
+            writer = csv.writer(csvfile)
+            writer.writerow(["File Path", "Czech Residue Comment Bytes", "Czech Residue Comment Blocks", "Detected Czech Words"])
+            for path, stats in sorted(
+                residue_stats.items(),
+                key=lambda item: (-int(item[1]["bytes"]), _path_sort_key(item[0])),
+            ):
+                writer.writerow(
+                    [
+                        path.replace("/", os.sep),
+                        stats["bytes"],
+                        stats["blocks"],
+                        " ".join(stats["words"]),
+                    ]
+                )
+        print(f"  Czech residue report: {residue_csv_path}")
+    except Exception as exc:
+        print(f"\nError saving Czech residue CSV report: {exc}", file=sys.stderr)
+
     generate_treemap(file_stats, output_dir)
     return 0
 

--- a/tools/comments/word_counter.py
+++ b/tools/comments/word_counter.py
@@ -1,4 +1,4 @@
-"""Count occurrences of predefined Czech words across source files."""
+"""Count occurrences of predefined Czech words that still remain in comments."""
 
 from __future__ import annotations
 
@@ -10,13 +10,14 @@ import sys
 from pathlib import Path
 from typing import Iterable
 
-from unidecode import unidecode
-
 from .translation_status import (
     DEFAULT_EXTENSIONS,
     WORD_RE,
     _path_is_excluded,
+    detect_czech_residue_tokens,
+    extract_comment_records_from_file,
 )
+from unidecode import unidecode
 
 REPOSITORY_ROOT = Path(__file__).resolve().parents[2]
 DEFAULT_WORDS = (
@@ -196,7 +197,7 @@ DEFAULT_WORDS = (
 
 
 def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Count predefined Czech words in the codebase.")
+    parser = argparse.ArgumentParser(description="Count predefined Czech words that still remain in comments.")
     parser.add_argument(
         "--project-root",
         type=Path,
@@ -302,16 +303,18 @@ def main(argv: list[str] | None = None) -> int:
         no_recursion=args.no_recursion,
     ):
         try:
-            content = file_path.read_text(encoding="utf-8", errors="ignore")
+            comments = extract_comment_records_from_file(file_path)
         except Exception as exc:
             print(f"Failed to read {file_path.relative_to(project_root)}: {exc}", file=sys.stderr)
             continue
 
-        # Normalize accented characters so we can compare tokens with ASCII word lists.
-        normalized_tokens = (unidecode(token).lower() for token in WORD_RE.findall(content))
-        for token in normalized_tokens:
-            if token in target_words:
-                counter[token] += 1
+        for comment in comments:
+            if not detect_czech_residue_tokens(comment.text):
+                continue
+            normalized_tokens = (unidecode(token).lower() for token in WORD_RE.findall(comment.text))
+            for token in normalized_tokens:
+                if token in target_words:
+                    counter[token] += 1
 
     lines = [f"{word}: {counter[word]}" for word in sorted(target_words)]
     output = "\n".join(lines)
@@ -330,6 +333,5 @@ def main(argv: list[str] | None = None) -> int:
 
 if __name__ == "__main__":
     sys.exit(main())
-
 
 


### PR DESCRIPTION
## Summary
- make the comment-audit utilities operate on extracted comments instead of whole-file token scans
- add mixed-comment Czech residue detection and emit a dedicated `comments_czech_residue.csv` report from `comment-translation-status`
- add regression tests and documentation for the new residue-detection workflow

## Why
The previous audit utilities mixed two problems together: they missed real Czech residue in mixed English/Czech comments, and they also reported false positives from non-comment source content. This patch moves all three audit entrypoints onto the same comment-aware residue detector so the tooling matches the actual translation-cleanup task.

## Verification
- `python3 -m py_compile tools/comments/translation_status.py tools/comments/find_czech_words.py tools/comments/word_counter.py tools/comments/test_comment_audit.py`
- `cd tools && UV_PROJECT_ENVIRONMENT=/tmp/sal_tools_venv uv run python -m unittest comments.test_comment_audit`
- `cd tools && UV_PROJECT_ENVIRONMENT=/tmp/sal_tools_venv uv run comment-translation-status --project-root ../src --output-dir /tmp/sal_translation_status_patched`
- confirmed the updated residue report keeps real findings such as `src/plugins/shared/mhandles.h` and `src/plugins/shared/spl_view.h`, drops the false positive from `src/plugins/mmviewer/mp3/id3tagv2.cpp`, and no longer flags `src/dialogs4.cpp`

Model: OpenAI GPT-5.4