### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -1535,7 +1535,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                                     // a pointer to CFileData is needed for PluginFSDir, because items in Files and Dirs can move
                                     // for example when sorting (Files and Dirs are arrays of CFileData, not `CFileData*`, which causes these problems)
                                     if (Configuration.NotHiddenSystemFiles &&
-                                        (f->Hidden || //both Hidden a Attr jsou nulovane pokud jsou neplatne -> testy failnou
+                                        (f->Hidden || // both Hidden and Attr are zeroed when invalid -> tests fail
                                          (f->Attr & (FILE_ATTRIBUTE_HIDDEN | FILE_ATTRIBUTE_SYSTEM))))
                                     { // skip hidden file/directory
                                         continue;

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -820,7 +820,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         memmove(iconData.NameAndData, file.Name, len);
                         memset(iconData.NameAndData + len, 0, size - len); // end of name is zeroed
                         iconData.SetFlag(0);                               // icon not loaded yet
-// bitmap storage must be allocated here; it cannot be done in the worker thread
+                                                                           // bitmap storage must be allocated here; it cannot be done in the worker thread
                         iconData.SetIndex(IconCache->AllocIcon(NULL, NULL));
                         if (iconData.GetIndex() != -1)
                         {
@@ -1166,7 +1166,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                                 memcpy(iconData.NameAndData + nameLen, s, len + 1);                 // icon-location + '\0'
 
                                 iconData.SetFlag(3); // icon not loaded yet; only the icon location is known
-// we need to allocate space for the bitmaps, which cannot be done in this thread
+                                                     // we need to allocate space for the bitmaps, which cannot be done in this thread
                                 iconData.SetIndex(IconCache->AllocIcon(NULL, NULL));
                                 if (iconData.GetIndex() != -1)
                                 {
@@ -1427,7 +1427,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                                     memcpy(iconData.NameAndData + nameLen, s, len + 1);                 // icon-location + '\0'
 
                                     iconData.SetFlag(3); // icon not yet loaded, specified only by icon-location
-// we need to allocate space for the bitmaps; this cannot be done in the worker thread
+                                                         // we need to allocate space for the bitmaps; this cannot be done in the worker thread
                                     iconData.SetIndex(IconCache->AllocIcon(NULL, NULL));
                                     if (iconData.GetIndex() != -1)
                                     {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 389 comment units, 389 review results, 389 resolved results, and 389 apply results.
- Branch-target comment guard passed for `src/fileswn3.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/fileswn3.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 61799 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 41819 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 19980 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
