### PR TITLE
[translation] Fix src/iconlist.cpp comments

### DIFF
--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -10,13 +10,13 @@
 // CIconList
 //
 
-// udava pocet polozek v jedne radce; po vzoru W2K davame 4;
-// asi pro vetsi rychlost provadenych operaci?
+// Specifies the number of items in one row; following the W2K model, we use 4;
+// probably for better performance of the operations performed.
 const int IL_ITEMS_IN_ROW = 4;
 
-#define IL_TYPE_NORMAL 0 // bezna ikona, kterou lze vykreslit pres BitBlt
-#define IL_TYPE_XOR 1    // ikona obsahujici oblasti, ktere je treba XORovat
-#define IL_TYPE_ALPHA 2  // ikona obsahujici alfa kanal
+#define IL_TYPE_NORMAL 0 // regular icon that can be drawn with BitBlt
+#define IL_TYPE_XOR 1    // icon containing areas that must be XOR-ed
+#define IL_TYPE_ALPHA 2  // icon containing an alpha channel
 
 HDC CIconList::HMemDC = NULL;
 HBITMAP CIconList::HOldBitmap = NULL;
@@ -101,8 +101,8 @@ BOOL CIconList::CreateOrEnlargeTmpImage(int width, int height)
 {
     if (HTmpImage == NULL || TmpImageWidth < width || TmpImageHeight < height)
     {
-        // !!! Pozor, pri pouzivani BITMAPV4HEADER u Petra padal Salamander v ICM32.DLL,
-        // stary BITMAPINFOHEADER zjevne staci
+        // !!! Warning: when Petr used BITMAPV4HEADER, Salamander crashed in ICM32.DLL;
+        // the older BITMAPINFOHEADER is evidently sufficient
         BITMAPINFOHEADER bmhdr;
         memset(&bmhdr, 0, sizeof(bmhdr));
         bmhdr.biSize = sizeof(bmhdr);
@@ -121,7 +121,7 @@ BOOL CIconList::CreateOrEnlargeTmpImage(int width, int height)
         }
 
         if (HTmpImage != NULL)
-            HANDLES(DeleteObject(HTmpImage)); // pokud existuje stara bitmapa, zrusime ji
+            HANDLES(DeleteObject(HTmpImage)); // if an old bitmap exists, delete it
 
         HTmpImage = hBmp;
         TmpImageRaw = (DWORD*)lpBits;
@@ -153,12 +153,12 @@ BOOL CIconList::Create(int imageWidth, int imageHeight, int imageCount)
         HANDLES(LeaveCriticalSection(&CriticalSection));
         return FALSE;
     }
-    ZeroMemory(ImageFlags, sizeof(BYTE) * imageCount); // bez alfa kanalu
+    ZeroMemory(ImageFlags, sizeof(BYTE) * imageCount); // no alpha channel
 
     int bmpWidth = imageWidth * min(imageCount, IL_ITEMS_IN_ROW);
     int bmpHeight = imageHeight * ((imageCount + IL_ITEMS_IN_ROW - 1) / IL_ITEMS_IN_ROW);
 
-    // pomocne DC, abychom mohli vytvorit kompatibilni bitmapu
+    // helper DC so that we can create a compatible bitmap
     HDC hDC = HANDLES(GetDC(NULL));
     if (hDC == NULL)
     {
@@ -185,7 +185,7 @@ BOOL CIconList::Create(int imageWidth, int imageHeight, int imageCount)
     }
     MemDCLocks++;
 
-    // pokud jeste neexistuje cache/mask bitmapa nebo je mala, vytvorime ji
+    // If the cache/mask bitmap does not exist yet or is too small, create it
     if (!CreateOrEnlargeTmpImage(imageWidth, imageHeight))
     {
         HANDLES(ReleaseDC(NULL, hDC));
@@ -194,8 +194,8 @@ BOOL CIconList::Create(int imageWidth, int imageHeight, int imageCount)
         return FALSE;
     }
 
-    // !!! Pozor, pri pouzivani BITMAPV4HEADER u Petra padal Salamander v ICM32.DLL,
-    // stary BITMAPINFOHEADER zjevne staci
+    // !!! Warning: when Petr used BITMAPV4HEADER, Salamander crashed in ICM32.DLL;
+    // the older BITMAPINFOHEADER is evidently sufficient
     BITMAPINFOHEADER bmhdr;
     memset(&bmhdr, 0, sizeof(bmhdr));
     bmhdr.biSize = sizeof(bmhdr);
@@ -239,7 +239,7 @@ BOOL CIconList::CreateFromImageList(HIMAGELIST hIL, int requiredImageSize)
         return FALSE;
     }
 
