### PR TITLE
[translation] Fix src/icncache.h comments

### DIFF
--- a/src/icncache.h
+++ b/src/icncache.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/icncache.h
+++ b/src/icncache.h
@@ -11,29 +11,29 @@
 class CIconData
 {
 public:
-    char* NameAndData;           // alokovano po DWORDech, konce nulovane (kvuli porovnavani);
-                                 // pro Flag==3 (i pro ==1, nasleduje-li po ==3) navic pripojen string s icon-location;
-                                 // pro Flag==4,5,6 navic pripojena znamka souboru (CQuadWord Size + FILETIME LastWrite)
-                                 //   a seznam rozhrani CPluginInterfaceForThumbLoaderEncapsulation
-                                 //   vsech pluginu, ktere umi vytvorit thumbnail pro soubor 'NameAndData', seznam je ukoncen
-                                 //   NULLem)
-    const CFileData* FSFileData; // ukazatel na CFileData souboru (jen u FS s typem ikon pitFromPlugin), jinak NULL
+    char* NameAndData;           // allocated on DWORD boundaries, null-terminated at the end (for comparison);
+                                 // for Flag==3 (and for ==1 if it follows ==3), a string with icon-location is also appended;
+                                 // for Flag==4,5,6, the file stamp (CQuadWord Size + FILETIME LastWrite) is also appended,
+                                 // along with the list of CPluginInterfaceForThumbLoaderEncapsulation interfaces for all
+                                 // plugins that can create a thumbnail for file 'NameAndData'; the list is terminated
+                                 // with NULL)
+    const CFileData* FSFileData; // pointer to CFileData for the file (only for FS with icon type pitFromPlugin), otherwise NULL
 
 private:
-    DWORD Index : 28;      // >= 0 index do cache ikon nebo thumbnailu (index musi byt < 134217728); -1 -> nenactene;
-                           //   pri Flag==0,1,2,3 jde o index do cache ikon;
-                           //   pri Flag==4,5,6 jde o index do cache thumbnailu
-    DWORD ReadingDone : 1; // 1 = uz jsme se pokouseli nacist (i neuspesne), 0 = jeste jsme nenacitali
-    DWORD Flag : 3;        // flag k danemu typu, v CIconCache:
-                           //   ikony: 0 - nenactene, 1 - o.k., 2 - stara verze, 3 - ikona zadana pomoci icon-location
-                           //   thumbnaily: 4 - nenactene, 5 - o.k., 6 - stara verze (nebo nekvalitni/mensi)
+    DWORD Index : 28;      // >= 0 index into the icon or thumbnail cache (must be < 134217728); -1 -> not loaded;
+                           // for Flag==0,1,2,3 this is an index into the icon cache;
+                           // for Flag==4,5,6 this is an index into the thumbnail cache
+    DWORD ReadingDone : 1; // 1 = we already tried to load it (even unsuccessfully), 0 = we have not tried yet
+    DWORD Flag : 3;        // flag for the given type, in CIconCache:
+                           // icons: 0 - not loaded, 1 - OK, 2 - old version, 3 - icon specified via icon-location
+                           // thumbnails: 4 - not loaded, 5 - OK, 6 - old version (or poor-quality/smaller)
 
 public:
     int GetIndex()
     {
         int index = Index;
         if (index & 0x08000000)
-            index |= 0xF0000000; // neumi 28-bit int na 32-bit int ...
+            index |= 0xF0000000; // sign-extend 28-bit int to 32-bit int ...
         return index;
     }
 
@@ -57,17 +57,17 @@ public:
 //
 
 //
-// reprezentuje jeden thumbnail v CIconCache::ThumbnailsCache
-// protoze pri vetsim mnozstvi handlu bitmap dochazi k tuhnuti procesu,
-// je lepsi drzet bitmapy jako RAW data
+// Represents one thumbnail in CIconCache::ThumbnailsCache.
+// Because a larger number of bitmap handles can make the process stall,
+// it is better to keep the bitmaps as RAW data.
 //
 struct CThumbnailData
 {
-    WORD Width; // rozmery thumbnailu
+    WORD Width; // thumbnail dimensions
     WORD Height;
-    WORD Planes;       // urcuji "geometrii" dat (tyto dva parametry bychom mohli vypustit,
-    WORD BitsPerPixel; // ale vzniklo by riziko pri prepnuti barevne hloubky)
-    DWORD* Bits;       // raw data device dependent bitmapy; format neznamy
+    WORD Planes;       // define the data "geometry" (we could omit these two parameters,
+    WORD BitsPerPixel; // but that would introduce a risk when switching color depth)
+    DWORD* Bits;       // raw data of a device-dependent bitmap; format unknown
 };
 
 //
@@ -81,47 +81,47 @@ protected:
     //
     // Icons
     //
-    TIndirectArray<CIconList> IconsCache; // pole bitmap slouzici jako cache na ikonky
-    int IconsCount;                       // pocet zaplnenych mist v bitmapach (ikon)
-    CIconSizeEnum IconSize;               // jakou velikost ikonek drzime?
+    TIndirectArray<CIconList> IconsCache; // array of bitmaps used as the icon cache
+    int IconsCount;                       // number of occupied slots in the icon bitmaps
+    CIconSizeEnum IconSize;               // which icon size do we keep?
 
     //
     // Thumbnails
     //
-    TDirectArray<CThumbnailData> ThumbnailsCache; // pole bitmap slouzici jako cache na thumbnaily
+    TDirectArray<CThumbnailData> ThumbnailsCache; // array of bitmaps used as the thumbnail cache
 
-    CPluginDataInterfaceEncapsulation* DataIfaceForFS; // jen pro interni pouziti v SortArray()
+    CPluginDataInterfaceEncapsulation* DataIfaceForFS; // for internal use in SortArray() only
 
 public:
-    // 'forAssociations' slouzi k dimenzovani velikosti (base/delta) pole; u asociaci se predpoklada vetsi
+    // 'forAssociations' is used to size the array (base/delta); associations are expected to be larger
     CIconCache();
     ~CIconCache();
 
-    void Release(); // uvolneni celeho pole + invalidate cache
-    void Destroy(); // uvolneni celeho pole + cache
+    void Release(); // release the entire array + invalidate cache
+    void Destroy(); // release the entire array + cache
 
-    // seradi pole pro rychle vyhledavani; 'dataIface' je NULL krome pripadu, kdy jde
-    // o ptPluginFS s ikonami typu pitFromPlugin
+    // Sorts the array for fast lookup; 'dataIface' is NULL except when this is
+    // ptPluginFS with icons of type pitFromPlugin.
     void SortArray(int left, int right, CPluginDataInterfaceEncapsulation* dataIface);
 
-    // vraci "nalezeno ?" a index polozky nebo kam se ma vlozit (razene pole);
-    // 'name' musi byt zarovnane po DWORDech (pouziva se jen pokud je 'dataIface' NULL);
-    // 'file' jsou file-data souboru/adresare 'name' (pouziva se jen pokud neni 'dataIface'
-    // NULL); 'dataIface' je NULL krome pripadu, kdy jde o ptPluginFS s ikonami typu
+    // Returns "found?" and the item index, or the insertion position (sorted array);
+    // 'name' must be DWORD-aligned (used only if 'dataIface' is NULL);
+    // 'file' is the file-data for file/directory 'name' (used only if 'dataIface' is
+    // not NULL); 'dataIface' is NULL except when this is ptPluginFS with icons of type
     // pitFromPlugin
     BOOL GetIndex(const char* name, int& index, CPluginDataInterfaceEncapsulation* dataIface,
                   const CFileData* file);
 
-    // nakopiruje si zname ikonky a thumbnaily (stara a nova cache musi byt serazene !)
-    // v pripade thumbnailu preda geometrii a raw data obrazku (CThumbnailData::Bits)
-    // do nove cache; ve stare nastavi Bits=NULL, aby pri destrukci nedoslo k dealokaci;
-    // 'dataIface' je NULL krome pripadu, kdy jde u stare i nove cache o ptPluginFS
-    // s ikonami typu pitFromPlugin
+    // Copies known icons and thumbnails (the old and new caches must be sorted!)
+    // In the thumbnail case, passes the image geometry and raw image data
+    // (CThumbnailData::Bits) to the new cache; sets Bits=NULL in the old cache to avoid
+    // deallocation during destruction; 'dataIface' is NULL except when both old and new
+    // caches are ptPluginFS with icons of type pitFromPlugin
     void GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEncapsulation* dataIface,
                                BOOL transferIconsAndThumbnailsAsNew = FALSE,
                                BOOL forceReloadThumbnails = FALSE);
 
