### PR TITLE
[translation] Fix src/plugins/shared/spl_view.h comments

### DIFF
--- a/src/plugins/shared/spl_view.h
+++ b/src/plugins/shared/spl_view.h
@@ -39,14 +39,14 @@ public:
     // Called when the viewer is requested to open and load file
     // 'name'; 'left'+'top'+'width'+'height'+'showCmd'+'alwaysOnTop' is the recommended window placement;
     // window; if 'returnLock' is FALSE, 'lock'+'lockOwner' have no meaning; if 'returnLock' is
-    // TRUE, mel by viewer vratit system-event 'lock' v nonsignaled stavu, do signaled stavu 'lock'
+    // TRUE, the viewer should return system event 'lock' in the nonsignaled state; 'lock'
     // becomes signaled when viewing file 'name' ends (the file is removed from the temporary
     // directory at that moment); it should also return TRUE in 'lockOwner' if the 'lock' object is to be closed
     // by the caller (FALSE means the viewer closes 'lock' itself - in that case the viewer must use
     // CSalamanderGeneralAbstract::UnlockFileInCache to make 'lock' signaled);
     // if the viewer does not set 'lock' (it remains NULL), file 'name' is valid only until this
     // ViewFile call ends; if 'viewerData' is not NULL, it passes extended viewer parameters (see
-    // CSalamanderGeneralAbstract::ViewFileInPluginViewer); 'enumFilesSourceUID' je UID zdroje (panelu
+    // CSalamanderGeneralAbstract::ViewFileInPluginViewer); 'enumFilesSourceUID' is the source UID (panel
     // or Find window) from which the viewer is opened; if it is -1, the source is unknown (archives
     // or file systems, or Alt+F11, etc.) - see e.g. CSalamanderGeneralAbstract::GetNextFileNameForViewer;
     // 'enumFilesCurrentIndex' is the index of the opened file in the source (panel or Find window); if it is -1,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_view.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 13 comment units, 13 review results, 13 resolved results, and 13 apply results.
- Branch-target comment guard passed for `src/plugins/shared/spl_view.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_view.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
