### PR TITLE
[translation] Fix src/iconlist.h comments

### DIFF
--- a/src/iconlist.h
+++ b/src/iconlist.h
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/iconlist.h
+++ b/src/iconlist.h
@@ -5,20 +5,23 @@
 
 /************************************************************************************
 
-Co lze vytahnout z HICON, ktere nam dodava OS?
+What can we extract from the HICON handles provided by the OS?
 
-  Pomoci GetIconInfo() nam OS vrati kopie bitmap MASK a COLOR. Ty lze dale
-  zkoumat volanim GetObject(), pomoci ktere vytahneme geometrii a bervne usporadani.
-  Jedna se o kopie bitmap, nikoliv o bitmapy originalni, drzene uvnitr OS. MASK je
-  vzdy 1bitova bitmapa. COLOR je bitmapa kompatibilni s DC obrazovky. Neexistuje tedy
-  zpusob, jak z techto dat ziskat informace o realne barevne hloubce bitmapy COLOR.
+  Using GetIconInfo(), the OS returns copies of the MASK and COLOR bitmaps. We can
+  inspect them further with GetObject(), which lets us obtain their geometry and
+  color layout. These are bitmap copies, not the original bitmaps held inside the OS.
+  MASK is always a 1-bit bitmap. COLOR is a bitmap compatible with the screen DC.
+  There is therefore no way to determine the real color depth of the COLOR bitmap
+  from this data.
 
-  Specialni pripad jsou ikony ciste cernobile. Ty jsou predany cele v MASK, ktera
-  je pak 2x vyssi. COLOR je pak NULL. Horni polovina MASK bitmapy AND cast a spodni
-  polovina je XOR cast. Tento pripad lze snadno detekovat pomoci testu COLOR == NULL.
+  A special case is fully monochrome icons. They are passed entirely in MASK, which
+  is then twice as tall. COLOR is NULL in that case. The upper half of the MASK
+  bitmap is the AND part and the lower half is the XOR part. This case can be
+  detected easily by testing COLOR == NULL.
 
-  Od Windows XP existuje dalsi specialni pripad: ikony obsahujici ALFA kanal. Jedna
-  s o DIBy s barevnou hloubkou 32bitu, kde je kazdy bod slozen z ARGB slozek.
+  Since Windows XP there has been another special case: icons containing an alpha
+  channel. These are DIBs with 32-bit color depth, where each pixel consists of
+  ARGB components.
 
   
 
@@ -28,52 +31,52 @@ Co lze vytahnout z HICON, ktere nam dodava OS?
 ************************************************************************************/
 
 //
-// Existuje potencialni prostor pro optimalizaci nasi implementace ImageListu.
-// DIB bychom mohli drzet ve stejnem formatu, ve kterem jede obrazovka. BitBlt
-// je potom udajne rychlejsi (neoveroval jsem) podle MSDN:
+// There is potential room to optimize our ImageList implementation.
+// We could keep the DIB in the same format as the display. According to MSDN,
+// BitBlt is then reportedly faster, although I did not verify that:
 //   http://support.microsoft.com/default.aspx?scid=kb;EN-US;230492
 //   (HOWTO: Retrieving an Optimal DIB Format for a Device)
 //
-// Proti teto optimalizaci mluvi nekolik faktoru:
-//   - museli bychom v kodu podporit ruzne formaty dat (15, 16, 24, 32 bitu)
-//   - protoze vykreslujeme soucasne maximalne desitky ikonek, neni pro
-//     nas rychlost kresleni kriticka; nameril jsem tyto rychlosti kresleni:
-//     (100 000 krat se do obrazovky kreslil pres BitBlt DIB 16x16, 32bpp)
-//     rozliseni obrazovky     celkova doba    (W2K, Matrox G450)
-//     32 bpp                  0.40 s
-//     24 bpp                  0.80 s
-//     16 bpp                  0.65 s
-//      8 bpp                  1.16 s
-//   - Nejak bychom stejne museli drzet ikonky s ALFA kanalem, ktere jsou 32 bpp
+// Several factors argue against that optimization:
+//   - we would have to support different data formats in the code (15, 16, 24, 32 bits)
+//   - because we draw at most a few dozen icons at once, drawing speed is not critical
+//     for us; I measured the following drawing speeds:
+//     (a 16x16, 32bpp DIB was drawn to the screen via BitBlt 100,000 times)
+//     screen resolution        total time      (W2K, Matrox G450)
+//     32 bpp                   0.40 s
+//     24 bpp                   0.80 s
+//     16 bpp                   0.65 s
+//      8 bpp                   1.16 s
+//   - we would still somehow need to keep icons with an ALPHA channel, which are 32 bpp
 //
 
 //