-    // musi prekreslit zakladni sadu ikon s novym pozadim
+    // Must redraw the base icon set with the new background.
     void ColorsChanged();
 
     ////////////////
@@ -129,14 +129,14 @@ public:
     // Icons methods
     //
 
-    // allokuje misto pro ikonku; vraci jeji index nebo -1 pri chybe
-    // promenne 'iconList' a 'iconListIndex' mohou byt NULL (pak nejsou nastavovany)
-    // jinak 'iconList' vraci ukazatel na CIconList, ktery nese ikonu a 'iconListIndex'
-    // je index v ramci tohoto imagelistu.
+    // Allocates space for an icon; returns its index or -1 on error.
+    // Variables 'iconList' and 'iconListIndex' may be NULL (then they are not set).
+    // Otherwise, 'iconList' returns a pointer to the CIconList carrying the icon and
+    // 'iconListIndex' is the index within that image list.
     int AllocIcon(CIconList** iconList, int* imageIconIndex);
 
-    // vrati v 'iconList' ukazatel na IconList a v 'iconListIndex' pozici ikonky
-    // 'iconIndex' (vracene z AllocIcon);
+    // Returns in 'iconList' a pointer to IconList and in 'iconListIndex' the icon position
+    // for 'iconIndex' (returned by AllocIcon);
     BOOL GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex);
 
     ////////////////
