### PR TITLE
[translation] Fix src/salspawn/salspawn.cpp comments

### DIFF
--- a/src/salspawn/salspawn.cpp
+++ b/src/salspawn/salspawn.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/salspawn/salspawn.cpp
+++ b/src/salspawn/salspawn.cpp
@@ -21,9 +21,9 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 {
     switch (fdwCtrlType)
     {
-    // vyignorujeme CTRL+C, Ctrl+Break a dalsi dobre duvody pro ukonceni... protoze ukoncit
-    // se musi nejdrive spousteny externi archivator (jinak archivator pokracuje ve spousteni,
-    // i kdyz uz Salamander pise, ze komprimace/dekomprimace skoncila)
+    // Ignore CTRL+C, Ctrl+Break, and other valid termination reasons, because the
+    // launched external archiver must terminate first. Otherwise it keeps running
+    // even after Salamander reports that compression or decompression has finished.
     case CTRL_C_EVENT:
     case CTRL_BREAK_EVENT:
     case CTRL_CLOSE_EVENT:
@@ -40,7 +40,7 @@ BOOL CtrlHandler(DWORD fdwCtrlType)
 // EnableExceptionsOn64
 //
 
-// Chceme se dozvedet o SEH Exceptions i na x64 Windows 7 SP1 a dal
+// We want to receive SEH exceptions even on x64 Windows 7 SP1 and later.
 // http://blog.paulbetts.org/index.php/2010/07/20/the-case-of-the-disappearing-onload-exception-user-mode-callback-exceptions-in-x64/
 // http://connect.microsoft.com/VisualStudio/feedback/details/550944/hardware-exceptions-on-x64-machines-are-silently-caught-in-wndproc-messages
 // http://support.microsoft.com/kb/976038
@@ -84,7 +84,7 @@ void mainCRTStartup()
 
     exeName[0] = '\0';
 
-    // nechceme zadne kriticke chyby jako "no disk in drive A:"
+    // Do not show critical errors such as "no disk in drive A:".
     SetErrorMode(SetErrorMode(0) | SEM_FAILCRITICALERRORS);
 
     cmdline = GetCommandLine();


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salspawn/salspawn.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 16 comment units, 16 review results, 16 resolved results, and 16 apply results.
- Branch-target comment guard passed for `src/salspawn/salspawn.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/salspawn/salspawn.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 66983 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 46917 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20066 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