-// Proc potrebujeme vlastni obdobu ImageList:
+// Why do we need our own ImageList equivalent:
 //
-// ImageList z CommonControls ma jeden zasadni problem: pokud jej pozadame,
-// aby drzel DeviceDependentBitmapy, neumi zobrazit blendenou polozku. Misto
-// toho ji sjede paternem.
+// The CommonControls ImageList has one major problem: if we ask it to keep
+// DeviceDependentBitmaps, it cannot display a blended item. Instead, it fills
+// it with a pattern.
 //
-// Pokud je drzena bitmapa DIB, blendeni slape skvele, ale vykresleni
-// klasicke polozky je radove pomalejsi (konverze DIB->obrazovka).
+// If a DIB bitmap is stored, blending works great, but drawing a normal item
+// is orders of magnitude slower (DIB -> screen conversion).
 //
-// Dale existuje riziko, ze v nekterych implementacich volani ImageList_SetBkColor
-// fyzicky nezmeni drzenou bitmapu na zaklade masky, ale pouze nastavi vnitrni
-// promennou. Samozrejme je pak kresleni pomalejsi, protoze je treba provadet
-// maskovani. Testoval jsem pod W2K a funkce chodi spravne.
+// There is also a risk that in some implementations, calling ImageList_SetBkColor
+// does not physically modify the stored bitmap using the mask, but only updates an
+// internal variable. Drawing is then naturally slower because masking has to be
+// performed. I tested this under W2K and the function behaves correctly there.
 //
-// Jedina moznost by byla v zachovani ImageListu pro drzeni dat a pouze blend
-// preprogramovat. Problem ale nastava ve funkci ImageList_GetImageInfo, ktera
-// umoznuje pristup k vnitrnim bitmapam Image/Mask. ImageList je ma neustale
-// vybrane v MemDC, takze podle MSDN (Q131279: SelectObject() Fails After
-// ImageList_GetImageInfo()) je jedinou moznosti napred volat CopyImage a teprve
-// potom nad bitmapou pracovat. To by vedlo ne neskutecne pomale kresleni
-// blendenych polozek.
+// The only option would be to keep ImageList for data storage and reimplement only
+// blending. The problem appears in ImageList_GetImageInfo, which provides access
+// to the internal Image/Mask bitmaps. ImageList keeps them permanently selected in
+// MemDC, so according to MSDN (Q131279: SelectObject() Fails After
+// ImageList_GetImageInfo()) the only option is to call CopyImage first and only
+// then work with the bitmap. That would lead to unbearably slow drawing of blended
+// items.
 //
-// Dalsim oriskem jsou pro ImageList ikony invert body. Ikona se sklada ze
-// dvou bitmap: MASKA a COLORS. Maska se ANDuje do cile a pres ni se XORuji barvy.
-// Diky XORovani tak muzou ikonky invertovat nektere sve casti. Vyuzivaji toho
-// predevsim kurzory, viz WINDOWS\Cursors.
+// Another difficulty for ImageList is icons with inverted pixels. An icon consists
+// of two bitmaps: MASK and COLORS. The mask is AND-ed into the target and then the
+// colors are XOR-ed through it. Thanks to XOR, icons can invert some of their
+// parts. This is used mainly by cursors, see WINDOWS\\Cursors.
 //
 
 //******************************************************************************
@@ -81,79 +84,79 @@ Co lze vytahnout z HICON, ktere nam dodava OS?
 // CIconList
 //
 //
-// Po vzoru W2K drzime polozky v bitmape siroke 4 polozky. Pravdepodobne
-// budou operace nad takto orientovanou bitmapu rychlejsi.
+// Following the W2K model, we keep items in a bitmap four items wide. Operations
+// on a bitmap arranged like this will probably be faster.
 
