### PR TITLE
[translation] Fix src/icncache.cpp comments

### DIFF
--- a/src/icncache.cpp
+++ b/src/icncache.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/icncache.cpp
+++ b/src/icncache.cpp
@@ -10,8 +10,8 @@
 #include "geticon.h"
 #include "logo.h"
 
-// melo by byt nasobkem hodnoty IL_ITEMS_IN_ROW
-// aby se plne vyuzil prostor v bitmape
+// should be a multiple of IL_ITEMS_IN_ROW
+// to fully use the space in the bitmap
 #define ICONS_IN_LIST 100
 
 //
@@ -21,11 +21,11 @@
 
 CIconCache::CIconCache()
     : TDirectArray<CIconData>(50, 30),
-      IconsCache(10, 5),     // jedna polozka je CIconList drzici ICONS_IN_LIST ikonek
-      ThumbnailsCache(1, 20) // ziskavani thumbnailu je pomale, relokace je v tom hracka
+      IconsCache(10, 5),     // one item is a CIconList holding ICONS_IN_LIST icons
+      ThumbnailsCache(1, 20) // obtaining thumbnails is slow, relocation is trivial by comparison
 {
     IconsCount = 0;
-    IconSize = ICONSIZE_COUNT; // zatim nenastaveno; pokus o pridani ikonky bez predchoziho volani SetIconSize() zpusobi TRACE_E
+    IconSize = ICONSIZE_COUNT; // not set yet; trying to add an icon without calling SetIconSize() first triggers TRACE_E
     DataIfaceForFS = NULL;
 }
 
@@ -35,12 +35,12 @@ CIconCache::~CIconCache()
 }
 
 inline int CompareDWORDS(const char* s1, const char* s2, int length)
