### PR TITLE
[translation] Fix src/plugins/shared/mhandles.h comments

### DIFF
--- a/src/plugins/shared/mhandles.h
+++ b/src/plugins/shared/mhandles.h
@@ -13,12 +13,12 @@
 #pragma once
 
 // MHANDLES_ENABLE macro - enables handle monitoring
-// POZOR: volat HANDLES_CAN_USE_TRACE() tesne po inicializaci "dbg.h" modulu
+// WARNING: call HANDLES_CAN_USE_TRACE() immediately after initializing the "dbg.h" module
 //        (after SalamanderDebug and SalamanderVersion have been initialized)
 // WARNING: MHANDLES are initialized/destroyed at the "lib" level; if a plugin
 //        uses the "lib" (or "compiler") level, it must ensure that MHANDLES are not
 //        used at those levels (see #pragma init_seg (lib))
-// POZNAMKA: pro snazsi rozmisteni maker HANDLES() a HANDLES_Q() pouzijte program CheckHnd.exe
+// NOTE: use CheckHnd.exe to simplify the placement of HANDLES() and HANDLES_Q() macros
 
 #define NOHANDLES(function) function
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/mhandles.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 29 comment units, 29 review results, 29 resolved results, and 29 apply results.
- Branch-target comment guard passed for `src/plugins/shared/mhandles.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/mhandles.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