-#define IL_DRAW_BLEND 0x00000001       // z 50% bude pouzita barva blendClr
-#define IL_DRAW_TRANSPARENT 0x00000002 // pri kresleni se zachova puvodni pozadi (pokud neni specifikovano, pouzije vyplni se pozadi definovanou barvou)
-#define IL_DRAW_ASALPHA 0x00000004     // pouzije (invertovanou) barvu v BLUE kanalu jako alpha, pomoci ktere k pozadi primicha specifikovanou barvu popredi; zatim slouzi pro throbber
-#define IL_DRAW_MASK 0x00000010        // vykreslit masku
+#define IL_DRAW_BLEND 0x00000001       // blendClr will be used at 50%
+#define IL_DRAW_TRANSPARENT 0x00000002 // drawing preserves the original background (unless specified otherwise, the background is filled with the defined color)
+#define IL_DRAW_ASALPHA 0x00000004     // uses the (inverted) color in the BLUE channel as alpha, with which it mixes the specified foreground color into the background; currently used for the throbber
+#define IL_DRAW_MASK 0x00000010        // draw the mask
 
 class CIconList : public CGUIIconListAbstract
 {
 private:
-    int ImageWidth; // rozmery jednoho obrazku
+    int ImageWidth; // dimensions of one image
     int ImageHeight;
-    int ImageCount;  // pocet obrazku v bitmape
-    int BitmapWidth; // rozmery drzenych bitmap
+    int ImageCount;  // number of images in the bitmap
+    int BitmapWidth; // dimensions of the stored bitmaps
     int BitmapHeight;
 
-    // obrazky jsou usporadany zleva doprava a shora dolu
-    HBITMAP HImage;   // DIB, jeho raw data jsou v promenne ImageRaw
-    DWORD* ImageRaw;  // ARGB hodnoty; Alfa: 0x00=pruhledna, 0xFF=nepruhledna, ostatni=castecna_pruhlednost(puze u IL_TYPE_ALPHA)
-    BYTE* ImageFlags; // pole o poctu prvku 'imageCount'; (IL_TYPE_xxx)
+    // images are laid out from left to right and top to bottom
+    HBITMAP HImage;   // DIB; its raw data is in the ImageRaw variable
+    DWORD* ImageRaw;  // ARGB values; Alpha: 0x00 = transparent, 0xFF = opaque, others = partial transparency (only for IL_TYPE_ALPHA)
+    BYTE* ImageFlags; // array with 'imageCount' elements; (IL_TYPE_xxx)
 
-    COLORREF BkColor; // aktualni barva pozadi (body kde je Alfa==0x00)
+    COLORREF BkColor; // current background color (pixels where Alpha == 0x00)
 
-    // sdilene promenne pres vsechny imagelisty -- setrime pameti
-    static HDC HMemDC;                       // sdilene mem dc
-    static HBITMAP HOldBitmap;               // puvodni bitmapa
-    static HBITMAP HTmpImage;                // cache pro paint + docasne uloziste masky
-    static DWORD* TmpImageRaw;               // raw data od HTmpImage
-    static int TmpImageWidth;                // rozmery HTmpImage v bodech
-    static int TmpImageHeight;               // rozmery HTmpImage v bodech
-    static int MemDCLocks;                   // pro destrukci mem dc
-    static CRITICAL_SECTION CriticalSection; // synchronizace pristupu
-    static int CriticalSectionLocks;         // pro konstrukci/destrukci CriticalSection
+    // shared variables across all image lists -- saves memory
+    static HDC HMemDC;                       // shared memory DC
+    static HBITMAP HOldBitmap;               // original bitmap
+    static HBITMAP HTmpImage;                // paint cache + temporary mask storage
+    static DWORD* TmpImageRaw;               // raw data from HTmpImage
+    static int TmpImageWidth;                // dimensions of HTmpImage in pixels
+    static int TmpImageHeight;               // dimensions of HTmpImage in pixels
+    static int MemDCLocks;                   // for destroying the memory DC
+    static CRITICAL_SECTION CriticalSection; // access synchronization
+    static int CriticalSectionLocks;         // for constructing/destroying CriticalSection
 
 public:
-    //    BOOL     Dump; // pokud je TRUE, dumpuji se raw data do TRACE
+    //    BOOL     Dump; // if TRUE, raw data is dumped to TRACE
 
 public:
     CIconList();
     ~CIconList();
 
     virtual BOOL WINAPI Create(int imageWidth, int imageHeight, int imageCount);
-    virtual BOOL WINAPI CreateFromImageList(HIMAGELIST hIL, int requiredImageSize = -1);          // pokud je 'requiredImageSize' -1, pouzije se geometrie z hIL
-    virtual BOOL WINAPI CreateFromPNG(HINSTANCE hInstance, LPCTSTR lpBitmapName, int imageWidth); // nacte z resourcu PNG, musi jit o dlouhy prouzek jeden radek vysoky
+    virtual BOOL WINAPI CreateFromImageList(HIMAGELIST hIL, int requiredImageSize = -1);          // if 'requiredImageSize' is -1, the geometry from hIL is used
+    virtual BOOL WINAPI CreateFromPNG(HINSTANCE hInstance, LPCTSTR lpBitmapName, int imageWidth); // loads PNG from resources; it must be a long strip one row high
     virtual BOOL WINAPI CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int imageWidth);