@@ -144,22 +144,22 @@ public:
     // Thumbnails methods
     //
 
-    // alokuje misto pro thumbnail na konci pole ThumbnailsCache
-    // pokud je vse OK, vraci index, ktery thumbnailu odpovida
-    // pri chybe vrati -1
+    // Allocates space for a thumbnail at the end of the ThumbnailsCache array.
+    // If everything is OK, returns the index corresponding to that thumbnail.
+    // On error, returns -1.
     int AllocThumbnail();
 
-    // vrati v 'thumbnailData' ukazatel na polozku
-    // 'index' (vracena z AllocThumbnail);
+    // Returns in 'thumbnailData' a pointer to the item
+    // 'index' (returned by AllocThumbnail);
     BOOL GetThumbnail(int index, CThumbnailData** thumbnailData);
 
     void SetIconSize(CIconSizeEnum iconSize);
     CIconSizeEnum GetIconSize() { return IconSize; }
 
 protected:
-    // jen pro interni pouziti
+    // For internal use only.
     void SortArrayInt(int left, int right);
-    // jen pro interni pouziti
+    // For internal use only.
     void SortArrayForFSInt(int left, int right);
 };
 
@@ -170,19 +170,19 @@ protected:
 
 struct CAssociationIndexAndFlag
 {
-    DWORD Index : 31; // >= 0 index; -1 nenactene; -2 dynamicke (ikona v souboru); -3 nacitane (-1 -> -3)
-    DWORD Flag : 1;   // jde *.ExtensionAndData otevrit ?
+    DWORD Index : 31; // >= 0 index; -1 not loaded; -2 dynamic (icon in file); -3 loading (-1 -> -3)
+    DWORD Flag : 1;   // can *.ExtensionAndData be opened?
 };
 
 class CAssociationData
 {
 public:
-    char* ExtensionAndData; // alokovano po DWORDech, konce nulovane (kvuli porovnavani);
-                            // extension + navic pripojen string s icon-location;
-    char* Type;             // retezec file-type; misto "" je NULL (setrime pamet)
+    char* ExtensionAndData; // allocated on DWORD boundaries, null-terminated at the end (for comparison);
+                            // extension + additionally appended string with icon-location;
+    char* Type;             // file-type string; NULL is used instead of "" (to save memory)
 
 private:
-    // pro kazdy rozmer ikon potrebujeme par Index+Flag
+    // We need an Index+Flag pair for each icon size.
     CAssociationIndexAndFlag IndexAndFlag[ICONSIZE_COUNT];
 
 public:
@@ -195,7 +195,7 @@ public:
         }
         DWORD index = IndexAndFlag[iconSize].Index;
         if (index & 0x40000000)
-            index |= 0x80000000; // neumi 31-bit int na 32-bit int ...
+            index |= 0x80000000; // sign-extend 31-bit int to 32-bit int ...
         return index;
     }
 