-{ // porovna nejvyse 'length' DWORDu
+{ // compares at most 'length' DWORDs
     //  int res;
     const char* end = s1 + length;
     while (s1 <= end)
     {
-        //    if ((res = *(DWORD *)s1 - *(DWORD *)s2) != 0) return res;  // takhle to nejde (zkus si 0x8 a 0x0 ve 4-bitovych cislech)
+        //    if ((res = *(DWORD *)s1 - *(DWORD *)s2) != 0) return res;  // this does not work (try 0x8 and 0x0 as 4-bit numbers)
         if (*(DWORD*)s1 > *(DWORD*)s2)
             return 1;
         else
@@ -56,12 +56,12 @@ inline int CompareDWORDS(const char* s1, const char* s2, int length)
 
 void CIconCache::SortArray(int left, int right, CPluginDataInterfaceEncapsulation* dataIface)
 {
-    if (dataIface != NULL) // jde o pitFromPlugin: nechame plugin, aby polozky porovnal sam (musi jit o porovnani
-    {                      // beze shod zadnych dvou polozek listingu)
+    if (dataIface != NULL) // this is pitFromPlugin: let the plugin compare the items itself (the comparison must not treat any two listing items as equal)
+    {                      // with no two identical listing items)
         DataIfaceForFS = dataIface;
         BOOL ok = TRUE;
         int i;
-        for (i = left; i <= right; i++) // jeden paranoicky testik
+        for (i = left; i <= right; i++) // one paranoid check
         {
             if (Data[i].GetFSFileData() == NULL)
             {
@@ -74,7 +74,7 @@ void CIconCache::SortArray(int left, int right, CPluginDataInterfaceEncapsulatio
             SortArrayForFSInt(left, right);
         DataIfaceForFS = NULL;
     }
-    else // klasicke razeni podle jmen
+    else // standard sorting by name
     {
         SortArrayInt(left, right);
     }
@@ -106,7 +106,8 @@ LABEL_SortArrayInt:
         }
     } while (i <= j);
 
-    // nasledujici "hezky" kod jsme nahradili kodem podstatne setricim stack (max. log(N) zanoreni rekurze)
+    // The following "nice" code was replaced with code that saves substantially more stack
+    // space (maximum recursion depth log(N)).
     //  if (left < j) SortArrayInt(left, j);
     //  if (i < right) SortArrayInt(i, right);
 
@@ -114,7 +115,7 @@ LABEL_SortArrayInt:
     {
         if (i < right)
         {
-            if (j - left < right - i) // je potreba seradit obe "poloviny", tedy do rekurze posleme tu mensi, tu druhou zpracujeme pres "goto"
+            if (j - left < right - i) // Both halves need to be sorted: recurse into the smaller one and process the other via goto.
             {
                 SortArrayInt(left, j);
                 left = i;
@@ -168,7 +169,7 @@ LABEL_SortArrayForFSInt:
         }
     } while (i <= j);
 
-    // nasledujici "hezky" kod jsme nahradili kodem podstatne setricim stack (max. log(N) zanoreni rekurze)
+    // The following "nice" code was replaced with code that uses significantly less stack (maximum recursion depth log(N)).
     //  if (left < j) SortArrayForFSInt(left, j);
     //  if (i < right) SortArrayForFSInt(i, right);
 
@@ -176,7 +177,7 @@ LABEL_SortArrayForFSInt:
     {
         if (i < right)
         {
-            if (j - left < right - i) // je potreba seradit obe "poloviny", tedy do rekurze posleme tu mensi, tu druhou zpracujeme pres "goto"
+            if (j - left < right - i) // Both halves need to be sorted, so recurse into the smaller one and process the other using goto.
             {
                 SortArrayForFSInt(left, j);
                 left = i;
@@ -208,7 +209,7 @@ LABEL_SortArrayForFSInt:
 BOOL CIconCache::GetIndex(const char* name, int& index, CPluginDataInterfaceEncapsulation* dataIface,
                           const CFileData* file)
 {
-    if (Count == 0 || dataIface != NULL && file == NULL) // overime platnost 'file'
+    if (Count == 0 || dataIface != NULL && file == NULL) // verify that 'file' is valid
     {
         if (dataIface != NULL && file == NULL)
             TRACE_E("CIconCache::GetIndex(): 'file' may not be NULL when 'dataIface' is not NULL! item=" << name);
@@ -216,8 +217,8 @@ BOOL CIconCache::GetIndex(const char* name, int& index, CPluginDataInterfaceEnca
         return FALSE;
     }
 
-    if (dataIface != NULL) // jde o pitFromPlugin: nechame plugin, aby polozky porovnal sam (musi jit o porovnani
-    {                      // beze shod zadnych dvou polozek listingu)
+    if (dataIface != NULL) // this is pitFromPlugin: let the plugin compare the items itself (the comparison must not treat any two listing items as equal)
+    {                      // with no two identical listing items)
         int l = 0, r = Count - 1, m;
         int res;
         while (1)
@@ -232,34 +233,34 @@ BOOL CIconCache::GetIndex(const char* name, int& index, CPluginDataInterfaceEnca
                         "for item: "
                         << At(m).NameAndData);
                 index = 0;
-                return FALSE; // chyba -> vratime treba: nenalezeno, vlozit na zacatek pole
+                return FALSE; // error -> return as if not found: insert at the beginning of the array
             }
-            if (res == 0) // nalezeno
+            if (res == 0) // found
             {
                 index = m;
                 return TRUE;
             }
             else if (res > 0)
             {
-                if (l == r || l > m - 1) // nenalezeno
+                if (l == r || l > m - 1) // not found
                 {
-                    index = m; // mel by byt na teto pozici
+                    index = m; // it should be at this position
                     return FALSE;
                 }
                 r = m - 1;
             }
             else
             {
-                if (l == r) // nenalezeno
+                if (l == r) // not found
                 {
-                    index = m + 1; // mel by byt az za touto pozici
+                    index = m + 1; // it should be just after this position
                     return FALSE;
                 }
                 l = m + 1;
             }
         }
     }
-    else // klasicke hledani podle jmena
+    else // classic search by name
     {
         int length = (int)strlen(name);
         int l = 0, r = Count - 1, m;
@@ -268,25 +269,25 @@ BOOL CIconCache::GetIndex(const char* name, int& index, CPluginDataInterfaceEnca
         {
             m = (l + r) / 2;
             res = CompareDWORDS(At(m).NameAndData, name, length);
-            if (res == 0) // nalezeno
+            if (res == 0) // found
             {
                 index = m;
                 return TRUE;
             }
             else if (res > 0)
             {
-                if (l == r || l > m - 1) // nenalezeno
+                if (l == r || l > m - 1) // not found
                 {
-                    index = m; // mel by byt na teto pozici
+                    index = m; // it should be at this position
                     return FALSE;
                 }
                 r = m - 1;
             }
             else
             {
-                if (l == r) // nenalezeno
+                if (l == r) // not found
                 {
-                    index = m + 1; // mel by byt az za touto pozici
+                    index = m + 1; // it should be just after this position
                     return FALSE;
                 }
                 l = m + 1;
@@ -307,31 +308,31 @@ void CIconCache::Release()
     DestroyMembers();
     IconsCount = 0;
 
-    // destrukce raw dat z ThumbnailsCache
+    // destroy the raw data from ThumbnailsCache
     for (i = 0; i < ThumbnailsCache.Count; i++)
     {
         CThumbnailData* data = &ThumbnailsCache[i];
         if (data->Bits != NULL)
-            free(data->Bits); // alokovano v CSalamanderThumbnailMaker::RenderToThumbnailData()
+            free(data->Bits); // allocated in CSalamanderThumbnailMaker::RenderToThumbnailData()
     }
     ThumbnailsCache.DestroyMembers();
 }
 
 void CIconCache::Destroy()
 {
-    // uvonime alokovana data a pole samotne
+    // free the allocated data and the array itself
     Release();
 
-    // destrukce imagelistu z IconsCache
+    // destroy the image lists from IconsCache
     IconsCache.DestroyMembers();
 }
 
 void CIconCache::ColorsChanged()
 {
     CALL_STACK_MESSAGE1("CIconCache::ColorsChanged()");
-    // tato funkce je volana pri zmene barev nebo barevne hloubky obrazovky
-    // druhy pripad neni reseny -- bylo by treba znovu konstruovat bitmapy
-    // v imagelistech pro aktualni barevnou hloubku
+    // this function is called when the screen colors or color depth change
+    // the second case is not handled; it would be necessary to reconstruct the bitmaps
+    // in the image lists for the current color depth
     COLORREF bkColor = GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]);
     int i;
     for (i = 0; i < IconsCache.Count; i++)
@@ -341,13 +342,13 @@ void CIconCache::ColorsChanged()
             il->SetBkColor(bkColor);
     }
 
-    // thumbnaily je potreba prekreslit, pokud se zmenila barva pozadi, budou se ikonky s pruhlednymi
-    // castmi kreslit do nove barvy pozadi
+    // thumbnails need to be redrawn if the background color changed; icons with transparent
+    // parts will be drawn onto the new background color
     for (i = 0; i < Count; i++)
     {
         CIconData* icon = &At(i);
-        if (icon->GetFlag() == 5 /* o.k. thumbnail */)
-            icon->SetFlag(6 /* stara verze thumbnailu */);
+        if (icon->GetFlag() == 5 /* valid thumbnail */)
+            icon->SetFlag(6 /* old thumbnail version */);
     }
 }
 
@@ -355,7 +356,7 @@ int CIconCache::AllocIcon(CIconList** iconList, int* iconListIndex)
 {
     SLOW_CALL_STACK_MESSAGE1("CIconCache::AllocIcon()");
     int cache = IconsCount / ICONS_IN_LIST; // cache
-    int index = IconsCount % ICONS_IN_LIST; // index v ramci teto cache
+    int index = IconsCount % ICONS_IN_LIST; // index within this cache
     if (cache >= IconsCache.Count)
     {
         if (cache > IconsCache.Count)
@@ -408,11 +409,11 @@ int CIconCache::AllocThumbnail()
 {
     CALL_STACK_MESSAGE1("CIconCache::AllocThumbnail()");
 
-    // stuktura pro drzeni thumbnailu
+    // structure for holding thumbnails
     CThumbnailData data;
     memset(&data, 0, sizeof(CThumbnailData));
 
-    // zaradime jej do seznamu
+    // add it to the list
     int index = ThumbnailsCache.Add(data);
     if (!ThumbnailsCache.IsGood())
     {
@@ -420,7 +421,7 @@ int CIconCache::AllocThumbnail()
         return -1;
     }
 
-    // vratime index pridaneho prvku
+    // returns the index of the added item
     return index;
 }
 
@@ -446,7 +447,7 @@ BOOL CIconCache::GetIcon(int iconIndex, CIconList** iconList, int* iconListIndex
     if (iconIndex >= 0 && iconIndex < IconsCount)
     {
         int cache = iconIndex / ICONS_IN_LIST; // cache
-        int index = iconIndex % ICONS_IN_LIST; // index v ramci cache
+        int index = iconIndex % ICONS_IN_LIST; // index within the cache
         if (cache < IconsCache.Count)
         {
             *iconList = IconsCache[cache];
@@ -473,8 +474,8 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
     int index1 = 0;
     int index2 = 0;
 
-    if (dataIface != NULL) // jde o pitFromPlugin: nechame plugin, aby polozky porovnal sam (musi jit o porovnani
-    {                      // beze shod zadnych dvou polozek listingu)
+    if (dataIface != NULL) // This is pitFromPlugin: let the plugin compare the items itself.
+    {                      // with no two identical listing items)
         const CFileData *file1, *file2;
 
         if (index1 < Count)
@@ -489,7 +490,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
             }
         }
         else
-            return; // neni co spojovat
+            return; // nothing to merge
 
         if (index2 < icons->Count)
         {
@@ -503,12 +504,12 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
             }
         }
         else
-            return; // neni co spojovat
+            return; // nothing to merge
         int res;
         while (1)
         {
             res = dataIface->CompareFilesFromFS(file1, file2);
-            if (res == 0) // shodne -> provedeme kopii (ikony a masky)
+            if (res == 0) // identical -> copy them (icons and masks)
             {
                 CIconList* srcIconList;
                 int srcIconListIndex;
@@ -518,13 +519,13 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
 
                 DWORD flag = icons->At(index2).GetFlag();
 
-                if ((flag == 1 || flag == 2) &&  // platna nebo stara ikona
-                    At(index1).GetFlag() == 0 && // zajima nas ikona (pokud doslo k prepnuti na thumbnail, starou ikonu nepotrebujeme)
+                if ((flag == 1 || flag == 2) &&  // valid or old icon
+                    At(index1).GetFlag() == 0 && // we care about the icon (if it switched to a thumbnail, the old icon is no longer needed)
                     GetIcon(At(index1).GetIndex(), &dstIconList, &dstIconListIndex) &&
                     icons->GetIcon(icons->At(index2).GetIndex(), &srcIconList, &srcIconListIndex))
                 {
                     dstIconList->Copy(dstIconListIndex, srcIconList, srcIconListIndex);
-                    At(index1).SetFlag((flag == 1 && transferIconsAndThumbnailsAsNew) ? 1 : 2); // ted uz je to stara (nebo platna/nova) verze ikony
+                    At(index1).SetFlag((flag == 1 && transferIconsAndThumbnailsAsNew) ? 1 : 2); // now it is the old (or valid/new) icon version
                 }
             }
 
@@ -542,7 +543,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                     }
                 }
                 else
-                    break; // uz neni co spojovat
+                    break; // nothing left to merge
             }
 
             if (res == 0 || res > 0) // index2++
@@ -559,7 +560,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                     }
                 }
                 else
-                    break; // uz neni co spojovat
+                    break; // nothing left to merge
             }
         }
     }
@@ -574,17 +575,17 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
             length = (int)strlen(name1);
         }
         else
-            return; // neni co spojovat
+            return; // nothing to merge
 
         if (index2 < icons->Count)
             name2 = icons->At(index2).NameAndData;
         else
-            return; // neni co spojovat
+            return; // nothing to merge
         int res;
         while (1)
         {
             res = CompareDWORDS(name1, name2, length);
-            if (res == 0) // shodne -> provedeme kopii (ikony a masky) || thumbnailu
+            if (res == 0) // match -> copy the icons and masks, or the thumbnail
             {
                 CIconList* srcIconList;
                 int srcIconListIndex;
@@ -594,33 +595,33 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
 
                 DWORD flag = icons->At(index2).GetFlag();
 
-                if ((flag == 1 || flag == 2) &&  // platna nebo stara ikona
-                    At(index1).GetFlag() == 0 && // zajima nas ikona (pokud doslo k prepnuti na thumbnail, starou ikonu nepotrebujeme)
+                if ((flag == 1 || flag == 2) &&  // valid or old icon
+                    At(index1).GetFlag() == 0 && // we care about the icon (if it switched to a thumbnail, the old icon is no longer needed)
                     GetIcon(At(index1).GetIndex(), &dstIconList, &dstIconListIndex) &&
                     icons->GetIcon(icons->At(index2).GetIndex(), &srcIconList, &srcIconListIndex))
                 {
                     dstIconList->Copy(dstIconListIndex, srcIconList, srcIconListIndex);
-                    At(index1).SetFlag((flag == 1 && transferIconsAndThumbnailsAsNew) ? 1 : 2); // ted uz je to stara (nebo platna/nova) verze ikony
+                    At(index1).SetFlag((flag == 1 && transferIconsAndThumbnailsAsNew) ? 1 : 2); // now it is the old (or valid/new) icon version
                 }
                 else
                 {
                     CThumbnailData* srcThumbnailData;
                     CThumbnailData* tgtThumbnailData;
 
-                    if ((flag == 5 || flag == 6) &&  // platny nebo stary thumbnail
-                        At(index1).GetFlag() == 4 && // zajima nas thumbnail (pokud doslo k prepnuti na ikonu, stary thumbnail nepotrebujeme)
+                    if ((flag == 5 || flag == 6) &&  // valid or old thumbnail
+                        At(index1).GetFlag() == 4 && // we care about the thumbnail (if it switched to an icon, the old thumbnail is no longer needed)
                         GetThumbnail(At(index1).GetIndex(), &tgtThumbnailData) &&
                         icons->GetThumbnail(icons->At(index2).GetIndex(), &srcThumbnailData))
                     {
-                        // stary thumbnail neni treba kopirovat -- staci predat jeho
-                        // geometrii a raw data do ciloveho thumbnailu
-                        *tgtThumbnailData = *srcThumbnailData; // predame stara data do nove cache
-                        srcThumbnailData->Bits = NULL;         // stara cache zanika a nesmi se dealokovat data
+                        // the old thumbnail does not need to be copied; it is enough to pass its
+                        // geometry and raw data to the target thumbnail
+                        *tgtThumbnailData = *srcThumbnailData; // pass the old data to the new cache
+                        srcThumbnailData->Bits = NULL;         // the old cache is going away and must not deallocate the data
 
                         int newFlag = 6;
-                        // pokud kopirujeme platny thumbnail, zkontrolujeme znamku souboru (size+date), pripadne
-                        // zkopirovany thumbnail oznacime rovnou jako platny (hrozba zmeny souboru beze zmeny
-                        // size+date je miziva a rychlostni zisk je obrovsky)
+                        // if we are copying a valid thumbnail, check the file stamp (size+date); if appropriate,
+                        // mark the copied thumbnail as valid immediately (the risk of the file changing without
+                        // changing size+date is negligible, while the speed gain is huge)
                         if (flag == 5 && !forceReloadThumbnails)
                         {
                             if (transferIconsAndThumbnailsAsNew)
@@ -628,7 +629,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                             else
                             {
                                 int offset = length + 4;
-                                offset -= (offset & 0x3); // offset % 4  (zarovnani po ctyrech bytech)
+                                offset -= (offset & 0x3); // offset % 4  (4-byte alignment)
                                 if (*(CQuadWord*)(name1 + offset) == *(CQuadWord*)(name2 + offset) &&
                                     CompareFileTime((FILETIME*)(name1 + offset + sizeof(CQuadWord)),
                                                     (FILETIME*)(name2 + offset + sizeof(CQuadWord))) == 0)
@@ -637,7 +638,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                                 }
                             }
                         }
-                        At(index1).SetFlag(newFlag); // ted uz je to stara (nebo platna/nova) verze thumbnailu
+                        At(index1).SetFlag(newFlag); // now it is the old (or valid/new) thumbnail version
                     }
                 }
             }
@@ -650,7 +651,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                     length = (int)strlen(name1);
                 }
                 else
-                    break; // uz neni co spojovat
+                    break; // nothing left to merge
             }
 
             if (res == 0 || res > 0) // index2++
@@ -658,7 +659,7 @@ void CIconCache::GetIconsAndThumbsFrom(CIconCache* icons, CPluginDataInterfaceEn
                 if (++index2 < icons->Count)
                     name2 = icons->At(index2).NameAndData;
                 else
-                    break; // uz neni co spojovat
+                    break; // nothing left to merge
             }
         }
     }
@@ -671,10 +672,10 @@ void CIconCache::SetIconSize(CIconSizeEnum iconSize)
         TRACE_E("CIconCache::SetIconSize() unexpected iconSize==ICONSIZE_COUNT");
         return;
     }
-    if (iconSize == IconSize) // pokud se nemeni velikost, neni co resit
+    if (iconSize == IconSize) // if the size is not changing, there is nothing to do
         return;
 
-    // zahodime soucasne ikonky
+    // discard the current icons
     int i;
     for (i = 0; i < Count; i++)
     {
@@ -738,7 +739,7 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
     {
         type[0] = 0;
 
-        // file-type retezec ziskame jako value "" podklice keyName
+        // get the file-type string as the value "" of the keyName subkey
         if (HANDLES_Q(RegOpenKey(root, keyNameBuf, &openKey)) == ERROR_SUCCESS)
         {
             LONG typeSize = MAX_PATH;
@@ -748,11 +749,11 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
         }
     }
 
-    if (size - 1 + 7 <= MAX_PATH) // test na moznost otevirani pres asociace
+    if (size - 1 + 7 <= MAX_PATH) // test whether opening via associations is possible
     {
         memmove(keyNameBuf + size - 1, "\\Shell", 7);
         if (HANDLES_Q(RegOpenKey(root, keyNameBuf, &openKey)) == ERROR_SUCCESS)
-        { // obsahuje-li "\\shell" nejaky podklic, da se otvirat (asociace na Enter)
+        { // if "\\shell" contains any subkey, it can be opened (association for Enter)
             DWORD keys;
             if (RegQueryInfoKey(openKey, NULL, NULL, NULL, &keys, NULL,
                                 NULL, NULL, NULL, NULL, NULL, NULL) == ERROR_SUCCESS)
@@ -767,7 +768,7 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
     if (size - 1 + 21 <= MAX_PATH)
     {
         memmove(keyNameBuf + size - 1, "\\ShellEx\\IconHandler", 21);
-        // obsahuje-li "\\ShellEx\\IconHandler", musi se tahat ze souboru
+        // if "\\ShellEx\\IconHandler" is present, the icon must be loaded from the file
         if (HANDLES_Q(RegOpenKey(root, keyNameBuf, &openKey)) == ERROR_SUCCESS)
         {
             found = TRUE;
@@ -783,7 +784,7 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
         if (HANDLES_Q(RegOpenKey(root, keyNameBuf, &openKey)) == ERROR_SUCCESS)
         {
             char buf[MAX_PATH];
-            size = MAX_PATH; // ziskani cesty k ikone
+            size = MAX_PATH; // get the path to the icon
             DWORD type2 = REG_SZ;
             DWORD err = SalRegQueryValueEx(openKey, "", 0, &type2,
                                            (LPBYTE)buf, (LPDWORD)&size);
@@ -803,7 +804,7 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
                 else
                     strcpy(iconLocation, buf);
 
-                // odstranime uvozovky v pripade "\"jmeno_souboru\",cislo_ikony" (napr. "\"C:\\Program Files\\VideoLAN\\VLC\\vlc.exe\",0")
+                // remove quotes in the case "\"file_name\",icon_number" (for example "\"C:\\Program Files\\VideoLAN\\VLC\\vlc.exe\",0")
                 char* num = strrchr(iconLocation, ',');
                 if (num != NULL)
                 {
@@ -817,15 +818,15 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
                     char* numBeg = numEnd + 1;
                     while (*++numEnd >= '0' && *numEnd <= '9')
                         ;
-                    if (numBeg < numEnd && *numEnd == 0 &&                                   // cislo ikony je za posledni carkou
-                        *iconLocation == '"' && num - 1 > iconLocation && *(num - 1) == '"') // na zacatku a pred carkou jsou uvozovky
-                    {                                                                        // odstranime uvozovky
+                    if (numBeg < numEnd && *numEnd == 0 &&                                   // the icon number is after the last comma
+                        *iconLocation == '"' && num - 1 > iconLocation && *(num - 1) == '"') // there are quotes at the beginning and before the comma
+                    {                                                                        // remove the quotes
                         memmove(iconLocation, iconLocation + 1, (num - 1) - (iconLocation + 1));
                         memmove(num - 2, num, numEnd - num + 1);
                     }
                 }
 
-                char* s = buf; // rozliseni typu "%1" od "...%promenna%..."
+                char* s = buf; // distinguish "%1" from "...%variable%..."
                 while (*s != 0)
                 {
                     if (*s == '%')
@@ -835,7 +836,7 @@ BOOL GetIconFromAssocAux(BOOL initFlagAndIndexes, HKEY root, const char* keyName
                         {
                             while (*s != 0 && *s != ' ' && *s != '%')
                                 s++;
-                            if (*s != '%') // neni to env. promenna -> dynamicky typ
+                            if (*s != '%') // not an environment variable -> dynamic type
                             {
                                 data.SetIndexAll(-2);
                                 break;
@@ -879,10 +880,10 @@ void CAssociations::Release()
 
 void CAssociations::Destroy()
 {
-    // uvonime alokovana data a pole samotne
+    // free the allocated data and the array itself
     Release();
 
-    // destrukce imagelistu z IconsCache
+    // destroy the image lists from IconsCache
     int i;
     for (i = 0; i < ICONSIZE_COUNT; i++)
         Icons[i].IconsCache.DestroyMembers();
@@ -891,9 +892,9 @@ void CAssociations::Destroy()
 void CAssociations::ColorsChanged()
 {
     CALL_STACK_MESSAGE1("CAssociations::ColorsChanged()");
-    // tato funkce je volana pri zmene barev nebo barevne hloubky obrazovky
-    // druhy pripad neni reseny -- bylo by treba znovu konstruovat bitmapy
-    // v imagelistech pro aktualni barevnou hloubku
+    // this function is called when the screen colors or color depth change
+    // the second case is not handled; it would be necessary to reconstruct the bitmaps
+    // in the image lists for the current color depth
     COLORREF bkColor = GetCOLORREF(CurrentColors[ITEM_BK_NORMAL]);
     int j;
     for (j = 0; j < ICONSIZE_COUNT; j++)
@@ -906,7 +907,7 @@ void CAssociations::ColorsChanged()
                 il->SetBkColor(bkColor);
         }
     }
-    // FIXME: stacilo by nastavovat pozadi pouze pro patricny iconlist
+    // FIXME: it would be enough to set the background only for the relevant icon list
     int i;
     for (i = 0; i < ICONSIZE_COUNT; i++)
         SimpleIconLists[i]->SetBkColor(bkColor);
@@ -927,25 +928,25 @@ BOOL CAssociations::GetIndex(const char* name, int& index)
     {
         m = (l + r) / 2;
         res = CompareDWORDS(At(m).ExtensionAndData, name, length);
-        if (res == 0) // nalezeno
+        if (res == 0) // found
         {
             index = m;
             return TRUE;
         }
         else if (res > 0)
         {
-            if (l == r || l > m - 1) // nenalezeno
+            if (l == r || l > m - 1) // not found
             {
-                index = m; // mel by byt na teto pozici
+                index = m; // it should be at this position
                 return FALSE;
             }
             r = m - 1;
         }
         else
         {
-            if (l == r) // nenalezeno
+            if (l == r) // not found
             {
-                index = m + 1; // mel by byt az za touto pozici
+                index = m + 1; // it should be just after this position
                 return FALSE;
             }
             l = m + 1;
@@ -957,7 +958,7 @@ int CAssociations::AllocIcon(CIconList** iconList, int* iconListIndex, CIconSize
 {
     CALL_STACK_MESSAGE1("CAssociations::AllocIcon()");
     int cache = Icons[iconSize].IconsCount / ICONS_IN_LIST; // cache
-    int index = Icons[iconSize].IconsCount % ICONS_IN_LIST; // index v ramci teto cache
+    int index = Icons[iconSize].IconsCount % ICONS_IN_LIST; // index within this cache
     if (cache >= Icons[iconSize].IconsCache.Count)
     {
         if (cache > Icons[iconSize].IconsCache.Count)
@@ -1008,7 +1009,7 @@ BOOL CAssociations::GetIcon(int iconIndex, CIconList** iconList, int* iconListIn
     if (iconIndex >= 0 && iconIndex < Icons[iconSize].IconsCount)
     {
         int cache = iconIndex / ICONS_IN_LIST; // cache
-        int index = iconIndex % ICONS_IN_LIST; // index v ramci cache
+        int index = iconIndex % ICONS_IN_LIST; // index within the cache
         if (cache < Icons[iconSize].IconsCache.Count)
         {
             *iconList = Icons[iconSize].IconsCache[cache];
@@ -1054,7 +1055,8 @@ LABEL_SortArray:
         }
     } while (i <= j);
 
-    // nasledujici "hezky" kod jsme nahradili kodem podstatne setricim stack (max. log(N) zanoreni rekurze)
+    // We replaced the following "nice" code with code that uses substantially less stack space
+    //  // (maximum recursion depth of log(N)).
     //  if (left < j) SortArray(left, j);
     //  if (i < right) SortArray(i, right);
 
@@ -1062,7 +1064,7 @@ LABEL_SortArray:
     {
         if (i < right)
         {
-            if (j - left < right - i) // je potreba seradit obe "poloviny", tedy do rekurze posleme tu mensi, tu druhou zpracujeme pres "goto"
+            if (j - left < right - i) // Both "halves" must be sorted, so recurse into the smaller one and process the other via "goto"
             {
                 SortArray(left, j);
                 left = i;
@@ -1099,13 +1101,13 @@ void CAssociations::InsertData(const char* /*origin*/, int index, BOOL overwrite
     //          ": type=" << (type == NULL ? "" : type));
 
     size = (LONG)(s - e) + 4;
-    size -= (size & 0x3); // size % 4  (zarovnani po ctyrech bytech)
+    size -= (size & 0x3); // size % 4 (alignment to four bytes)
     int iLen = (int)strlen(iconLocation) + 1;
     data.ExtensionAndData = (char*)malloc(size + iLen);
-    memcpy(data.ExtensionAndData, e, size);                   // pripona + zarovnani nul +
+    memcpy(data.ExtensionAndData, e, size);                   // extension + null padding +
     memcpy(data.ExtensionAndData + size, iconLocation, iLen); // icon-location
     if (type[0] != 0)
-        data.Type = DupStr(type); // chyba -> jen se neukaze file-type
+        data.Type = DupStr(type); // error -> only the file type stays hidden
     else
         data.Type = NULL;
     if (overwriteItem)
@@ -1122,28 +1124,28 @@ void CAssociations::InsertData(const char* /*origin*/, int index, BOOL overwrite
 
 void CAssociations::ReadAssociations(BOOL showWaitWnd)
 {
-    //---  nahozeni dialogu cekani + hodin
+    //---  bring up the wait dialog and hourglass
     HCURSOR oldCur;
     HWND parent = (MainWindow != NULL) ? MainWindow->HWindow : NULL;
-    // wait okenko zlobilo:
-    // pokud dam nad souborem Open With a zvolim napriklad NOTEPAD, ten se otevre
-    // potom se rozesle notifikace o zmene asociaci SHCNE_ASSOCCHANGED
-    // v dusledku se zavola tato fce, ktera zobrazi okenko a vytahne ho nahoru
-    // s nim vytahne celeho Salamandera, proto ho docasne zakazuji
+    // The wait window was problematic:
+    // if I use Open With on a file and choose, for example, NOTEPAD, it opens,
+    // then SHCNE_ASSOCCHANGED notifications are broadcast for the association change,
+    // which calls this function, shows the wait window, and pulls it to the front,
+    // taking the whole Salamander window with it, so I disable it temporarily
     CWaitWindow waitWnd(parent, IDS_READINGASSOCIATIONS, FALSE, ooStatic);
     BOOL closeDialog = FALSE;
     if (!ExistSplashScreen())
     {
         if (showWaitWnd)
-            waitWnd.Create(); //j.r. pro ladeni shortcuty z desktopu
+            waitWnd.Create(); // j.r. for debugging desktop shortcuts
         oldCur = SetCursor(LoadCursor(NULL, IDC_WAIT));
         closeDialog = TRUE;
     }
     else
         IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_ASSOCIATIONS));
-    //---  vycisteni pole + cache
+    //---  clear the array and cache
     Release();
-    //---  projiti registry zaznamu o classech (extenzich)
+    //---  iterate through the registry records for classes (extensions)
     char ext[MAX_PATH + 4];
     char extType[MAX_PATH];
     char *s, *e;
@@ -1162,8 +1164,8 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
         systemFileAssoc = NULL;
     }
 
-    // Windows 2000 a novejsi maji jeste "Open With..." asociace ulozeny pro kazdeho usera zvlast
-    // v klici HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
+    // Windows 2000 and later also store "Open With..." associations separately for each user
+    // in HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Explorer\FileExts
     HKEY explorerFileExts;
     if (HANDLES_Q(RegOpenKey(HKEY_CURRENT_USER, "Software\\Microsoft\\Windows\\CurrentVersion\\Explorer\\FileExts",
                              &explorerFileExts)) != ERROR_SUCCESS)
@@ -1175,13 +1177,13 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
     LONG enumRet;
     FILETIME ft;
     while (1)
-    { // postupne enumnuti vsech pripon
+    { // enumerate all extensions one by one
         DWORD extS = MAX_PATH;
         if ((enumRet = RegEnumKeyEx(HKEY_CLASSES_ROOT, i, ext, &extS, NULL, NULL, NULL, &ft)) == ERROR_SUCCESS)
-        { // otevreni klice pripony
+        { // open the extension key
             if (ext[0] == '.' && HANDLES_Q(RegOpenKey(HKEY_CLASSES_ROOT, ext, &extKey)) == ERROR_SUCCESS)
             {
-                size = MAX_PATH; // ziskani typu asociace
+                size = MAX_PATH; // get the association type
                 iconLocation[0] = 0;
                 data.SetFlag(0);
                 data.SetIndexAll(-1);
@@ -1190,37 +1192,37 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
                 BOOL addExt = (SalRegQueryValue(extKey, "", extType, &size) == ERROR_SUCCESS && size > 1);
                 if (addExt)
                 {
-                    // test na typ ikony (staticka/dynamicka viz .h)
+                    // test the icon type (static/dynamic, see .h)
                     tryPerceivedType = !GetIconFromAssocAux(FALSE, HKEY_CLASSES_ROOT, extType, size, data, iconLocation, type);
                 }
                 else
                     tryPerceivedType = TRUE;
                 if (tryPerceivedType && systemFileAssoc != NULL)
                 {
-                    // nejdrive zkusime najit 'ext' pod klicem SystemFileAssociations
+                    // first try to find 'ext' under the SystemFileAssociations key
                     if (GetIconFromAssocAux(FALSE, systemFileAssoc, ext, (LONG)strlen(ext) + 1, data, iconLocation, NULL))
                         addExt = TRUE;
                     else
-                    { // zkusime jeste klic z hodnoty PerceivedType (je-li definovana)
+                    { // also try the key from the PerceivedType value, if it is defined
                         size = MAX_PATH;
                         if (SalRegQueryValueEx(extKey, "PerceivedType", NULL, NULL, (BYTE*)extType, (DWORD*)&size) == ERROR_SUCCESS && size > 1)
                         {
-                            extType[MAX_PATH - 1] = 0; // pro jistotu (hodnota nemusi byt typu string, pak muze chybet null-terminator)
+                            extType[MAX_PATH - 1] = 0; // just in case (the value may not be a string, so the null terminator may be missing)
                             if (GetIconFromAssocAux(FALSE, systemFileAssoc, extType, (LONG)strlen(extType) + 1, data, iconLocation, NULL))
                                 addExt = TRUE;
                         }
                     }
                 }
                 if (addExt)
-                {                // prevod ext. na mala pismena + pridani do pole
-                    e = ext + 1; // preskok '.'
+                {                // convert the extension to lowercase and add it to the array
+                    e = ext + 1; // skip '.'
                     s = e;
                     while (*s != 0)
                     {
                         *s = LowerCase[*s];
                         s++;
                     }
-                    *(DWORD*)s = 0; // nulovani konce stringu
+                    *(DWORD*)s = 0; // zero the end of the string
 
                     InsertData("", Count, FALSE, e, s, data, size, iconLocation, type);
                 }
@@ -1231,41 +1233,41 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
         {
             if (enumRet != ERROR_NO_MORE_ITEMS)
             {
-                // u jednoho usera (Bernard Vander Beken <Bernard.VanderBeken@deceuninck.com>) sem prijde
-                // jedna chyba ERROR_MORE_DATA, a pak spousta ERROR_OUTOFMEMORY, ma Microsoft Windows Server 2003,
-                // Standard Edition Service Pack 2 (Build 3790), zvetseni bufferu na 10000 nepomaha, nutne
-                // ukoncit enumeraci uz pri prvni chybe, jinak zacne cyklit a zarat pamet (zrejme jde
-                // o interni chybu Windowsu), nikdo dalsi to nehlasil, takze to dal neresime
+                // For one reported user, this returns
+                // one ERROR_MORE_DATA and then many ERROR_OUTOFMEMORY errors on Microsoft Windows Server 2003,
+                // Standard Edition Service Pack 2 (Build 3790). Increasing the buffer to 10000 does not help;
+                // enumeration must be stopped at the first error, otherwise it starts looping and eating memory
+                // (apparently an internal Windows bug). Nobody else reported it, so we do not investigate further.
                 _snprintf_s(errBuf, _TRUNCATE, LoadStr(IDS_UNABLETOGETASSOC), GetErrorText(enumRet));
                 SalMessageBox(parent, errBuf, LoadStr(IDS_UNABLETOGETASSOCTITLE), MB_OK | MB_ICONEXCLAMATION);
             }
-            break; // konec enumerace
+            break; // end of enumeration
         }
         i++;
     }
     if (Count > 1)
         SortArray(0, Count - 1);
 
-    // Windows XP maji asociace (viz PerceivedType) ulozeny jeste v klici HKEY_CLASSES_ROOT\SystemFileAssociations,
-    // nacteme dosud nezname pripony jeste z tohoto klice
+    // Windows XP also stores associations (see PerceivedType) under HKEY_CLASSES_ROOT\SystemFileAssociations,
+    // so load any extensions that are still unknown from this key as well
     if (systemFileAssoc != NULL)
     {
         i = 0;
         while (1)
-        { // postupne enumnuti vsech pripon
+        { // enumerate all extensions one by one
             DWORD extS = MAX_PATH;
             if ((enumRet = RegEnumKeyEx(systemFileAssoc, i, ext, &extS, NULL, NULL, NULL, &ft)) == ERROR_SUCCESS)
-            { // otevreni klice pripony
+            { // open the extension key
                 if (ext[0] == '.')
                 {
-                    e = ext + 1; // preskok '.'
+                    e = ext + 1; // skip '.'
                     s = ext;
                     while (*++s != 0)
                         *s = LowerCase[*s];
-                    *(DWORD*)s = 0; // nulovani konce stringu
+                    *(DWORD*)s = 0; // zero the end of the string
 
                     int index;
-                    if (!GetIndex(e, index)) // nenalezeno, ma smysl zkoumat + pripadne pridat
+                    if (!GetIndex(e, index)) // not found; it makes sense to check and add it if needed
                     {
                         if (GetIconFromAssocAux(TRUE, systemFileAssoc, ext, (LONG)strlen(ext) + 1, data, iconLocation, NULL))
                         {
@@ -1278,15 +1280,15 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
             {
                 if (enumRet != ERROR_NO_MORE_ITEMS)
                 {
-                    // u jednoho usera (Bernard Vander Beken <Bernard.VanderBeken@deceuninck.com>) sem prijde
-                    // jedna chyba ERROR_MORE_DATA, a pak spousta ERROR_OUTOFMEMORY, ma Microsoft Windows Server 2003,
-                    // Standard Edition Service Pack 2 (Build 3790), zvetseni bufferu na 10000 nepomaha, nutne
-                    // ukoncit enumeraci uz pri prvni chybe, jinak zacne cyklit a zrat pamet (zrejme jde
-                    // o interni chybu Windowsu), nikdo dalsi to nehlasil, takze to dal neresime
+                    // For one reported user, this returns
+                    // one ERROR_MORE_DATA and then many ERROR_OUTOFMEMORY errors on Microsoft Windows Server 2003,
+                    // Standard Edition Service Pack 2 (Build 3790). Increasing the buffer to 10000 does not help;
+                    // enumeration must be stopped at the first error, otherwise it starts looping and eating memory
+                    // (apparently an internal Windows bug). Nobody else reported it, so we do not investigate further.
                     _snprintf_s(errBuf, _TRUNCATE, LoadStr(IDS_UNABLETOGETASSOC), GetErrorText(enumRet));
                     SalMessageBox(parent, errBuf, LoadStr(IDS_UNABLETOGETASSOCTITLE), MB_OK | MB_ICONEXCLAMATION);
                 }
-                break; // konec enumerace
+                break; // end of enumeration
             }
             i++;
         }
@@ -1296,46 +1298,46 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
     {
         i = 0;
         while (1)
-        { // postupne enumnuti vsech pripon
+        { // enumerate all extensions one by one
             DWORD extS = MAX_PATH;
             if (RegEnumKeyEx(explorerFileExts, i, ext, &extS, NULL, NULL, NULL, &ft) == ERROR_SUCCESS)
-            { // otevreni klice pripony
+            { // open the extension key
                 if (ext[0] == '.' && HANDLES_Q(RegOpenKey(explorerFileExts, ext, &extKey)) == ERROR_SUCCESS)
                 {
-                    e = ext + 1; // preskok '.'
+                    e = ext + 1; // skip '.'
                     s = ext;
                     while (*++s != 0)
                         *s = LowerCase[*s];
-                    *(DWORD*)s = 0; // nulovani konce stringu
+                    *(DWORD*)s = 0; // zero the end of the string
 
                     int index;
                     BOOL found = GetIndex(e, index);
                     if (WindowsVistaAndLater && HANDLES_Q(RegOpenKey(extKey, "UserChoice", &openKey)) == ERROR_SUCCESS)
-                    {                    // zkusime, jestli neni asociovana pres klic UserChoice, pokud ano, je to neprioritnejsi zaznam, pripadne tedy prepiseme jiz existujici asociaci
-                        size = MAX_PATH; // ziskani typu asociace
+                    {                    // try whether it is associated through the UserChoice key; if so, it is the highest-priority record, so overwrite any association already found
+                        size = MAX_PATH; // get the association type
                         if (SalRegQueryValueEx(openKey, "Progid", NULL, NULL, (BYTE*)extType, (DWORD*)&size) == ERROR_SUCCESS && size > 1)
                         {
-                            extType[MAX_PATH - 1] = 0; // pro jistotu (hodnota nemusi byt typu string, pak muze chybet null-terminator)
+                            extType[MAX_PATH - 1] = 0; // just in case (the value may not be a string, so the null terminator may be missing)
 
                             if (GetIconFromAssocAux(TRUE, HKEY_CLASSES_ROOT, extType, (LONG)strlen(extType) + 1, data, iconLocation, type))
                             {
-                                InsertData("UserChoice: ", index, found, e, s, data, size, iconLocation, type); // found==TRUE znamena prepis jiz nalezene asociace tou z UserChoice
+                                InsertData("UserChoice: ", index, found, e, s, data, size, iconLocation, type); // found==TRUE means overwriting the association already found with the one from UserChoice
                                 found = TRUE;
                             }
                         }
                         HANDLES(RegCloseKey(openKey));
                     }
-                    if (!found) // zkusime jeste, jestli neni asociovana pres klic OpenWithProgids
+                    if (!found) // Check whether it is associated through the OpenWithProgids key
                     {
                         if (WindowsVistaAndLater && HANDLES_Q(RegOpenKey(extKey, "OpenWithProgids", &openKey)) == ERROR_SUCCESS)
                         {
                             DWORD j = 0;
-                            size = MAX_PATH; // ziskani typu asociace
+                            size = MAX_PATH; // get the association type
                             while (RegEnumValue(openKey, j++, extType, (DWORD*)&size, NULL, NULL, NULL, NULL) == ERROR_SUCCESS)
-                            { // postupne enumnuti vsech typu asociaci
+                            { // enumerate all association types one by one
                                 if (extType[0] != 0)
                                 {
-                                    extType[MAX_PATH - 1] = 0; // pro jistotu (hodnota nemusi byt typu string, pak muze chybet null-terminator)
+                                    extType[MAX_PATH - 1] = 0; // just in case (the value may not be a string, so the null terminator may be missing)
 
                                     if (GetIconFromAssocAux(TRUE, HKEY_CLASSES_ROOT, extType, (LONG)strlen(extType) + 1, data, iconLocation, type))
                                     {
@@ -1344,7 +1346,7 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
                                         break;
                                     }
                                 }
-                                size = MAX_PATH; // ziskani typu asociace
+                                size = MAX_PATH; // get the association type
                             }
                             HANDLES(RegCloseKey(openKey));
                         }
@@ -1352,15 +1354,15 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
 
                     if (SalRegQueryValueEx(extKey, "Application", NULL, NULL, NULL, NULL) == ERROR_SUCCESS)
                     {
-                        if (found) // nalezeno, nastavime, ze ma asociaci
+                        if (found) // found, mark that it has an association
                         {
                             CAssociationData* iconData = &(At(index));
-                            iconData->SetFlag(1); // soubory s touto priponou jdou otevirat
-                                                  // iconData->SetIndexAll(-1);  // prepnuti na statickou ikonu zlobi s CDR a CPT Corelackymi soubory s nahledy v ikonach, radsi nechame ikonu v nastaveni z HKEY_CLASSES_ROOT
+                            iconData->SetFlag(1); // files with this extension can be opened
+                                                  // iconData->SetIndexAll(-1);  // switching to a static icon causes problems for CDR and CPT Corel files with thumbnails in their icons, so leave the icon configured in HKEY_CLASSES_ROOT
                         }
-                        else // nenalezeno, vlozime jako statickou ikonu
+                        else // not found, insert it as a static icon
                         {
-                            data.SetFlag(1); // soubory s touto priponou jdou otevirat
+                            data.SetFlag(1); // files with this extension can be opened
                             data.SetIndexAll(-1);
 
                             InsertData("FileExts: Application: ", index, FALSE, e, s, data, size, "", "");
@@ -1370,13 +1372,13 @@ void CAssociations::ReadAssociations(BOOL showWaitWnd)
                 }
             }
             else
-                break; // konec enumerace
+                break; // end of enumeration
             i++;
         }
         HANDLES(RegCloseKey(explorerFileExts));
     }
 
-    // pridani pevnych ikonek vsech velikosti do cache-bitmap CAssociations
+    // add fixed icons of all sizes to the CAssociations cache bitmap
     int iconSize;
     for (iconSize = 0; iconSize < ICONSIZE_COUNT; iconSize++)
     {
@@ -1440,8 +1442,8 @@ BOOL CAssociations::IsAssociated(char* ext, BOOL& addtoIconCache, CIconSizeEnum 
     {
         int i = At(index).GetIndex(iconSize);
         if (i == -1)
-            At(index).SetIndex(-3, iconSize);  // nenactena -> nacitana
-        addtoIconCache = (i == -1 || i == -2); // dynamicka nebo nenactena/nenacitana staticka
+            At(index).SetIndex(-3, iconSize);  // not loaded -> loading
+        addtoIconCache = (i == -1 || i == -2); // dynamic or static not loaded/not loading
         return At(index).GetFlag() != 0;
     }
     else
@@ -1460,7 +1462,7 @@ BOOL CAssociations::IsAssociatedStatic(char* ext, const char*& iconLocation, CIc
         if (i == -1)
         {
             At(index).SetIndex(-3, iconSize);          // nenactena -> nacitana
-            iconLocation = At(index).ExtensionAndData; // nenactena/nenacitana staticka
+            iconLocation = At(index).ExtensionAndData; // unloaded static item
         }
         else
             iconLocation = NULL;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/icncache.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 45 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 164 comment units, 164 review results, 164 resolved results, and 164 apply results.
- Branch-target comment guard passed for `src/icncache.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/icncache.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 29 provider calls, 435325 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 22 calls, 343428 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 91897 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