-    virtual BOOL WINAPI CreateFromBitmap(HBITMAP hBitmap, int imageCount, COLORREF transparentClr); // nasosne bitmapu (maximalne 256 barev), musi jit o dlouhy prouzek jeden radek vysoky
+    virtual BOOL WINAPI CreateFromBitmap(HBITMAP hBitmap, int imageCount, COLORREF transparentClr); // accepts a bitmap (up to 256 colors); it must be a long strip one row high
     virtual BOOL WINAPI CreateAsCopy(const CIconList* iconList, BOOL grayscale);
     virtual BOOL WINAPI CreateAsCopy(const CGUIIconListAbstract* iconList, BOOL grayscale);
 
-    // prevede icon list na cernobilou verzi
+    // converts the icon list to a grayscale version
     virtual BOOL WINAPI ConvertToGrayscale(BOOL forceAlphaForBW);
 
-    // zakomprimuje bitmapu do 32bitoveho PNG a alfa kanalem (jeden dlouhy radek)
-    // pokud se vse podari, vraci TRUE a ukazatel na alokovanou pamet, kterou je nutne potom dealokovat
-    // pri chybe vraci FALSE
+    // compresses the bitmap into a 32-bit PNG with an alpha channel (one long row)
+    // on success, returns TRUE and a pointer to allocated memory that must later be freed
+    // on error, returns FALSE
     virtual BOOL WINAPI SaveToPNG(BYTE** rawPNG, DWORD* rawPNGSize);
 
     virtual BOOL WINAPI ReplaceIcon(int index, HICON hIcon);
 
-    // vytvori ikonku z pozice 'index'; vraci jeji handle nebo NULL v pripade neuspechu
-    // vracenou ikonu je po pouziti treba destruovat pomoci API DestroyIcon
+    // creates an icon from position 'index'; returns its handle or NULL on failure
+    // the returned icon must be destroyed after use with the DestroyIcon API
     virtual HICON WINAPI GetIcon(int index);
     HICON GetIcon(int index, BOOL useHandles);
 
-    // vytvori imagelist (jeden radek, pocet sloupcu dle poctu polozek); vraci jeho handle nebo NULL v pripade neuspechu
-    // vraceny imagelist je po pouziti treba destruovat pomoci API ImageList_Destroy()
+    // creates an image list (one row, with the number of columns based on the number of items); returns its handle or NULL on failure
+    // the returned image list must be destroyed with the ImageList_Destroy() API after use
     virtual HIMAGELIST WINAPI GetImageList();
 
-    // kopiruje jednu polozku ze 'srcIL' a pozice 'srcIndex' na pozici 'dstIndex'
+    // copies one item from 'srcIL' at position 'srcIndex' to position 'dstIndex'
     virtual BOOL WINAPI Copy(int dstIndex, CIconList* srcIL, int srcIndex);
 