@@ -226,7 +226,7 @@ public:
 // CAssociations
 //
 
-#define ASSOC_ICON_NO_ASSOC 0 // pevne ikonky v cache-bitmape CAssociations
+#define ASSOC_ICON_NO_ASSOC 0 // fixed icons in the CAssociations cache bitmap
 #define ASSOC_ICON_SOME_FILE 1
 #define ASSOC_ICON_SOME_EXE 2
 #define ASSOC_ICON_SOME_DIR 3
@@ -235,8 +235,8 @@ public:
 struct CAssociationsIcons
 {
 public:
-    TIndirectArray<CIconList> IconsCache; // pole bitmap slouzici jako cache na ikonky
-    int IconsCount;                       // pocet zaplnenych mist v bitmapach (ikon)
+    TIndirectArray<CIconList> IconsCache; // array of bitmaps used as the icon cache
+    int IconsCount;                       // number of occupied slots in the icon bitmaps
 
 public:
     CAssociationsIcons() : IconsCache(10, 5)
@@ -254,43 +254,43 @@ public:
     CAssociations();
     ~CAssociations();
 
-    void Release(); // uvolneni celeho pole + invalidate cache
-    void Destroy(); // uvolneni celeho pole + cache
+    void Release(); // release the entire array + invalidate cache
+    void Destroy(); // release the entire array + cache
 
-    // vsechny -3 -> -1
+    // all -3 -> -1
     //    void SetAllReadingToUnread();
 
-    // seradi pole pro rychle vyhledavani
+    // Sorts the array for fast lookup.
     void SortArray(int left, int right);
 
-    // vraci "nalezeno ?" a index polozky nebo kam se ma vlozit (razene pole);
-    // 'name' musi byt zarovnane po DWORDech ;
+    // Returns "found?" and the item index, or the insertion position (sorted array);
+    // 'name' must be DWORD-aligned;
     BOOL GetIndex(const char* name, int& index);
 
-    // allokuje misto pro ikonku; vraci jeji index nebo -1 pri chybe
-    // promenne 'iconList' a 'iconListIndex' mohou byt NULL (pak nejsou nastavovany)
-    // jinak 'iconList' vraci ukazatel na CIconList, ktery nese ikonu a 'iconListIndex'
-    // je index v ramci tohoto imagelistu.
+    // Allocates space for an icon; returns its index or -1 on error.
+    // Variables 'iconList' and 'iconListIndex' may be NULL (then they are not set).
+    // Otherwise, 'iconList' returns a pointer to the CIconList carrying the icon and
+    // 'iconListIndex' is the index within that image list.
     int AllocIcon(CIconList** iconList, int* imageIconIndex, CIconSizeEnum iconSize);
 
-    // vrati v 'iconList' ukazatel na IconList a v 'iconListIndex' pozici ikonky
-    // 'iconIndex' (vracene z AllocIcon);
+    // Returns in 'iconList' a pointer to IconList and in 'iconListIndex' the icon position
+    // for 'iconIndex' (returned by AllocIcon);
     BOOL GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex, CIconSizeEnum iconSize);
 
-    // musi prekreslit zakladni sadu ikon s novym pozadim
+    // Must redraw the base icon set with the new background.
     void ColorsChanged();
 
     void ReadAssociations(BOOL showWaitWnd);
 
-    // ext musi byt zarovnan po DWORDech
+    // ext must be DWORD-aligned
     BOOL IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum iconSize);
     BOOL IsAssociatedStatic(char* ext, const char*& iconLocation, CIconSizeEnum iconSize);
     BOOL IsAssociated(char* ext);
 
 protected:
-    // pomocna metoda
+    // Helper method.
     void InsertData(const char* origin, int index, BOOL overwriteItem, char* e, char* s,
                     CAssociationData& data, LONG& size, const char* iconLocation, const char* type);
 };
 
-extern CAssociations Associations; // zde jsou zalozeny nactene asociace
+extern CAssociations Associations; // loaded associations are stored here


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/icncache.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 49 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 59 comment units, 59 review results, 59 resolved results, and 59 apply results.
- Branch-target comment guard passed for `src/icncache.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/icncache.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 164892 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 7 calls, 144003 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 20889 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