-    // vytahneme geometrii image listu
+    // get the image list geometry
     int count = ImageList_GetImageCount(hIL);
     if (count == 0)
     {
@@ -265,7 +265,7 @@ BOOL CIconList::CreateFromImageList(HIMAGELIST hIL, int requiredImageSize)
     if (!Create(cx, cy, count))
         return FALSE;
 
-    // j.r. tady by se dalo optimalizovat: misto predavani po ikonach predat pres ImageList_Draw
+    // j.r. This could be optimized here: instead of passing icons one by one, pass them via ImageList_Draw
     if (count > 20)
     {
         TRACE_E("CIconList::CreateFromImageList(): Let me know that you need so many icons, it would deserve some optimizations here. Jan.");
@@ -288,20 +288,20 @@ BOOL CIconList::CreateFromImageList(HIMAGELIST hIL, int requiredImageSize)
     return TRUE;
 }
 
-// Pokud mam pod W2K desktop 32bpp, dostavam XP ikonky s alfa kanalem neorezane,
-// tedy vcetne alfa kanalu. Pokud prepnu desktop na 16bpp, je alfa kanal orezany (nulovany).
-// Pokud tedy ApplyMaskToImage dostane ikonku vcetne alfa kanalu, vrati typ
-// IL_TYPE_ALPHA a Salamander bude korektne zobrazovat tyto ikony i pod OS < XP
+// If the desktop is running at 32 bpp under W2K, XP icons are obtained with the alpha channel intact,
+// including the alpha channel itself. If the desktop is switched to 16 bpp, the alpha channel is clipped (zeroed).
+// If `ApplyMaskToImage` therefore receives an icon including the alpha channel, it returns
+// `IL_TYPE_ALPHA` and Salamander will display these icons correctly even on OS versions older than XP
 
 BYTE CIconList::ApplyMaskToImage(int index, BYTE forceXOR)
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // prohledneme celou ikonku a urcime o jaky typ se jedna (NORMAL, XOR, ALPHA)
+    // scan the entire icon and determine which type it is (NORMAL, XOR, ALPHA)
     BYTE type = IL_TYPE_NORMAL;
     if (forceXOR)
         type = IL_TYPE_XOR;
@@ -323,8 +323,8 @@ BYTE CIconList::ApplyMaskToImage(int index, BYTE forceXOR)
                 if ((*maskPtr != 0) && (*ptr != 0))
                 {
                     type = IL_TYPE_XOR;
-                    // to ze je ikonka kandidat na XOR jeste neznamena,
-                    // ze nebude ALPHA, takze nemuzeme vypadnout
+                    // The fact that the icon is a candidate for XOR does not yet mean
+                    // that it will not be ALPHA, so we cannot exit early
                 }
                 ptr++;
                 maskPtr++;
@@ -337,9 +337,9 @@ BYTE CIconList::ApplyMaskToImage(int index, BYTE forceXOR)
 SKIP:
     if (type == IL_TYPE_NORMAL)
     {
-        // pripravime si barvu pozadi ve spravnem formatu
+        // prepare the background color in the correct format
         DWORD bkClr = GetRValue(BkColor) << 16 | GetGValue(BkColor) << 8 | GetBValue(BkColor);
-        // pruhledne oblasti masky preneseme do alfa kanalu
+        // transfer the transparent mask areas into the alpha channel
         int row;
         for (row = 0; row < ImageHeight; row++)
         {
@@ -350,13 +350,13 @@ SKIP:
             {
                 if (*maskPtr != 0)
                 {
-                    // zcela pruhledna oblast
-                    // alfa kanal je v nejvyssim bytu, nastavime na 00, zbytek bude barva pozadi
+                    // fully transparent area
+                    // the alpha channel is in the highest byte; set it to 00, the rest will be the background color
                     *ptr = bkClr;
                 }
                 else
                 {
-                    *ptr |= 0xFF000000; // oblast nastavime jako nepruhlednou
+                    *ptr |= 0xFF000000; // mark the area as opaque
                 }
                 ptr++;
                 maskPtr++;
@@ -374,7 +374,7 @@ SKIP:
             for (col = 0; col < ImageWidth; col++)
             {
                 if (*maskPtr == 0)
-                    *ptr |= 0xFF000000; // nepruhledna oblast
+                    *ptr |= 0xFF000000; // opaque area
 
                 ptr++;
                 maskPtr++;
@@ -392,7 +392,7 @@ CIconList::DumpToTrace(int index, BOOL dumpMask)
 {
   HANDLES(EnterCriticalSection(&CriticalSection));
 
-  // souradnice v bodech v HImage
+  // coordinates in points in HImage
   int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
   int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -458,19 +458,19 @@ BOOL CIconList::ReplaceIcon(int index, HICON hIcon)
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // kontrola parametru
+    // Parameter validation
     if (index < 0 || index >= ImageCount)
     {
         TRACE_E("CIconList::ReplaceIcon(): Index is out of range! index=" << index);
         goto BAIL;
     }
 
-    // pokud je treba, provedeme resize ikonky
-    // Honza: pod W10 mi zacalo volani CopyImage padat v debug x64 verzi, pokud byl povolen LR_COPYFROMRESOURCE flag
-    // FIXME: provest audit, zda je tento downscale jeste potreba, kdyz SalLoadIcon() nove vola LoadIconWithScaleDown()
+    // Resize the icon if needed.
+    // Honza: On Windows 10, CopyImage() started crashing for me in the debug x64 build when the LR_COPYFROMRESOURCE flag was enabled.
+    // FIXME: Audit whether this downscale is still needed now that SalLoadIcon() calls LoadIconWithScaleDown().
     hIcon = (HICON)CopyImage(hIconOrig, IMAGE_ICON, ImageWidth, ImageHeight, /*LR_COPYFROMRESOURCE | */ LR_COPYRETURNORG);
 
-    // vytahneme z handlu ikony jeji MASK a COLOR bitmapy
+    // Extract the MASK and COLOR bitmaps from the icon handle
     if (!GetIconInfo(hIcon, &ii))
     {
         TRACE_E("GetIconInfo() failed!");
@@ -485,36 +485,36 @@ BOOL CIconList::ReplaceIcon(int index, HICON hIcon)
         goto BAIL;
     }
 
-    // pokud se jedna o b&w ikonu, mela by mit sudou vysku
+    // if this is a b&w icon, it should have an even height
     if (ii.hbmColor == NULL && (bm.bmHeight & 1) == 1)
     {
         TRACE_E("CIconList::ReplaceIcon() Icon has wrong MASK height");
         goto BAIL;
     }
-    // ikonka by mela mit stejne rozmery, jako ma nase polozka
+    // the icon should have the same dimensions as our item
     if (bm.bmWidth != ImageWidth ||
         (ii.hbmColor == NULL && bm.bmHeight != ImageHeight * 2) ||
         (ii.hbmColor != NULL && bm.bmHeight != ImageHeight))
         TRACE_E("CIconList::ReplaceIcon() Icon has wrong size: bmWidth=" << bm.bmWidth << " bmHeight=" << bm.bmHeight);
 
-    // potrebujeme dostatecny prostor pro masku
+    // enough space for the mask
     if (!CreateOrEnlargeTmpImage(bm.bmWidth, bm.bmHeight))
         goto BAIL;
 
-    hSrcDC = HANDLES(CreateCompatibleDC(NULL)); // pomocne dc pro bitblt
+    hSrcDC = HANDLES(CreateCompatibleDC(NULL)); // helper DC for BitBlt
     hOldSrcBmp = (HBITMAP)SelectObject(hSrcDC, ii.hbmMask);
 
     // ii.hbmMask -> HTmpImage
     SelectObject(HMemDC, HTmpImage);
     BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hSrcDC, 0, 0, SRCCOPY);
 
-    // ii.hbmColor -> HImage (pokud je hbmColor==NULL, lezi XOR cast ve spodni polovine hbmMask
+    // ii.hbmColor -> HImage (if hbmColor == NULL, the XOR part is in the lower half of hbmMask)
     if (ii.hbmColor != NULL)
         SelectObject(hSrcDC, ii.hbmColor);
     SelectObject(HMemDC, HImage);
     BitBlt(HMemDC, iX, iY, ImageWidth, ImageHeight, hSrcDC, 0, (ii.hbmColor != NULL) ? 0 : ImageHeight, SRCCOPY);
 
-    GdiFlush(); // podle MSDN je treba zavolat nez zacneme pristupovat na raw data
+    GdiFlush(); // according to MSDN, this must be called before we start accessing raw data
 
     //  TRACE_I("counter: "<<counter);
     //  if (++counter == 19)
@@ -534,7 +534,7 @@ BAIL:
     if (ii.hbmColor != NULL)
         DeleteObject(ii.hbmColor);
 
-    // pokud jsme menili velikost, musime sestrelit docasnou ikonku
+    // if we changed the size, we must destroy the temporary icon
     if (hIcon != hIconOrig)
         DestroyIcon(hIcon);
 
@@ -561,14 +561,14 @@ CIconList::GetIcon(int index, BOOL useHandles)
 HICON
 CIconList::GetIcon(int index)
 {
-    // kontrola parametru
+    // Parameter validation
     if (index < 0 || index >= ImageCount)
     {
         TRACE_E("CIconList::GetIcon: index is out of range!");
         return NULL;
     }
 
-    // vytvorime B&W masku + barevnou bitmapu dle obrazovky
+    // create a B&W mask plus a screen-format color bitmap
     HDC hDC = HANDLES(GetDC(NULL));
     HBITMAP hMask = HANDLES(CreateBitmap(ImageWidth, ImageHeight, 1, 1, NULL));
     HBITMAP hColor = HANDLES(CreateCompatibleBitmap(hDC, ImageWidth, ImageHeight));
@@ -581,7 +581,7 @@ CIconList::GetIcon(int index)
 
     BYTE type = ImageFlags[index];
 
-    // do HTmpImage pripravime COLOR cast ikonky
+    // prepare the COLOR part of the icon in HTmpImage
     int row;
     for (row = 0; row < ImageHeight; row++)
     {
@@ -593,14 +593,14 @@ CIconList::GetIcon(int index)
             DWORD argb = *imagePtr;
             BYTE alpha = (BYTE)((argb & 0xFF000000) >> 24);
 
-            if (type == IL_TYPE_ALPHA) // az na XP a novejsich systemech vracime ikony s alphou
+            if (type == IL_TYPE_ALPHA) // on Windows XP and later, return icons with alpha
             {
                 *tmpPtr = argb;
             }
             else
             {
-                // v pruhledne oblasti je barva pozadi image listu, ale my tam
-                // musime dodat cernou barvu, aby fungoval XOR mechanismus kresleni
+                // the transparent area contains the image list background color, but we
+                // must put black there so that the XOR drawing mechanism works
                 if (alpha != 0)
                     *tmpPtr = argb;
                 else
@@ -612,7 +612,7 @@ CIconList::GetIcon(int index)
         }
     }
 
-    // preneseme HTmpImage do hColor
+    // copy HTmpImage into hColor
     SelectObject(HMemDC, HTmpImage);
     hDC = HANDLES(CreateCompatibleDC(NULL));
     HBITMAP hOldBmp = (HBITMAP)SelectObject(hDC, hColor);
@@ -620,7 +620,7 @@ CIconList::GetIcon(int index)
 
     SelectObject(hDC, hMask);
 
-    // do HTmpImage pripravime MASK cast ikonky
+    // Prepare the icon mask in HTmpImage
     for (row = 0; row < ImageHeight; row++)
     {
         DWORD* imagePtr = ImageRaw + iX + (iY + row) * BitmapWidth;
@@ -638,7 +638,7 @@ CIconList::GetIcon(int index)
         }
     }
 
-    // preneseme HTmpImage do hMask
+    // Copy HTmpImage to hMask
     BitBlt(hDC, 0, 0, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
     //  if (Dump)
@@ -647,13 +647,13 @@ CIconList::GetIcon(int index)
     //    DumpToTrace(index, TRUE);
     //  }
 
-    // zameteme
+    // clean up
     SelectObject(hDC, hOldBmp);
     HANDLES(DeleteDC(hDC));
 
     HANDLES(LeaveCriticalSection(&CriticalSection));
 
-    // z hColor + hMask vytvorime ikonku
+    // create an icon from hColor + hMask
     ICONINFO ii;
     ii.fIcon = TRUE;
     ii.xHotspot = 0;
@@ -661,7 +661,7 @@ CIconList::GetIcon(int index)
     ii.hbmColor = hColor;
     ii.hbmMask = hMask;
     HICON hIcon;
-    hIcon = CreateIconIndirect(&ii); // nesmi byt v handles, vyvazi ikonku ven ze Salamandera
+    hIcon = CreateIconIndirect(&ii); // must not be in handles; transfers the icon out of Salamander
 
     HANDLES(DeleteObject(hColor));
     HANDLES(DeleteObject(hMask));
@@ -671,14 +671,14 @@ CIconList::GetIcon(int index)
 
 BOOL CIconList::Draw(int index, HDC hDC, int x, int y, COLORREF blendClr, DWORD flags)
 {
-    // kontrola parametru
+    // parameter validation
     if (index < 0 || index >= ImageCount)
     {
         TRACE_E("CIconList::Draw() Index is out of range! index=" << index << " ImageCount=" << ImageCount);
         return FALSE;
     }
 
-    if (flags & IL_DRAW_MASK) // maska se pouziva pri drag&dropu, napriklad u shared adesaru, viz StateImageList_Draw()
+    if (flags & IL_DRAW_MASK) // The mask is used during drag and drop, for example for shared folders; see StateImageList_Draw().
         return DrawMask(hDC, x, y, index, RGB(0, 0, 0), RGB(255, 255, 255));
     if (flags & IL_DRAW_BLEND)
         return AlphaBlend(hDC, x, y, index, BkColor, blendClr);
@@ -712,21 +712,21 @@ BOOL CIconList::DrawMask(HDC hDC, int x, int y, int index, COLORREF fgColor, COL
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
     //DumpToTrace(index);
 
-    // sosneme data z obrazovky do HTmpImage
-    // nase DrawMask pouze nastavuje cerne body v miste masky, abychom mohli snadno mergovat s overlayem
-    // pri volani z StateImageList_Draw(); pokud bude casem treba zobrazovat dalsi overlay, bude to chtit
-    // udelat v StateImageList_Draw() merger na zaklade boolovskych bitblt operaci a tato metoda by pak
-    // mohla nastavovat take fgColor; odpadla by podminka *** dole
+    // Copy the screen data into HTmpImage
+    // Our `DrawMask` only sets black pixels at the mask locations so that it can be merged easily with the overlay
+    // when called from `StateImageList_Draw()`; if support for another overlay is ever needed, it will be necessary
+    // to implement the merge in `StateImageList_Draw()` using boolean `BitBlt` operations, and this method could then
+    // also set `fgColor`; the `***` condition below would no longer be needed
     SelectObject(HMemDC, HTmpImage);
     BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hDC, x, y, SRCCOPY);
 
-    // budeme kreslit do HTmpImage
+    // draw into HTmpImage
     int row;
     for (row = 0; row < ImageHeight; row++)
     {
@@ -739,7 +739,7 @@ BOOL CIconList::DrawMask(HDC hDC, int x, int y, int index, COLORREF fgColor, COL
             BYTE alpha = (BYTE)((argb & 0xFF000000) >> 24);
 
             DWORD clr = (alpha == 0) ? bkColor : fgColor;
-            if (alpha != 0) // *** viz komentar nahore
+            if (alpha != 0) // *** see comment above
                 *tmpPtr = clr;
 
             imagePtr++;
@@ -747,7 +747,7 @@ BOOL CIconList::DrawMask(HDC hDC, int x, int y, int index, COLORREF fgColor, COL
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     //  SelectObject(HMemDC, HTmpImage);
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
@@ -759,11 +759,11 @@ BOOL CIconList::DrawXOR(HDC hDC, int x, int y, int index, COLORREF bkColor)
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // budeme kreslit do HTmpImage
+    // draw into HTmpImage
     BYTE bkR = GetRValue(bkColor);
     BYTE bkG = GetGValue(bkColor);
     BYTE bkB = GetBValue(bkColor);
@@ -789,7 +789,7 @@ BOOL CIconList::DrawXOR(HDC hDC, int x, int y, int index, COLORREF bkColor)
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     SelectObject(HMemDC, HTmpImage);
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
@@ -801,11 +801,11 @@ BOOL CIconList::DrawALPHA(HDC hDC, int x, int y, int index, COLORREF bkColor)
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // v prvni fazi preneseme data do HMask
+    // in the first phase, transfer the data into HMask
     SelectObject(HMemDC, HTmpImage);
 
     BYTE bkR = GetRValue(bkColor);
@@ -844,7 +844,7 @@ BOOL CIconList::DrawALPHA(HDC hDC, int x, int y, int index, COLORREF bkColor)
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
     HANDLES(LeaveCriticalSection(&CriticalSection));
@@ -856,14 +856,14 @@ BOOL CIconList::DrawALPHALeaveBackground(HDC hDC, int x, int y, int index)
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // v prvni fazi preneseme z ciloveho DC data do HMask
+    // in the first phase, transfer data from the target DC into HMask
     SelectObject(HMemDC, HTmpImage);
     BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hDC, x, y, SRCCOPY);
-    GdiFlush(); // podle MSDN je treba zavolat nez zacneme pristupovat na raw data
+    GdiFlush(); // according to MSDN, this must be called before we start accessing raw data
 
     /*
   BYTE bkR = GetRValue(bkColor);
@@ -905,7 +905,7 @@ BOOL CIconList::DrawALPHALeaveBackground(HDC hDC, int x, int y, int index)
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
     HANDLES(LeaveCriticalSection(&CriticalSection));
@@ -917,14 +917,14 @@ BOOL CIconList::DrawAsAlphaLeaveBackground(HDC hDC, int x, int y, int index, COL
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // v prvni fazi preneseme z ciloveho DC data do HMask
+    // in the first phase, transfer data from the target DC into HMask
     SelectObject(HMemDC, HTmpImage);
     BitBlt(HMemDC, 0, 0, ImageWidth, ImageHeight, hDC, x, y, SRCCOPY);
-    GdiFlush(); // podle MSDN je treba zavolat nez zacneme pristupovat na raw data
+    GdiFlush(); // according to MSDN, this must be called before we start accessing raw data
 
     BYTE fgR = GetRValue(fgColor);
     BYTE fgG = GetGValue(fgColor);
@@ -939,7 +939,7 @@ BOOL CIconList::DrawAsAlphaLeaveBackground(HDC hDC, int x, int y, int index, COL
         for (col = 0; col < ImageWidth; col++)
         {
             DWORD argb = *imagePtr;
-            BYTE alpha = 255 - (BYTE)(argb & 0x000000FF); // vsechny kanaly nesou stejnou hodnotu, kterou mame povazovat za alpha kanal
+            BYTE alpha = 255 - (BYTE)(argb & 0x000000FF); // all channels carry the same value, which should be treated as the alpha channel
             if (alpha != 0)
             {
                 BYTE bkR = (BYTE)((*tmpPtr & 0x00FF0000) >> 16);
@@ -956,7 +956,7 @@ BOOL CIconList::DrawAsAlphaLeaveBackground(HDC hDC, int x, int y, int index, COL
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
     HANDLES(LeaveCriticalSection(&CriticalSection));
@@ -968,18 +968,18 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
 {
     HANDLES(EnterCriticalSection(&CriticalSection));
 
-    // souradnice v bodech v HImage
+    // coordinates in pixels in HImage
     int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
     int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
-    // jde o variantu, kde je treba XORovat?
+    // Is this the variant that needs XORing?
     BOOL xorType = ImageFlags[index] == IL_TYPE_XOR;
 
-    // v prvni pripravime raw data pro HTmpImage
+    // in the first phase, prepare raw data for HTmpImage
     int bitsPerPixel = GetCurrentBPP(hDC);
     if (bitsPerPixel <= 8)
     {
-        // 256 barev nebo mene: misto blendeni prekryvame sachovnici
+        // 256 colors or less: overlay a checkerboard instead of blending
         DWORD bkClrOpaque = GetRValue(bkColor) << 16 | GetGValue(bkColor) << 8 | GetBValue(bkColor);
         DWORD bkClr;
         if (fgColor != CLR_NONE)
@@ -999,7 +999,7 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
 
                 if (xorType && alpha == 0)
                 {
-                    // XOR && pruhledna oblast
+                    // XOR && transparent area
                     BYTE bkR = GetRValue(bkColor);
                     BYTE bkG = GetGValue(bkColor);
                     BYTE bkB = GetBValue(bkColor);
@@ -1010,7 +1010,7 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
                 {
                     if (alpha == 0)
                     {
-                        // pruhledna oblast
+                        // transparent area
                         argb = bkClrOpaque;
                     }
                     else
@@ -1032,7 +1032,7 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
     }
     else
     {
-        // vice nez 256 barev: blednime pomoci alfa kanalu
+        // more than 256 colors: fade using the alpha channel
         BYTE bkR = GetRValue(bkColor);
         BYTE bkG = GetGValue(bkColor);
         BYTE bkB = GetBValue(bkColor);
@@ -1051,7 +1051,7 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
 
                 if (xorType && alpha == 0)
                 {
-                    // XOR && pruhledna oblast
+                    // XOR && transparent area
                     *tmpPtr = (DWORD)bkR << 16 | (DWORD)bkG << 8 | (DWORD)bkB;
                     *tmpPtr ^= (argb & 0x00FFFFFF);
                 }
@@ -1086,7 +1086,7 @@ BOOL CIconList::AlphaBlend(HDC hDC, int x, int y, int index, COLORREF bkColor, C
         }
     }
 
-    // vykreslime HTmpImage do obrazovky
+    // draw HTmpImage to the screen
     SelectObject(HMemDC, HTmpImage);
     BitBlt(hDC, x, y, ImageWidth, ImageHeight, HMemDC, 0, 0, SRCCOPY);
 
@@ -1112,7 +1112,7 @@ BOOL CIconList::SetBkColor(COLORREF bkColor)
     int index;
     for (index = 0; index < ImageCount; index++)
     {
-        if (ImageFlags[index] != IL_TYPE_NORMAL) // pouze u normalnich ikon ma smysl nastavovat barvu pozadi
+        if (ImageFlags[index] != IL_TYPE_NORMAL) // setting the background color only makes sense for normal icons
             continue;
 
         int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
@@ -1145,7 +1145,7 @@ CIconList::GetBkColor()
 
 BOOL CIconList::Copy(int dstIndex, CIconList* srcIL, int srcIndex)
 {
-    // kontrola parametru
+    // Check parameters
     if (dstIndex < 0 || dstIndex >= ImageCount)
     {
         TRACE_E("CIconList::Copy: dstIndex is out of range!");
@@ -1167,9 +1167,9 @@ BOOL CIconList::Copy(int dstIndex, CIconList* srcIL, int srcIndex)
         return FALSE;
     }
 
-    // verze kopirovani pomoci primeho pristupu k datum, vyhodou by mela byt
-    // vyssi rychlost a naprosto identicka kopie (fce BitBlt by mohla zahazovat
-    // alpha kanal)
+    // copy variant using direct access to the data; the advantage should be
+    // higher speed and a completely identical copy (the BitBlt function could drop
+    // the alpha channel)
     HANDLES(EnterCriticalSection(&CriticalSection));
     int srcX = ImageWidth * (srcIndex % IL_ITEMS_IN_ROW);
     int srcY = ImageHeight * (srcIndex / IL_ITEMS_IN_ROW);
@@ -1192,7 +1192,7 @@ BOOL CIconList::Copy(int dstIndex, CIconList* srcIL, int srcIndex)
     ImageFlags[dstIndex] = srcIL->ImageFlags[srcIndex];
     HANDLES(LeaveCriticalSection(&CriticalSection));
 
-    // verze kopirovani pomoci BitBlt
+    // BitBlt-based copy variant
     //  HDC hSrcMemDC = HANDLES(CreateCompatibleDC(NULL));
     //  if (hSrcMemDC == NULL)
     //  {
@@ -1223,11 +1223,11 @@ BOOL CIconList::CreateFromBitmap(HBITMAP hBitmap, int imageCount, COLORREF trans
     int cx = bmp.bmWidth / imageCount;
     int cy = bmp.bmHeight;
 
-    // naalokujeme bitmapu
+    // allocate the bitmap
     if (!Create(cx, cy, imageCount))
         return FALSE;
 
-    // po radcich do ni pridame prouzky ze zdrojove bitmapy
+    // add strips from the source bitmap row by row
     int index = 0;
     while (index < imageCount)
     {
@@ -1303,9 +1303,9 @@ BOOL CIconList::CopyFromBitmapIternal(int dstIndex, HBITMAP hSrcBitmap, int srcI
     BitBlt(HMemDC, dstX, dstY, ImageWidth * imageCount, ImageHeight, hSrcMemDC, srcX, srcY, SRCCOPY);
     ImageFlags[dstIndex] = IL_TYPE_NORMAL;
 
-    GdiFlush(); // podle MSDN je treba zavolat nez zacneme pristupovat na raw data
+    GdiFlush(); // according to MSDN, this must be called before we start accessing raw data
 
-    // podle transparentni barvy nastavime alpha kanal
+    // set the alpha channel according to the transparent color
     int row;
     for (row = dstY; row < dstY + ImageHeight; row++)
     {
@@ -1400,7 +1400,7 @@ BOOL CIconList::ConvertToGrayscale(BOOL forceAlphaForBW)
             BYTE brightness = GetGrayscaleFromRGB(r, g, b);
             if (forceAlphaForBW)
             {
-                // pokud jde vystup do BW bitmapy, nastavime prah mezi bilou a cernou (odladeno na Vista ikonkach v user menu)
+                // if the output goes to a B&W bitmap, set the threshold between white and black (tuned on Vista icons in the user menu)
                 if (alpha < 200)
                     alpha = 0;
                 if (brightness > 240)
@@ -1430,49 +1430,49 @@ CIconList::GetImageList()
     return hIL;
 
     /*
-  // vytahnu rozmery bitmapy
-  HDC hDC = HANDLES(GetDC(NULL));
-  BITMAPINFO bi;
-  memset(&bi, 0, sizeof(bi));
-  bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
-  bi.bmiHeader.biBitCount = 0;   // nechceme paletu
+      // get the bitmap dimensions
+      HDC hDC = HANDLES(GetDC(NULL));
+      BITMAPINFO bi;
+      memset(&bi, 0, sizeof(bi));
+      bi.bmiHeader.biSize = sizeof(bi.bmiHeader);
+      bi.bmiHeader.biBitCount = 0;   // palette not needed
   
-  if (!GetDIBits(hDC, 
-                hSrc,
-                0, 0, 
-                NULL,
-                &bi,
-                DIB_RGB_COLORS))
-  {
-    TRACE_E("GetDIBits failed");
-    if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
-    return NULL;
-  }
+      if (!GetDIBits(hDC,
+                    hSrc,
+                    0, 0,
+                    NULL,
+                    &bi,
+                    DIB_RGB_COLORS))
+      {
+        TRACE_E("GetDIBits failed");
+        if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
+        return NULL;
+      }
 
-  if (bi.bmiHeader.biSizeImage == 0)
-  {
-    TRACE_E("bi.bmiHeader.biSizeImage == 0");
-    if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
-    return NULL;
-  }
-  if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
+      if (bi.bmiHeader.biSizeImage == 0)
+      {
+        TRACE_E("bi.bmiHeader.biSizeImage == 0");
+        if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
+        return NULL;
+      }
+      if (hDC != NULL) HANDLES(ReleaseDC(NULL, hDC));
   
-  HIMAGELIST hIL = ImageList_Create(16, 16, GetImageListColorFlags() | ILC_MASK, 0, 1);
-  if (hIL != NULL)
-  {
-    // funkce ImageList_AddMasked nici pruhlednou barvu v hSrc, proto
-    // pridame ikonky postupne a pomalu
-    int count = bi.bmiHeader.biWidth / 16;
-    int i;
-    for (i = 0; i < count; i++)
-    {
-      HICON hIcon = GetIconFromDIB(hSrc, i);
-      ImageList_AddIcon(hIL, hIcon);
-      HANDLES(DestroyIcon(hIcon));
-    }
-  }
-  return hIL;
-*/
+      HIMAGELIST hIL = ImageList_Create(16, 16, GetImageListColorFlags() | ILC_MASK, 0, 1);
+      if (hIL != NULL)
+      {
+        // the ImageList_AddMasked function destroys the transparent color in hSrc, so
+        // add the icons one by one, slowly
+        int count = bi.bmiHeader.biWidth / 16;
+        int i;
+        for (i = 0; i < count; i++)
+        {
+          HICON hIcon = GetIconFromDIB(hSrc, i);
+          ImageList_AddIcon(hIL, hIcon);
+          HANDLES(DestroyIcon(hIcon));
+        }
+      }
+      return hIL;
+    */
 }
 
 //****************************************************************************
@@ -1750,7 +1750,7 @@ HBITMAP LoadRawPNGBitmap(const void* rawPNG, DWORD rawPNGSize, DWORD flags)
                 if (result >= 0)
                 {
                     HBITMAP hBitmap = LoadPNGBitmapCreateDIB(&png, buff, buffSize, flags);
-                    png_free_data(&png); // release palette, etc allocated in png_get_data
+                    png_free_data(&png); // release the palette, etc. allocated by png_get_data
                     if (buff[buffSize] != 0xfe)
                     {
                         TRACE_E("Memory corrupted!!!");
@@ -1851,7 +1851,7 @@ BOOL CIconList::CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int image
                             int row;
                             for (row = 0; row < ImageHeight; row++)
                             {
-                                // souradnice v bodech v HImage
+                                // coordinates in pixels in HImage
                                 int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
                                 int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -1886,7 +1886,7 @@ BOOL CIconList::CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int image
                             int row;
                             for (row = 0; row < ImageHeight; row++)
                             {
-                                // souradnice v bodech v HImage
+                                // coordinates in pixels in HImage
                                 int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
                                 int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -1922,7 +1922,7 @@ BOOL CIconList::CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int image
                             int row;
                             for (row = 0; row < ImageHeight; row++)
                             {
-                                // souradnice v bodech v HImage
+                                // coordinates in pixels in HImage
                                 int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
                                 int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -1959,7 +1959,7 @@ BOOL CIconList::CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int image
                             int row;
                             for (row = 0; row < ImageHeight; row++)
                             {
-                                // souradnice v bodech v HImage
+                                // coordinates in pixels in HImage
                                 int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
                                 int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -1998,7 +1998,7 @@ BOOL CIconList::CreateFromRawPNG(const void* rawPNG, DWORD rawPNGSize, int image
                             int row;
                             for (row = 0; row < ImageHeight; row++)
                             {
-                                // souradnice v bodech v HImage
+                                // coordinates in pixels in HImage
                                 int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
                                 int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
 
@@ -2062,7 +2062,7 @@ struct CPNGBitmapWriteCallbackData
 {
     BYTE* RawPNGIterator;
     DWORD FreeSpace;
-    // navratove hodnoty
+    // return values
     BOOL NotEnoughSpace;
     DWORD Size;
 };
@@ -2090,7 +2090,7 @@ unsigned PNGBitmapWriteCallback(void* input, size_t size, size_t numel, void* us
 
 BOOL CIconList::SaveToPNG(BYTE** rawPNG, DWORD* rawPNGSize)
 {
-    // pripravime ikony do jednoho dlouheho radku
+    // prepare the icons in one long row
     DWORD* buff = (DWORD*)malloc(ImageWidth * ImageCount * ImageHeight * 4);
     int index;
     for (index = 0; index < ImageCount; index++)
@@ -2098,7 +2098,7 @@ BOOL CIconList::SaveToPNG(BYTE** rawPNG, DWORD* rawPNGSize)
         int row;
         for (row = 0; row < ImageHeight; row++)
         {
-            // souradnice v bodech ve zdroji
+            // coordinates in pixels in the source
             int iX = ImageWidth * (index % IL_ITEMS_IN_ROW);
             int iY = ImageHeight * (index / IL_ITEMS_IN_ROW);
             BYTE* srcPtr = (BYTE*)ImageRaw + iX * 4 + (iY + row) * BitmapWidth * 4;
@@ -2119,7 +2119,7 @@ BOOL CIconList::SaveToPNG(BYTE** rawPNG, DWORD* rawPNGSize)
     }
 
     CPNGBitmapWriteCallbackData callbackData;
-    callbackData.FreeSpace = ImageWidth * ImageCount * ImageHeight * 4 * 2; // radeji pripravim dvojnasobek pameti, tam se PNG MUSI vejit
+    callbackData.FreeSpace = ImageWidth * ImageCount * ImageHeight * 4 * 2; // allocate double the memory to be safe; the PNG must fit there
     callbackData.Size = 0;
     BYTE* output = (BYTE*)malloc(callbackData.FreeSpace);
     callbackData.RawPNGIterator = output;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/iconlist.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 94 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 129 comment units, 129 review results, 129 resolved results, and 129 apply results.
- Branch-target comment guard passed for `src/iconlist.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/iconlist.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 45 provider calls, 417654 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 14 calls, 241291 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 31 calls, 176363 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