-    // kopiruje jednu polozku z pozice 'srcIndex' do 'hDstImageList' na pozici 'dstIndex'
+    // copies one item from position 'srcIndex' into 'hDstImageList' at position 'dstIndex'
     //    BOOL CopyToImageList(HIMAGELIST hDstImageList, int dstIndex, int srcIndex);
 
     virtual BOOL WINAPI Draw(int index, HDC hDC, int x, int y, COLORREF blendClr, DWORD flags);
@@ -162,24 +165,24 @@ public:
     virtual COLORREF WINAPI GetBkColor();
 
 private:
-    // pokud neexistuje, vytvori HTmpImage
-    // pokud HTmpImage existuje a je mensi nez 'width' x 'height', vytvori novy
-    // vraci TRUE v pripade uspechu, jinak vraci FALSE a zachovava minuly HTmpImage
+    // creates HTmpImage if it does not exist
+    // if HTmpImage exists and is smaller than 'width' x 'height', creates a new one
+    // returns TRUE on success; otherwise returns FALSE and keeps the previous HTmpImage
     BOOL CreateOrEnlargeTmpImage(int width, int height);
 
-    // vraci handle bitmapy prave vybrane v HMemDC
-    // pokud HMemDC neexistuje, vraci NULL
+    // returns the handle of the bitmap currently selected in HMemDC
+    // if HMemDC does not exist, returns NULL
     HBITMAP GetCurrentBitmap();
 
-    // 'index' urcuje pozici ikonky v HImage
-    // vraci TRUE, pokud v obrazek 'index' v HImage obsahoval alfa kanal
+    // 'index' specifies the icon position in HImage
+    // returns TRUE if image 'index' in HImage contained an alpha channel
     BYTE ApplyMaskToImage(int index, BYTE forceXOR);
 
-    // pro ladici ucely -- zobrazi dump ARGB hodnot barevne bitmapy i masky
+    // for debugging purposes -- shows a dump of the ARGB values of both the color bitmap and the mask
     //    void DumpToTrace(int index, BOOL dumpMask);
 
-    // renderovani bod po bodu a nasledny BitBlt je v RELEASE verzi
-    // pouze o 30% pomalejsi proti cistemu BitBlt
+    // point-by-point rendering followed by BitBlt is in the RELEASE build
+    // only about 30% slower than a plain BitBlt
 
     BOOL DrawALPHA(HDC hDC, int x, int y, int index, COLORREF bkColor);
     BOOL DrawXOR(HDC hDC, int x, int y, int index, COLORREF bkColor);
@@ -190,13 +193,13 @@ private:
 
     void StoreMonoIcon(int index, WORD* mask);
 
-    // specialni podpurna funkce pro CreateFromBitmap(); nakopiruj z 'hSrcBitmap'
-    // zvoleny pocet polozek do 'dstIndex'; predpoklada, ze 'hSrcBitmap' bude dlouhy
-    // prouzek ikon, jeden radek vysoky
-    // transparentClr udava barvu, ktera se ma povazovat za pruhlednou
-    // predpoklada se, ze zdrojova bitmapa ma stejny rozmer ikonek jako ma cilova (ImageWidth, ImageHeight)
-    // jednim kopirovanim lze pracovat maximalne s jednim radkem cilove bitmapy,
-    // nelze napriklad nakopirovat data do dvou radku v cilove bitmape
+    // special helper for CreateFromBitmap(); copies the selected number of items
+    // from 'hSrcBitmap' into 'dstIndex'; assumes 'hSrcBitmap' is a long strip of
+    // icons one row high
+    // transparentClr specifies the color to be considered transparent
+    // assumes the source bitmap has the same icon dimensions as the target one (ImageWidth, ImageHeight)
+    // a single copy operation can work with at most one row of the target bitmap;
+    // for example, it cannot copy data into two rows in the target bitmap
     BOOL CopyFromBitmapIternal(int dstIndex, HBITMAP hSrcBitmap, int srcIndex, int imageCount, COLORREF transparentClr);
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/iconlist.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 41 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 45 comment units, 45 review results, 45 resolved results, and 45 apply results.
- Branch-target comment guard passed for `src/iconlist.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/iconlist.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 6 provider calls, 140760 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 73944 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 3 calls, 66816 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
