### PR TITLE
[translation] Fix src/plugins/shared/lukas/utilaux.cpp comments

### DIFF
--- a/src/plugins/shared/lukas/utilaux.cpp
+++ b/src/plugins/shared/lukas/utilaux.cpp
@@ -286,16 +286,16 @@ BOOL SalGetFullName(char* name, int* errTextID, const char* curDir)
                 else // "c:path..."
                 {
                     /*
-          int l1 = strlen(s + 2);  // delka zbytku ("path...")
+          int l1 = strlen(s + 2);  // length of the remainder ("path...")
           if (SalamanderGeneral->CharToLowerCase(*s) >= 'a' && SalamanderGeneral->CharToLowerCase(*s) <= 'z')
           {
             const char *head;
             if (curDir != NULL && SalamanderGeneral->CharToLowerCase(curDir[0]) == SalamanderGeneral->CharToLowerCase(*s)) head = curDir;
             else head = DefaultDir[LowerCase[*s] - 'a'];
             int l2 = strlen(head);
-            if (head[l2 - 1] != '\\') l2++;  // misto pro '\\'
+            if (head[l2 - 1] != '\\') l2++;  // room for '\\'
             if (l1 + l2 >= MAX_PATH) err = GFN_TOOLONGPATH;
-            else  // sestaveni full path
+            else  // build the full path
             {
               memmove(name + l2, s + 2, l1 + 1);
               *(name + l2 - 1) = '\\';


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/utilaux.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 35 comment units, 35 review results, 35 resolved results, and 35 apply results.
- Branch-target comment guard passed for `src/plugins/shared/lukas/utilaux.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/lukas/utilaux.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 121995 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 117378 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 4617 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
