### PR TITLE
[translation] Fix src/salamdr1.cpp comments

### DIFF
--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <time.h>
@@ -46,11 +47,11 @@ extern "C"
 #include "execute.h"
 #include "drivelst.h"
 
-#pragma comment(linker, "/ENTRY:MyEntryPoint") // chceme vlastni vstupni bod do aplikace
+#pragma comment(linker, "/ENTRY:MyEntryPoint") // we want a custom entry point for the application
 
 #pragma comment(lib, "UxTheme.lib")
 
-// zpristupnime si puvodni vstupni bod aplikace
+// Make the application's original entry point available.
 extern "C" int WinMainCRTStartup();
 
 #ifdef X64_STRESS_TEST
@@ -61,64 +62,65 @@ LPVOID X64StressTestPointers[X64_STRESS_TEST_ALLOC_COUNT];
 
 void X64StressTestAlloc()
 {
-    // v teto chvili jiz loader nacetl EXE a RTL a v inicializaci RTL doslo k vytvoreni a alokaci heapu,
-    // ktery lezi na adresach pod 4GB; abychom dalsi alokace vystrcili nahoru nad 4GB, muysime zabrat spodek
-    // virtualni pameti a pak nasledne donutit RTL pomoci alokaci k rozsireni jeho heapu
+    // At this point the loader has already loaded the EXE and the RTL, and RTL initialization
+    // has already created and allocated a heap that lives below 4 GB. To push subsequent
+    // allocations above 4 GB, we have to reserve the lower part of the virtual address space
+    // and then force the RTL to expand its heap by making allocations.
     //
-    // zabereme prostor ve virtualni pameti
+    // Reserve space in the virtual address space.
     UINT64 vaAllocated = 0;
     _int64 allocSize[] = {10000000, 1000000, 100000, 10000, 1000, 100, 10, 1, 0};
     for (int i = 0; allocSize[i] != 0; i++)
-        while (VirtualAlloc(0, allocSize[i], MEM_RESERVE, PAGE_NOACCESS) <= (LPVOID)(UINT_PTR)0x00000000ffffffff) // pri pristupu chceme exception a nechceme MEM_COMMIT, at zbytecne nezerem
+        while (VirtualAlloc(0, allocSize[i], MEM_RESERVE, PAGE_NOACCESS) <= (LPVOID)(UINT_PTR)0x00000000ffffffff) // If this memory is accessed, we want an exception, and we do not want MEM_COMMIT so we do not waste memory unnecessarily.
             vaAllocated += allocSize[i];
 
-    // nyni nafoukneme RTL heap
+    // Now fill up the RTL heap.
     UINT64 rtlAllocated = 0;
     _int64 rtlAllocSize[] = {10000000, 1000000, 100000, 10000, 1000, 100, 10, 1, 0};
     for (int i = 0; rtlAllocSize[i] != 0; i++)
         while (_malloc_dbg(rtlAllocSize[i], _CRT_BLOCK, __FILE__, __LINE__) <= (LPVOID)(UINT_PTR)0x00000000ffffffff)
             rtlAllocated += rtlAllocSize[i];
 
-    // kontrola uspechu
-    void* testNew = new char; // new jede pres alloc, ale radeji take overime
+    // check for success
+    void* testNew = new char; // new uses alloc too, but let's verify that as well
     if (testNew <= (LPVOID)(UINT_PTR)0x00000000ffffffff)
         MessageBox(NULL, "new address <= 0x00000000ffffffff!\nPlease contact jan.rysavy@altap.cz with this information.", "X64_STRESS_TEST", MB_OK | MB_ICONEXCLAMATION);
     delete testNew;
 }
 
 #endif //X64_STRESS_TEST
-// nas vlastni vstupni bod, o ktery jsme si pozadali linker pomoci pragmy
+// our own entry point, which we told the linker to use via pragma
 int MyEntryPoint()
 {
 #ifdef X64_STRESS_TEST
-    // alokacema vyzereme spodni 4GB pameti, aby dalsi alokace mely ukazatele vetsi nez DWORD
+    // Consume the lower 4 GB of address space so later allocations get pointers larger than a DWORD.
     X64StressTestAlloc();
 #endif //X64_STRESS_TEST
 
     int ret = 1; // error
 
-    // spustime Salmon, chceme aby pochytal maximum nasich padu
+    // Start Salmon so it can catch as many of our crashes as possible
     if (SalmonInit())
     {
-        // zavolame puvodni entry point aplikace a spustime tim program
+        // call the application's original entry point to start the program
         ret = WinMainCRTStartup();
     }
     else
         MessageBox(NULL, "Open Salamander Bug Reporter (salmon.exe) initialization has failed. Please reinstall Open Salamander.",
                    SALAMANDER_TEXT_VERSION, MB_OK | MB_ICONSTOP);
 
-    // sem uz mi debugger nechodi, sestreli nas v RTL (testovano pod VC 2008 s nasim RTL)
+    // the debugger no longer gets this far; we crash in the RTL (tested with VC 2008 and our RTL)
 
-    // koncime
+    // done
     return ret;
 }
 
-BOOL SalamanderBusy = TRUE;       // je Salamander busy?
-DWORD LastSalamanderIdleTime = 0; // GetTickCount() z okamziku, kdy SalamanderBusy naposledy presel na TRUE
+BOOL SalamanderBusy = TRUE;       // Is Salamander busy?
+DWORD LastSalamanderIdleTime = 0; // GetTickCount() value from when SalamanderBusy last changed to TRUE
 
-int PasteLinkIsRunning = 0; // pokud je vetsi nez nula, probiha prave Past Shortcuts prikaz v jednom z panelu
+int PasteLinkIsRunning = 0; // if greater than zero, the Paste Shortcuts command is currently running in one of the panels
 
-BOOL CannotCloseSalMainWnd = FALSE; // TRUE = nesmi dojit k zavreni hlavniho okna
+BOOL CannotCloseSalMainWnd = FALSE; // TRUE = the main window must not be closed
 
 DWORD MainThreadID = -1;
 
@@ -131,14 +133,14 @@ int GTDExceptionHasOccured = 0;
 int SHLExceptionHasOccured = 0;
 int RelExceptionHasOccured = 0;
 
-char DecimalSeparator[5] = "."; // "znaky" (max. 4 znaky) vytazene ze systemu
-int DecimalSeparatorLen = 1;    // delka ve znacich bez nuly na konci
+char DecimalSeparator[5] = "."; // characters retrieved from the system (max. 4 characters)
+int DecimalSeparatorLen = 1;    // length in characters, excluding the terminating null
 char ThousandsSeparator[5] = " ";
 int ThousandsSeparatorLen = 1;
 
-BOOL WindowsXP64AndLater = FALSE;  // JRYFIXME - zrusit
-BOOL WindowsVistaAndLater = FALSE; // JRYFIXME - zrusit
-BOOL Windows7AndLater = FALSE;     // JRYFIXME - zrusit
+BOOL WindowsXP64AndLater = FALSE;  // JRYFIXME - remove
+BOOL WindowsVistaAndLater = FALSE; // JRYFIXME - remove this
+BOOL Windows7AndLater = FALSE;     // JRYFIXME - remove
 BOOL Windows8AndLater = FALSE;
 BOOL Windows8_1AndLater = FALSE;
 BOOL Windows10AndLater = FALSE;
@@ -189,14 +191,14 @@ const char* CommonFileTypeName2 = NULL;
 
 char WindowsDirectory[MAX_PATH] = "";
 
-// pro zajisteni uniku z odstranenych drivu na fixed drive (po vysunuti device - USB flash disk, atd.)
-BOOL ChangeLeftPanelToFixedWhenIdleInProgress = FALSE; // TRUE = prave se meni cesta, nastaveni ChangeLeftPanelToFixedWhenIdle na TRUE je zbytecne
+// Ensures escape from removed drives to a fixed drive after a device is ejected (USB flash drive, etc.).
+BOOL ChangeLeftPanelToFixedWhenIdleInProgress = FALSE; // TRUE = the path is currently being changed; setting ChangeLeftPanelToFixedWhenIdle to TRUE is unnecessary
 BOOL ChangeLeftPanelToFixedWhenIdle = FALSE;
-BOOL ChangeRightPanelToFixedWhenIdleInProgress = FALSE; // TRUE = prave se meni cesta, nastaveni ChangeRightPanelToFixedWhenIdle na TRUE je zbytecne
+BOOL ChangeRightPanelToFixedWhenIdleInProgress = FALSE; // TRUE = the path is currently being changed; setting ChangeRightPanelToFixedWhenIdle to TRUE is unnecessary
 BOOL ChangeRightPanelToFixedWhenIdle = FALSE;
-BOOL OpenCfgToChangeIfPathIsInaccessibleGoTo = FALSE; // TRUE = v idle otevre konfiguraci na Drives a focusne "If path in panel is inaccessible, go to:"
+BOOL OpenCfgToChangeIfPathIsInaccessibleGoTo = FALSE; // TRUE = when idle, opens the configuration on Drives and focuses "If path in panel is inaccessible, go to:"
 
-char IsSLGIncomplete[ISSLGINCOMPLETE_SIZE]; // pokud je retezec prazdny, SLG je kompletne prelozene; jinak obsahuje URL na forum do sekce daneho jazyka
+char IsSLGIncomplete[ISSLGINCOMPLETE_SIZE]; // If the string is empty, the SLG is fully translated; otherwise it contains the URL of the forum section for that language.
 
 UINT TaskbarBtnCreatedMsg = 0;
 
@@ -217,7 +219,7 @@ const char* CMAINWINDOW_CLASSNAME = "SalamanderMainWindowVer25";
 const char* SAVEBITS_CLASSNAME = "SalamanderSaveBits";
 const char* SHELLEXECUTE_CLASSNAME = "SalamanderShellExecute";
 
-CAssociations Associations; // asociace nactene z registry
+CAssociations Associations; // associations loaded from the registry
 CShares Shares;
 
 char DefaultDir['Z' - 'A' + 1][MAX_PATH];
@@ -225,15 +227,15 @@ char DefaultDir['Z' - 'A' + 1][MAX_PATH];
 HACCEL AccelTable1 = NULL;
 HACCEL AccelTable2 = NULL;
 
-HINSTANCE NtDLL = NULL;             // handle k ntdll.dll
-HINSTANCE Shell32DLL = NULL;        // handle k shell32.dll (ikonky)
-HINSTANCE ImageResDLL = NULL;       // handle k imageres.dll (ikonky - Vista)
-HINSTANCE User32DLL = NULL;         // handle k user32.dll (DisableProcessWindowsGhosting)
-HINSTANCE HLanguage = NULL;         // handle k jazykove zavislym resourcum (.SPL souboru)
-char CurrentHelpDir[MAX_PATH] = ""; // po prvnim pouziti helpu je zde cesta do adresare helpu (umisteni vsech .chm souboru)
-WORD LanguageID = 0;                // language-id .SPL souboru
+HINSTANCE NtDLL = NULL;             // handle to ntdll.dll
+HINSTANCE Shell32DLL = NULL;        // handle to shell32.dll (icons)
+HINSTANCE ImageResDLL = NULL;       // handle to imageres.dll (Vista icons)
+HINSTANCE User32DLL = NULL;         // handle to user32.dll (DisableProcessWindowsGhosting)
+HINSTANCE HLanguage = NULL;         // handle to language-specific resources (.SPL file)
+char CurrentHelpDir[MAX_PATH] = ""; // after Help is used for the first time, this stores the path to the help directory (where all .chm files are located)
+WORD LanguageID = 0;                // language ID of the .SPL file
 
-char OpenReadmeInNotepad[MAX_PATH]; // pouziva se jen pri spusteni z instalaku: jmeno souboru, ktere mame v IDLE otevrit v notepadu (spustit notepad)
+char OpenReadmeInNotepad[MAX_PATH]; // used only when launched from the installer: the name of the file to open in Notepad when idle
 
 BOOL UseCustomPanelFont = FALSE;
 HFONT Font = NULL;
@@ -262,12 +264,12 @@ HBRUSH HMenuSelectedTextBrush = NULL;
 HBRUSH HMenuHilightBrush = NULL;
 HBRUSH HMenuGrayTextBrush = NULL;
 
-HPEN HActiveNormalPen = NULL; // pera pro ramecek kolem polozky
+HPEN HActiveNormalPen = NULL; // pens for the rectangle around an item
 HPEN HActiveSelectedPen = NULL;
 HPEN HInactiveNormalPen = NULL;
 HPEN HInactiveSelectedPen = NULL;
 
-HPEN HThumbnailNormalPen = NULL; // pera pro ramecek kolem thumbnail
+HPEN HThumbnailNormalPen = NULL; // Pens for the thumbnail border
 HPEN HThumbnailFucsedPen = NULL;
 HPEN HThumbnailSelectedPen = NULL;
 HPEN HThumbnailFocSelPen = NULL;
@@ -297,7 +299,7 @@ HBITMAP HZoomBitmap = NULL;
 
 HCURSOR HHelpCursor = NULL;
 
-int SystemDPI = 0; // Globalni DPI pres vsechny monitory. Salamander nepodporuje Per-Monitor DPI, viz https://msdn.microsoft.com/library/windows/desktop/dn469266.aspx
+int SystemDPI = 0; // Global DPI across all monitors. Salamander does not support per-monitor DPI; see https://msdn.microsoft.com/library/windows/desktop/dn469266.aspx
 int IconSizes[] = {16, 32, 48};
 int IconLRFlags = 0;
 HICON HSharedOverlays[] = {0};
@@ -305,7 +307,7 @@ HICON HShortcutOverlays[] = {0};
 HICON HSlowFileOverlays[] = {0};
 CIconList* SimpleIconLists[] = {0};
 CIconList* ThrobberFrames = NULL;
-CIconList* LockFrames = NULL; // pro jednoduchost deklaruji a nacitam jako throbber
+CIconList* LockFrames = NULL; // for simplicity, declare and load it like the throbber
 
 HICON HGroupIcon = NULL;
 HICON HFavoritIcon = NULL;
@@ -315,9 +317,9 @@ RGBQUAD ColorTable[256] = {0};
 
 DWORD MouseHoverTime = 0;
 
-SYSTEMTIME SalamanderStartSystemTime = {0}; // cas startu Salamandera (GetSystemTime)
+SYSTEMTIME SalamanderStartSystemTime = {0}; // Salamander start time (GetSystemTime)
 
-BOOL WaitForESCReleaseBeforeTestingESC = FALSE; // ma se cekat na pusteni ESC pred zacatkem listovani cesty v panelu?
+BOOL WaitForESCReleaseBeforeTestingESC = FALSE; // should we wait for ESC to be released before starting to list the path in the panel?
 
 int SPACE_WIDTH = 10;
 
@@ -340,40 +342,40 @@ BOOL CriticalShutdown = FALSE;
 HANDLE SalOpenFileMapping = NULL;
 void* SalOpenSharedMem = NULL;
 
-// mutex pro synchronizaci load/save do Registry (dva procesy najednou nemuzou, ma to neblahe vysledky)
+// mutex for synchronizing load/save to the Registry (two processes at once cause problems)
 CLoadSaveToRegistryMutex LoadSaveToRegistryMutex;
 
-BOOL IsNotAlphaNorNum[256]; // pole TRUE/FALSE pro znaky (TRUE = neni pismeno ani cislice)
-BOOL IsAlpha[256];          // pole TRUE/FALSE pro znaky (TRUE = pismeno)
+BOOL IsNotAlphaNorNum[256]; // TRUE/FALSE array for characters (TRUE = not a letter or digit)
+BOOL IsAlpha[256];          // TRUE/FALSE array for characters (TRUE = letter)
 
-// defaultni useruv charset pro fonty; pod W2K+ uz by stacilo DEFAULT_CHARSET
+// the default user charset for fonts; on W2K+ DEFAULT_CHARSET alone would already be enough
 //
-// Pod WinXP lze v regionalnim nastaveni zvolit jako default napriklad cestinu,
-// ale na zalozce Advanced nenainstalovat ceske fotny. Potom pri konstrukci
-// fontu s kodovanim UserCharset operacni system vrati font s uplne
-// jinym nazvem (face name), hlavne aby mel pozadovane kodovani. Proto je DULEZITE pri
-// specifikaci parametru fontu spravne zvolit promennou lfPitchAndFamily,
-// kde si lze volit mezi FF_SWISS a FF_ROMAN fonty (bezpatkove/patkove).
+// Under WinXP, Czech can be selected as the default in the regional settings,
+// but Czech fonts may still be missing on the Advanced tab. Then, when creating
+// a font with UserCharset encoding, the operating system returns a font with a completely
+// different name (face name), mainly to satisfy the requested encoding. Therefore, it is IMPORTANT to
+// choose the lfPitchAndFamily variable correctly when specifying font parameters,
+// because it lets you select between FF_SWISS and FF_ROMAN fonts (sans serif/serif).
 int UserCharset = DEFAULT_CHARSET;
 
-DWORD AllocationGranularity = 1; // granularita alokaci (potreba pro pouzivani souboru mapovanych do pameti)
+DWORD AllocationGranularity = 1; // Allocation granularity (needed when using memory-mapped files)
 
 #ifdef USE_BETA_EXPIRATION_DATE
 
-// urcuje prvni den, kdy uz tato beta/PB verze nepobezi
-// beta/PB verze 4.0 beta 1 pojede pouze do 1. unora 2020
+// specifies the first day on which this beta/PB version will no longer run
+// beta/PB version 4.0 beta 1 will run only until February 1, 2020
 //                                 YEAR  MONTH DAY
 SYSTEMTIME BETA_EXPIRATION_DATE = {2020, 2, 0, 1, 0, 0, 0, 0};
 #endif // USE_BETA_EXPIRATION_DATE
 
 //******************************************************************************
 //
-// Rizeni Idle processingu (CMainWindow::OnEnterIdle)
+// Idle processing control (CMainWindow::OnEnterIdle)
 //
 
-BOOL IdleRefreshStates = TRUE;  // na uvod nechame nastavit promenne
-BOOL IdleForceRefresh = FALSE;  // vyradi cache Enabler*
-BOOL IdleCheckClipboard = TRUE; // koukneme taky na clipboard
+BOOL IdleRefreshStates = TRUE;  // initialize the state variables on the first idle pass
+BOOL IdleForceRefresh = FALSE;  // bypasses the Enabler* cache
+BOOL IdleCheckClipboard = TRUE; // also check the clipboard
 
 DWORD EnablerUpDir = FALSE;
 DWORD EnablerRootDir = FALSE;
@@ -448,7 +450,7 @@ SALCOLOR ViewerColors[NUMBER_OF_VIEWERCOLORS] =
 
 COLORREF SalamanderColors[NUMBER_OF_COLORS] =
     {
-        // barvy pera pro ramecek kolem polozky
+        // pen colors for the frame around the item
         RGBF(0, 0, 0, SCF_DEFAULT),       // FOCUS_ACTIVE_NORMAL
         RGBF(0, 0, 0, SCF_DEFAULT),       // FOCUS_ACTIVE_SELECTED
         RGBF(128, 128, 128, 0),           // FOCUS_FG_INACTIVE_NORMAL
@@ -456,43 +458,43 @@ COLORREF SalamanderColors[NUMBER_OF_COLORS] =
         RGBF(255, 255, 255, SCF_DEFAULT), // FOCUS_BK_INACTIVE_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // FOCUS_BK_INACTIVE_SELECTED
 
-        // barvy textu polozek v panelu
+        // item text colors in the panel
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_NORMAL
         RGBF(255, 0, 0, 0),         // ITEM_FG_SELECTED
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_FOCUSED
         RGBF(255, 0, 0, 0),         // ITEM_FG_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_HIGHLIGHT
 
-        // barvy pozadi polozek v panelu
+        // background colors of items in the panel
         RGBF(255, 255, 255, SCF_DEFAULT), // ITEM_BK_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // ITEM_BK_SELECTED
         RGBF(232, 232, 232, 0),           // ITEM_BK_FOCUSED
         RGBF(232, 232, 232, 0),           // ITEM_BK_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT),       // ITEM_BK_HIGHLIGHT
 
-        // barvy pro blend ikonek
+        // icon blend colors
         RGBF(255, 128, 128, SCF_DEFAULT), // ICON_BLEND_SELECTED
         RGBF(128, 128, 128, 0),           // ICON_BLEND_FOCUSED
         RGBF(255, 0, 0, 0),               // ICON_BLEND_FOCSEL
 
-        // barvy progress bary
+        // progress bar colors
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_FG_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_FG_SELECTED
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_BK_NORMAL
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_BK_SELECTED
 
-        // barvy hot polozek
+        // colors of hot items
         RGBF(0, 0, 255, SCF_DEFAULT),     // HOT_PANEL
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_ACTIVE
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_INACTIVE
 
-        // barvy titulku panelu
+        // panel title colors
         RGBF(255, 255, 255, SCF_DEFAULT), // ACTIVE_CAPTION_FG
         RGBF(0, 0, 128, SCF_DEFAULT),     // ACTIVE_CAPTION_BK
         RGBF(255, 255, 255, SCF_DEFAULT), // INACTIVE_CAPTION_FG
         RGBF(128, 128, 128, SCF_DEFAULT), // INACTIVE_CAPTION_BK
 
-        // barvy pera pro ramecek kolem thumbnails
+        // Pen colors for the frame around thumbnails
         RGBF(192, 192, 192, 0), // THUMBNAIL_FRAME_NORMAL
         RGBF(0, 0, 0, 0),       // THUMBNAIL_FRAME_FOCUSED
         RGBF(255, 0, 0, 0),     // THUMBNAIL_FRAME_SELECTED
@@ -501,7 +503,7 @@ COLORREF SalamanderColors[NUMBER_OF_COLORS] =
 
 COLORREF ExplorerColors[NUMBER_OF_COLORS] =
     {
-        // barvy pera pro ramecek kolem polozky
+        // Pen colors for the frame around the item
         RGBF(0, 0, 0, SCF_DEFAULT),       // FOCUS_ACTIVE_NORMAL
         RGBF(255, 255, 0, 0),             // FOCUS_ACTIVE_SELECTED
         RGBF(128, 128, 128, 0),           // FOCUS_FG_INACTIVE_NORMAL
@@ -509,43 +511,43 @@ COLORREF ExplorerColors[NUMBER_OF_COLORS] =
         RGBF(255, 255, 255, SCF_DEFAULT), // FOCUS_BK_INACTIVE_NORMAL
         RGBF(255, 255, 0, 0),             // FOCUS_BK_INACTIVE_SELECTED
 
-        // barvy textu polozek v panelu
+        // item text colors in the panel
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_NORMAL
         RGBF(255, 255, 255, 0),     // ITEM_FG_SELECTED
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_FOCUSED
         RGBF(255, 255, 255, 0),     // ITEM_FG_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_HIGHLIGHT
 
-        // barvy pozadi polozek v panelu
+        // Background colors of items in the panel
         RGBF(255, 255, 255, SCF_DEFAULT), // ITEM_BK_NORMAL
         RGBF(0, 0, 128, 0),               // ITEM_BK_SELECTED
         RGBF(232, 232, 232, 0),           // ITEM_BK_FOCUSED
         RGBF(0, 0, 128, 0),               // ITEM_BK_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT),       // ITEM_BK_HIGHLIGHT
 
-        // barvy pro blend ikonek
+        // colors for icon blending
         RGBF(0, 0, 128, SCF_DEFAULT), // ICON_BLEND_SELECTED
         RGBF(128, 128, 128, 0),       // ICON_BLEND_FOCUSED
         RGBF(0, 0, 128, 0),           // ICON_BLEND_FOCSEL
 
-        // barvy progress bary
+        // progress bar colors
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_FG_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_FG_SELECTED
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_BK_NORMAL
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_BK_SELECTED
 
-        // barvy hot polozek
+        // hot item colors
         RGBF(0, 0, 255, SCF_DEFAULT),     // HOT_PANEL
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_ACTIVE
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_INACTIVE
 
-        // barvy titulku panelu
+        // panel title colors
         RGBF(255, 255, 255, SCF_DEFAULT), // ACTIVE_CAPTION_FG
         RGBF(0, 0, 128, SCF_DEFAULT),     // ACTIVE_CAPTION_BK
         RGBF(255, 255, 255, SCF_DEFAULT), // INACTIVE_CAPTION_FG
         RGBF(128, 128, 128, SCF_DEFAULT), // INACTIVE_CAPTION_BK
 
-        // barvy pera pro ramecek kolem thumbnails
+        // pen colors for the frame around thumbnails
         RGBF(192, 192, 192, 0), // THUMBNAIL_FRAME_NORMAL
         RGBF(0, 0, 128, 0),     // THUMBNAIL_FRAME_FOCUSED
         RGBF(0, 0, 128, 0),     // THUMBNAIL_FRAME_SELECTED
@@ -554,7 +556,7 @@ COLORREF ExplorerColors[NUMBER_OF_COLORS] =
 
 COLORREF NortonColors[NUMBER_OF_COLORS] =
     {
-        // barvy pera pro ramecek kolem polozky
+        // pen colors for the frame around the item
         RGBF(0, 128, 128, 0), // FOCUS_ACTIVE_NORMAL
         RGBF(0, 128, 128, 0), // FOCUS_ACTIVE_SELECTED
         RGBF(0, 128, 128, 0), // FOCUS_FG_INACTIVE_NORMAL
@@ -562,43 +564,43 @@ COLORREF NortonColors[NUMBER_OF_COLORS] =
         RGBF(0, 0, 128, 0),   // FOCUS_BK_INACTIVE_NORMAL
         RGBF(0, 0, 128, 0),   // FOCUS_BK_INACTIVE_SELECTED
 
-        // barvy textu polozek v panelu
+        // panel item text colors
         RGBF(0, 255, 255, 0),       // ITEM_FG_NORMAL
         RGBF(255, 255, 0, 0),       // ITEM_FG_SELECTED
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_FOCUSED
         RGBF(255, 255, 0, 0),       // ITEM_FG_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_HIGHLIGHT
 
-        // barvy pozadi polozek v panelu
+        // background colors of items in the panel
         RGBF(0, 0, 128, 0),         // ITEM_BK_NORMAL
         RGBF(0, 0, 128, 0),         // ITEM_BK_SELECTED
         RGBF(0, 128, 128, 0),       // ITEM_BK_FOCUSED
         RGBF(0, 128, 128, 0),       // ITEM_BK_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_BK_HIGHLIGHT
 
-        // barvy pro blend ikonek
+        // colors for icon blending
         RGBF(255, 255, 0, SCF_DEFAULT), // ICON_BLEND_SELECTED
         RGBF(128, 128, 128, 0),         // ICON_BLEND_FOCUSED
         RGBF(255, 255, 0, 0),           // ICON_BLEND_FOCSEL
 
-        // barvy progress bary
+        // progress bar colors
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_FG_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_FG_SELECTED
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_BK_NORMAL
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_BK_SELECTED
 
-        // barvy hot polozek
+        // colors of hot items
         RGBF(0, 0, 255, SCF_DEFAULT),     // HOT_PANEL
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_ACTIVE
         RGBF(128, 128, 128, SCF_DEFAULT), // HOT_INACTIVE
 
-        // barvy titulku panelu
+        // panel title colors
         RGBF(255, 255, 255, SCF_DEFAULT), // ACTIVE_CAPTION_FG
         RGBF(0, 0, 128, SCF_DEFAULT),     // ACTIVE_CAPTION_BK
         RGBF(255, 255, 255, SCF_DEFAULT), // INACTIVE_CAPTION_FG
         RGBF(128, 128, 128, SCF_DEFAULT), // INACTIVE_CAPTION_BK
 
-        // barvy pera pro ramecek kolem thumbnails
+        // Pen colors for the frame around thumbnails
         RGBF(192, 192, 192, 0), // THUMBNAIL_FRAME_NORMAL
         RGBF(0, 128, 128, 0),   // THUMBNAIL_FRAME_FOCUSED
         RGBF(255, 255, 0, 0),   // THUMBNAIL_FRAME_SELECTED
@@ -607,7 +609,7 @@ COLORREF NortonColors[NUMBER_OF_COLORS] =
 
 COLORREF NavigatorColors[NUMBER_OF_COLORS] =
     {
-        // barvy pera pro ramecek kolem polozky
+        // Pen colors for the frame around the item
         RGBF(0, 128, 128, 0), // FOCUS_ACTIVE_NORMAL
         RGBF(0, 128, 128, 0), // FOCUS_ACTIVE_SELECTED
         RGBF(0, 128, 128, 0), // FOCUS_FG_INACTIVE_NORMAL
@@ -615,43 +617,43 @@ COLORREF NavigatorColors[NUMBER_OF_COLORS] =
         RGBF(0, 0, 128, 0),   // FOCUS_BK_INACTIVE_NORMAL
         RGBF(0, 0, 128, 0),   // FOCUS_BK_INACTIVE_SELECTED
 
-        // barvy textu polozek v panelu
+        // panel item text colors
         RGBF(255, 255, 255, 0),     // ITEM_FG_NORMAL
         RGBF(255, 255, 0, 0),       // ITEM_FG_SELECTED
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_FOCUSED
         RGBF(255, 255, 0, 0),       // ITEM_FG_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_FG_HIGHLIGHT
 
-        // barvy pozadi polozek v panelu
+        // item background colors in the panel
         RGBF(80, 80, 80, 0),        // ITEM_BK_NORMAL
         RGBF(80, 80, 80, 0),        // ITEM_BK_SELECTED
         RGBF(0, 128, 128, 0),       // ITEM_BK_FOCUSED
         RGBF(0, 128, 128, 0),       // ITEM_BK_FOCSEL
         RGBF(0, 0, 0, SCF_DEFAULT), // ITEM_BK_HIGHLIGHT
 
-        // barvy pro blend ikonek
+        // colors for icon blending
         RGBF(255, 255, 0, SCF_DEFAULT), // ICON_BLEND_SELECTED
         RGBF(128, 128, 128, 0),         // ICON_BLEND_FOCUSED
         RGBF(255, 255, 0, 0),           // ICON_BLEND_FOCSEL
 
-        // barvy progress bary
+        // progress bar colors
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_FG_NORMAL
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_FG_SELECTED
         RGBF(255, 255, 255, SCF_DEFAULT), // PROGRESS_BK_NORMAL
         RGBF(0, 0, 192, SCF_DEFAULT),     // PROGRESS_BK_SELECTED
 
-        // barvy hot polozek
+        // hot item colors
         RGBF(0, 0, 255, SCF_DEFAULT),     // HOT_PANEL
         RGBF(173, 182, 205, SCF_DEFAULT), // HOT_ACTIVE
         RGBF(212, 212, 212, SCF_DEFAULT), // HOT_INACTIVE
 
-        // barvy titulku panelu
+        // panel title colors
         RGBF(255, 255, 255, SCF_DEFAULT), // ACTIVE_CAPTION_FG
         RGBF(0, 0, 128, SCF_DEFAULT),     // ACTIVE_CAPTION_BK
         RGBF(255, 255, 255, SCF_DEFAULT), // INACTIVE_CAPTION_FG
         RGBF(128, 128, 128, SCF_DEFAULT), // INACTIVE_CAPTION_BK
 
-        // barvy pera pro ramecek kolem thumbnails
+        // Pen colors for the frame around thumbnails
         RGBF(192, 192, 192, 0), // THUMBNAIL_FRAME_NORMAL
         RGBF(0, 128, 128, 0),   // THUMBNAIL_FRAME_FOCUSED
         RGBF(255, 255, 0, 0),   // THUMBNAIL_FRAME_SELECTED
@@ -692,15 +694,15 @@ void MakeCrc32Table(DWORD* crcTab)
     DWORD poly = 0xedb88320L; //polynomial exclusive-or pattern
 
     /*
-  // generate crc polonomial, using precomputed poly should be faster
-  // terms of polynomial defining this crc (except x^32):
-  static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
+      // generate CRC polynomial; using a precomputed polynomial should be faster
+      // terms of the polynomial defining this CRC (except x^32):
+      static const Byte p[] = {0,1,2,4,5,7,8,10,11,12,16,22,23,26};
 
-  // make exclusive-or pattern from polynomial (0xedb88320L)
-  poly = 0L;
-  for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
-    poly |= 1L << (31 - p[n]);
-*/
+      // make exclusive-or pattern from the polynomial (0xedb88320L)
+      poly = 0L;
+      for (n = 0; n < sizeof(p)/sizeof(Byte); n++)
+        poly |= 1L << (31 - p[n]);
+    */
     int n;
     for (n = 0; n < 256; n++)
     {
@@ -736,11 +738,11 @@ DWORD UpdateCrc32(const void* buffer, DWORD count, DWORD crcVal)
             c = Crc32Tab[((int)c ^ (*p++)) & 0xff] ^ (c >> 8);
         } while (--count);
 
-    // Honza: meril jsem nasledujici optimalizace a nemaji zadny vyznam;
-    // jedina sance by bylo prepsani do ASM a cteni pameti po DWORDech,
-    // ze kterych by pak bylo mozne vyzobavat jednotlive bajty;
-    // pri soucasnem nastaveni release verze neni prekladac schopen tuto
-    // optimalizaci provest za nas.
+    // The following optimizations were benchmarked and have no practical benefit;
+    // the only remaining option would be to rewrite this in ASM and read memory in DWORDs,
+    // from which individual bytes could then be extracted;
+    // with the current release-build settings, the compiler cannot perform this
+    // optimization for us.
     /*
   int remain = count % 8;
   count -= remain;
@@ -796,17 +798,17 @@ BOOL IsRemoteSession(void)
 
 BOOL SalamanderIsNotBusy(DWORD* lastIdleTime)
 {
-    // k SalamanderBusy a k LastSalamanderIdleTime se chodi bez kritickych sekci, nevadi,
-    // protoze jsou to DWORDy a tudiz nemuzou byt "rozpracovane" pri switchnuti kontextu
-    // (vzdy je tam stara nebo nova hodnota, nic jineho nehrozi)
+    // SalamanderBusy and LastSalamanderIdleTime are accessed without critical sections, which is fine,
+    // because they are DWORDs and therefore cannot be left in a "partially updated" state during a context switch
+    // (the value is always either the old one or the new one, and nothing else can occur)
     if (lastIdleTime != NULL)
         *lastIdleTime = LastSalamanderIdleTime;
     if (!SalamanderBusy)
         return TRUE;
     DWORD oldLastIdleTime = LastSalamanderIdleTime;
-    if (GetTickCount() - oldLastIdleTime <= 100)                                   // pokud neni SalamanderBusy uz prilis dlouho (napr. otevreny modalni dialog)
-        Sleep(100);                                                                // pockame jestli se SalamanderBusy nezmeni
-    return !SalamanderBusy || (int)(LastSalamanderIdleTime - oldLastIdleTime) > 0; // neni "busy" nebo aspon osciluje
+    if (GetTickCount() - oldLastIdleTime <= 100)                                   // if SalamanderBusy has not changed for too long already (for example, because a modal dialog is open)
+        Sleep(100);                                                                // wait to see if SalamanderBusy changes
+    return !SalamanderBusy || (int)(LastSalamanderIdleTime - oldLastIdleTime) > 0; // not busy, or at least changing state
 }
 
 BOOL InitPreloadedStrings()
@@ -886,7 +888,7 @@ void InitLocales()
     else
     {
         DecimalSeparatorLen--;
-        DecimalSeparator[DecimalSeparatorLen] = 0; // posychrujeme nulu na konci
+        DecimalSeparator[DecimalSeparatorLen] = 0; // make sure the string is null-terminated
     }
 
     if ((ThousandsSeparatorLen = GetLocaleInfo(LOCALE_USER_DEFAULT, LOCALE_STHOUSAND, ThousandsSeparator, 5)) == 0 ||
@@ -898,7 +900,7 @@ void InitLocales()
     else
     {
         ThousandsSeparatorLen--;
-        ThousandsSeparator[ThousandsSeparatorLen] = 0; // posychrujeme nulu na konci
+        ThousandsSeparator[ThousandsSeparatorLen] = 0; // ensure the null terminator stays at the end
     }
 }
 
@@ -911,11 +913,11 @@ HICON GetFileOrPathIconAux(const char* path, BOOL large, BOOL isDir)
         SHFILEINFO shi;
         if (!GetFileIcon(path, FALSE, &shi.hIcon, large ? ICONSIZE_32 : ICONSIZE_16, TRUE, isDir))
             shi.hIcon = NULL;
-        //Presli jsme na vlastni implementaci (mensi pametova narocnost, fungujici XOR ikonky)
+        // We switched to our own implementation (lower memory use, and XOR icons work correctly)
         //shi.hIcon = NULL;
         //SHGetFileInfo(path, 0, &shi, sizeof(shi),
         //              SHGFI_ICON | SHGFI_SHELLICONSIZE | (large ? 0 : SHGFI_SMALLICON));
-        // pridame handle na 'shi.hIcon' do HANDLES
+        // add the handle for 'shi.hIcon' to HANDLES
         if (shi.hIcon != NULL)
             HANDLES_ADD(__htIcon, __hoLoadImage, shi.hIcon);
         return shi.hIcon;
@@ -933,12 +935,12 @@ HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large)
     int id;
     switch (type)
     {
-    case DRIVE_REMOVABLE: // ikonky 3.5, 5.25
+    case DRIVE_REMOVABLE: // 3.5" and 5.25" drive icons
     {
         HICON i = GetFileOrPathIconAux(root, large, TRUE);
         if (i != NULL)
             return i;
-        id = 28; // 3 1/2 " mechanika
+        id = 28; // 3.5" drive
         break;
     }
 
@@ -967,14 +969,14 @@ HICON GetDriveIcon(const char* root, UINT type, BOOL accessible, BOOL large)
     int iconSize = IconSizes[large ? ICONSIZE_32 : ICONSIZE_16];
     return SalLoadIcon(ImageResDLL, id, iconSize);
 
-    // JRYFIXME - prozkoumat jestli neni IconLRFlags na zruseni? (W7+)
+    // JRYFIXME - investigate whether IconLRFlags should be removed. (W7+)
 
-    /* JRYFIXME - grepnout plosne zdrojaky na LoadImage / IMAGE_ICON
-  return (HICON)HANDLES(LoadImage(ImageResDLL, MAKEINTRESOURCE(id), IMAGE_ICON,
-                                  large ? ICON32_CX : ICON16_CX,
-                                  large ? ICON32_CX : ICON16_CX,
-                                  IconLRFlags));
-  */
+    /* JRYFIXME - grep the source tree for LoadImage / IMAGE_ICON
+      return (HICON)HANDLES(LoadImage(ImageResDLL, MAKEINTRESOURCE(id), IMAGE_ICON,
+                                      large ? ICON32_CX : ICON16_CX,
+                                      large ? ICON32_CX : ICON16_CX,
+                                      IconLRFlags));
+      */
 }
 
 HICON SalLoadIcon(HINSTANCE hDLL, int id, int iconSize)
@@ -992,7 +994,7 @@ char* BuildName(char* path, char* name, char* dosName, BOOL* skip, BOOL* skipAll
 {
     if (skip != NULL)
         *skip = FALSE;
-    int l1 = (int)strlen(path); // je vzdy na stacku ...
+    int l1 = (int)strlen(path); // Always on the stack...
     int l2, len = l1;
     if (name != NULL)
     {
@@ -1027,17 +1029,17 @@ char* BuildName(char* path, char* name, char* dosName, BOOL* skip, BOOL* skipAll
                 params.Caption = LoadStr(IDS_ERRORTITLE);
                 params.Text = text;
                 char aliasBtnNames[200];
-                /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   nechame pro tlacitka msgboxu resit kolize hotkeys tim, ze simulujeme, ze jde o menu
-MENU_TEMPLATE_ITEM MsgBoxButtons[] = 
-{
-  {MNTT_PB, 0
-  {MNTT_IT, IDS_MSGBOXBTN_SKIP
-  {MNTT_IT, IDS_MSGBOXBTN_SKIPALL
-  {MNTT_IT, IDS_MSGBOXBTN_FOCUS
-  {MNTT_PE, 0
-};
-*/
+                /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
+                   for message box buttons, let hotkey collisions be handled by pretending they are a menu
+                MENU_TEMPLATE_ITEM MsgBoxButtons[] =
+                {
+                  {MNTT_PB, 0
+                  {MNTT_IT, IDS_MSGBOXBTN_SKIP
+                  {MNTT_IT, IDS_MSGBOXBTN_SKIPALL
+                  {MNTT_IT, IDS_MSGBOXBTN_FOCUS
+                  {MNTT_PE, 0
+                };
+                */
                 sprintf(aliasBtnNames, "%d\t%s\t%d\t%s\t%d\t%s",
                         DIALOG_YES, LoadStr(IDS_MSGBOXBTN_SKIP),
                         DIALOG_NO, LoadStr(IDS_MSGBOXBTN_SKIPALL),
@@ -1086,10 +1088,10 @@ BOOL HasTheSameRootPath(const char* path1, const char* path2)
     if (LowerCase[path1[0]] == LowerCase[path2[0]] && path1[1] == path2[1])
     {
         if (path1[1] == ':')
-            return TRUE; // stejny root normal ("c:\path") cesty
+            return TRUE; // same root for regular ("c:\path") paths
         else
         {
-            if (path1[0] == '\\' && path1[1] == '\\') // oboji UNC
+            if (path1[0] == '\\' && path1[1] == '\\') // both UNC paths
             {
                 const char* s1 = path1 + 2;
                 const char* s2 = path2 + 2;
@@ -1101,9 +1103,9 @@ BOOL HasTheSameRootPath(const char* path1, const char* path2)
                         s2++;
                     }
                     else
-                        break; // ruzne masiny
+                        break; // different machines
                 }
-                if (*s1 != 0 && *s1++ == *s2++) // preskok '\\'
+                if (*s1 != 0 && *s1++ == *s2++) // skip '\\'
                 {
                     while (*s1 != 0 && *s1 != '\\')
                     {
@@ -1113,7 +1115,7 @@ BOOL HasTheSameRootPath(const char* path1, const char* path2)
                             s2++;
                         }
                         else
-                            break; // ruzne disky
+                            break; // different shares
                     }
                     return (*s1 == 0 && (*s2 == 0 || *s2 == '\\')) || *s1 == *s2 ||
                            (*s2 == 0 && (*s1 == 0 || *s1 == '\\'));
@@ -1142,44 +1144,44 @@ BOOL HasTheSameRootPathAndVolume(const char* p1, const char* p2)
         lstrcpyn(resPath, p1, MAX_PATH);
         ResolveSubsts(resPath);
         GetRootPath(root, resPath);
-        if (!IsUNCPath(root) && GetDriveType(root) == DRIVE_FIXED) // reparse pointy ma smysl hledat jen na fixed discich
+        if (!IsUNCPath(root) && GetDriveType(root) == DRIVE_FIXED) // only look for reparse points on fixed drives
         {
-            // pokud nejde o root cestu, zkusime jeste traverzovat po reparse pointech
+            // if this is not a root path, also try traversing through reparse points
             BOOL cutPathIsPossible = TRUE;
             char p1NetPath[MAX_PATH];
             p1NetPath[0] = 0;
             ResolveLocalPathWithReparsePoints(ourPath, p1, &cutPathIsPossible, NULL, NULL, NULL, NULL, p1NetPath);
 
-            if (p1NetPath[0] == 0) // ze sitove cesty volume ziskat nelze, nebudeme se ani snazit
+            if (p1NetPath[0] == 0) // The volume cannot be obtained from a network path, so do not even try
             {
                 while (!GetVolumeNameForVolumeMountPoint(ourPath, p1Volume, 100))
                 {
                     if (!cutPathIsPossible || !CutDirectory(ourPath))
                     {
-                        strcpy(p1Volume, "fail"); // ani root nevratil uspech, neocekavane (bohuzel se deje na substenych discich pod W2K - ladeno u Bachaalany - pri selhani na obou cestach vracime SHODU, protoze je pravdepodobnejsi)
+                        strcpy(p1Volume, "fail"); // Even the root path failed, unexpectedly (unfortunately this happens on SUBST drives under W2K, debugged at Bachaalany; if both paths fail, we treat them as matching because that is more likely)
                         break;
                     }
                     SalPathAddBackslash(ourPath, MAX_PATH);
                 }
             }
 
-            // pokud jsme pod W2K a nejde o root cestu, zkusime jeste traverzovat po reparse pointech
+            // if it is not a root path, try traversing the reparse points as well
             cutPathIsPossible = TRUE;
             char p2NetPath[MAX_PATH];
             p2NetPath[0] = 0;
             ResolveLocalPathWithReparsePoints(ourPath, p2, &cutPathIsPossible, NULL, NULL, NULL, NULL, p2NetPath);
 
-            if ((p1NetPath[0] == 0) != (p2NetPath[0] == 0) || // pokud je jen jedna z cest sitova nebo
+            if ((p1NetPath[0] == 0) != (p2NetPath[0] == 0) || // if only one of the paths is a network path, or
                 p1NetPath[0] != 0 && !HasTheSameRootPath(p1NetPath, p2NetPath))
-                ret = FALSE; // nemaji stejny root, ohlasime ruzne volumy (na sitovych cestach nelze overit volumy)
+                ret = FALSE; // Different root path, so treat them as different volumes (volumes cannot be checked on network paths)
 
-            if (p2NetPath[0] == 0 && ret) // ze sitove cesty volume ziskat nelze, nebudeme se ani snazit + pokud uz je rozhodnuto, tez se nebudeme snazit
+            if (p2NetPath[0] == 0 && ret) // A volume cannot be obtained from a network path, so do not even try; also skip it if the result is already decided
             {
                 while (!GetVolumeNameForVolumeMountPoint(ourPath, p2Volume, 100))
                 {
                     if (!cutPathIsPossible || !CutDirectory(ourPath))
                     {
-                        strcpy(p2Volume, "fail"); // ani root nevratil uspech, neocekavane (bohuzel se deje na substenych discich pod W2K - ladeno u Bachaalany - pri selhani na obou cestach vracime SHODU, protoze je pravdepodobnejsi)
+                        strcpy(p2Volume, "fail"); // Even the root path failed, unexpectedly (unfortunately this happens on SUBST drives under W2K, debugged at Bachaalany; if both paths fail, we treat them as matching because that is more likely)
                         break;
                     }
                     SalPathAddBackslash(ourPath, MAX_PATH);
@@ -1211,30 +1213,30 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
     BOOL trySimpleTest = TRUE;
     if (resIsOnlyEstimation != NULL)
         *resIsOnlyEstimation = TRUE;
-    if (!IsUNCPath(path1) && !IsUNCPath(path2)) // svazky na UNC cestach nema smysl resit
+    if (!IsUNCPath(path1) && !IsUNCPath(path2)) // No point checking volumes for UNC paths
     {
         char p1Volume[100] = "1";
         char p2Volume[100] = "2";
         UINT drvType1 = GetDriveType(root1);
         UINT drvType2 = GetDriveType(root2);
-        if (drvType1 != DRIVE_REMOTE && drvType2 != DRIVE_REMOTE) // krome site je sance zjistit "volume name"
+        if (drvType1 != DRIVE_REMOTE && drvType2 != DRIVE_REMOTE) // except on network paths, the "volume name" can be determined
         {
             BOOL cutPathIsPossible = TRUE;
-            path1NetPath[0] = 0;         // sitova cesta, na kterou vede aktualni (posledni) lokalni symlink v ceste
-            if (drvType1 == DRIVE_FIXED) // reparse pointy ma smysl hledat jen na fixed discich
+            path1NetPath[0] = 0;         // network path that the current (last) local symlink in the path points to
+            if (drvType1 == DRIVE_FIXED) // only look for reparse points on fixed drives
             {
-                // pokud jsme pod W2K a nejde o root cestu, zkusime jeste traverzovat po reparse pointech
+                // if it is not a root path, try traversing the reparse points as well
                 ResolveLocalPathWithReparsePoints(ourPath, path1, &cutPathIsPossible, NULL, NULL, NULL, NULL, path1NetPath);
             }
             else
                 lstrcpyn(ourPath, root1, MAX_PATH);
             int numOfGetVolNamesFailed = 0;
-            if (path1NetPath[0] == 0) // ze sitove cesty "volume name" ziskat nelze, nebudeme se ani snazit
+            if (path1NetPath[0] == 0) // Volume names cannot be obtained for network paths, so do not even try.
             {
                 while (!GetVolumeNameForVolumeMountPoint(ourPath, p1Volume, 100))
                 {
                     if (!cutPathIsPossible || !CutDirectory(ourPath))
-                    { // ani root nevratil uspech, neocekavane (bohuzel se deje na substenych discich pod W2K - ladeno u Bachaalany - pri selhani na obou cestach se stejnymi rooty vracime SHODU, protoze je pravdepodobnejsi)
+                    { // Even the root path failed, which is unexpected (unfortunately this happens on SUBST drives under W2K, debugged at Bachaalany; if both paths with the same root fail, treat them as the same volume because that is more likely)
                         numOfGetVolNamesFailed++;
                         break;
                     }
@@ -1243,22 +1245,22 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
             }
 
             cutPathIsPossible = TRUE;
-            path2NetPath[0] = 0;         // sitova cesta, na kterou vede aktualni (posledni) lokalni symlink v ceste
-            if (drvType2 == DRIVE_FIXED) // reparse pointy ma smysl hledat jen na fixed discich
+            path2NetPath[0] = 0;         // network path the current (last) local symlink in the path leads to
+            if (drvType2 == DRIVE_FIXED) // only look for reparse points on fixed drives
             {
-                // pokud jsme pod W2K a nejde o root cestu, zkusime jeste traverzovat po reparse pointech
+                // if it is not a root path, try traversing the reparse points as well
                 ResolveLocalPathWithReparsePoints(ourPath, path2, &cutPathIsPossible, NULL, NULL, NULL, NULL, path2NetPath);
             }
             else
                 lstrcpyn(ourPath, root2, MAX_PATH);
-            if (path2NetPath[0] == 0) // ze sitove cesty "volume name" ziskat nelze, nebudeme se ani snazit
+            if (path2NetPath[0] == 0) // Volume names cannot be obtained for network paths, so do not even try.
             {
                 if (path1NetPath[0] == 0)
                 {
                     while (!GetVolumeNameForVolumeMountPoint(ourPath, p2Volume, 100))
                     {
                         if (!cutPathIsPossible || !CutDirectory(ourPath))
-                        { // ani root nevratil uspech, neocekavane (bohuzel se deje na substenych discich pod W2K - ladeno u Bachaalany - pri selhani na obou cestach se stejnymi rooty vracime SHODU, protoze je pravdepodobnejsi)
+                        { // Even the root path failed, which is unexpected (unfortunately this happens on SUBST drives under W2K, debugged at Bachaalany; if both paths with the same root fail, treat them as the same volume because that is more likely)
                             numOfGetVolNamesFailed++;
                             break;
                         }
@@ -1267,13 +1269,13 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
                     if (numOfGetVolNamesFailed != 2)
                     {
                         if (numOfGetVolNamesFailed == 0 && resIsOnlyEstimation != NULL)
-                            *resIsOnlyEstimation = FALSE; // jediny pripad, kdy jsme si jisty vysledkem je, kdyz se podarilo ziskat "volume name" z obou cest (zaroven tak nemohly byt sitove)
+                            *resIsOnlyEstimation = FALSE; // The only time we know the result for sure is when we managed to get the "volume name" for both paths (which also means neither path could have been a network path).
                         if (numOfGetVolNamesFailed == 1 || strcmp(p1Volume, p2Volume) != 0)
-                            ret = FALSE; // povedl se ziskat jen jeden "volume name", takze nejde o stejne svazky (a pokud ano, nejsme schopny to zjistit - mozna pokud slo o selhani kvuli SUBSTu, dalo by se to resit resolvnutim cilove cesty ze SUBSTu)
+                            ret = FALSE; // Only one volume name was obtained, so we must treat them as different volumes (and if they are actually the same, we cannot detect it; if the failure was caused by SUBST, this might be fixable by resolving the SUBST target path)
                         trySimpleTest = FALSE;
                     }
                 }
-                else // sitova je jen jedna cesta, nejde o stejne svazky (a pokud ano, nejsme schopny to zjistit)
+                else // Only one of the paths is a network path, so they are not on the same volume (and if they are, we cannot determine that).
                 {
                     ret = FALSE;
                     trySimpleTest = FALSE;
@@ -1281,12 +1283,12 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
             }
             else
             {
-                if (path1NetPath[0] != 0) // srovname rooty sitovych cest
+                if (path1NetPath[0] != 0) // compare the roots of the network paths
                 {
                     GetRootPath(root1, path1NetPath);
                     GetRootPath(root2, path2NetPath);
                 }
-                else // sitova je jen jedna cesta, nejde o stejne svazky (a pokud ano, nejsme schopny to zjistit)
+                else // Only one of the paths is a network path, so they are not on the same volume (and if they are, we cannot determine that).
                 {
                     ret = FALSE;
                     trySimpleTest = FALSE;
@@ -1295,7 +1297,7 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
         }
     }
 
-    if (trySimpleTest) // zkusime jen jestli se shoduji root-cesty (sitove cesty + vse na NT)
+    if (trySimpleTest) // Only test whether the root paths match (network paths and everything on NT)
     {
         ret = _stricmp(root1, root2) == 0;
 
@@ -1306,7 +1308,7 @@ BOOL PathsAreOnTheSameVolume(const char* path1, const char* path2, BOOL* resIsOn
             if (ResolveSubsts(path1NetPath) && ResolveSubsts(path2NetPath))
             {
                 if (IsTheSamePath(path1NetPath, path2NetPath))
-                    *resIsOnlyEstimation = FALSE; // stejne cesty = urcite i stejne svazky
+                    *resIsOnlyEstimation = FALSE; // same paths definitely mean the same volumes
             }
         }
     }
@@ -1359,17 +1361,17 @@ int CommonPrefixLength(const char* path1, const char* path2)
     if (*s1 == 0 && *s2 == '\\' || *s1 == '\\' && *s2 == 0 ||
         *s1 == 0 && *s2 == 0 && *(s1 - 1) != '\\')
     {
-        lastBackslash = s1; // tento terminator nebude v lastBackslash
+        lastBackslash = s1; // points at the terminator, but the terminator itself is not included
         backslashCount++;
     }
 
     if (path1[1] == ':')
     {
-        // klasicka cesta
+        // drive-letter path
         if (path1[2] != '\\')
             return 0;
 
-        // osetrim specialni pripad: u root cesty musime vratit delku i s posledni zpetnym lomitkem
+        // Handle a special case: for a root path, we must return the length including the trailing backslash.
         if (lastBackslash - path1 < 3)
             return 3;
 
@@ -1377,10 +1379,10 @@ int CommonPrefixLength(const char* path1, const char* path2)
     }
     else
     {
-        // UNC cesta
+        // UNC path
         if (path1[0] != '\\' || path1[1] != '\\')
             return 0;
-        if (backslashCount < 4) // cesta musi mit tvar "\\masina\share"
+        if (backslashCount < 4) // the path must have the form "\\machine\share"
             return 0;
 
         return (int)(lastBackslash - path1);
@@ -1399,8 +1401,8 @@ BOOL SalPathIsPrefix(const char* prefix, const char* path)
     if (prefixLen < 3)
         return FALSE;
 
-    // CommonPrefixLength nam vratila delku bez posledniho zpetneho lomitka (pokud neslo o root path)
-    // pokud nas prefix ma koncove zpetne lomitko, musim ho zahodit
+    // CommonPrefixLength returned the length without the trailing backslash (unless this was a root path)
+    // if our prefix ends with a backslash, we have to drop it
     if (prefixLen > 3 && prefix[prefixLen - 1] == '\\')
         prefixLen--;
 
@@ -1418,8 +1420,8 @@ BOOL IsDirError(DWORD err)
            err == ERROR_BAD_PATHNAME ||
            err == ERROR_FILE_NOT_FOUND ||
            err == ERROR_PATH_NOT_FOUND ||
-           err == ERROR_INVALID_NAME ||   // je-li hacek v ceste na anglickych Windows, hlasi se tato chyba misto ERROR_PATH_NOT_FOUND
-           err == ERROR_INVALID_FUNCTION; // hlasilo jednomu chlapikovi na WinXP na sitovem disku Y: v okamziku, kdy Salam pristupoval na cestu, ktera jiz neexistovala (nedoslo tak ke zkraceni a chlapik byl dobre v riti ;-) Shift+F7 na Y:\ to vyresila)
+           err == ERROR_INVALID_NAME ||   // On English Windows, if the path contains characters with diacritics, this error is reported instead of ERROR_PATH_NOT_FOUND
+           err == ERROR_INVALID_FUNCTION; // Reported by one user on WinXP on network drive Y: Salamander hit this when accessing a path that no longer existed (so the path was not shortened, which caused serious trouble; Shift+F7 on Y:\ fixed it)
 }
 
 // ****************************************************************************
@@ -1445,7 +1447,7 @@ BOOL CutDirectory(char* path, char** cutDir)
         if (cutDir != NULL)
         {
             if (*(path + l - 1) == '\\')
-                *(path + --l) = 0; // zruseni '\\' na konci
+                *(path + --l) = 0; // Remove trailing '\\'
             memmove(lastBackslash + 2, lastBackslash + 1, l - (lastBackslash - path));
             *cutDir = lastBackslash + 2; // "somedir" or "seconddir"
         }
@@ -1454,13 +1456,13 @@ BOOL CutDirectory(char* path, char** cutDir)
     else // "c:\firstdir\seconddir" or "c:\firstdir\seconddir\"
     {    // UNC: "\\server\share\path"
         if (path[0] == '\\' && path[1] == '\\' && nextBackslash <= path + 2)
-        { // "\\server\share" - neda se zkratit
+        { // "\\server\share" - cannot be shortened further
             if (cutDir != NULL)
                 *cutDir = path + l;
             return FALSE;
         }
         *lastBackslash = 0;
-        if (cutDir != NULL) // odriznuti '\' na konci
+        if (cutDir != NULL) // remove trailing '\\'
         {
             if (*(path + l - 1) == '\\')
                 *(path + l - 1) = 0;
@@ -1473,7 +1475,7 @@ BOOL CutDirectory(char* path, char** cutDir)
 // ****************************************************************************
 
 int GetRootPath(char* root, const char* path)
-{                                           // POZOR: netypicke pouziti z GetShellFolder(): pro "\\\\" vraci "\\\\\\", pro "\\\\server" vraci "\\\\server\\"
+{                                           // WARNING: special-case behavior for GetShellFolder(): for "\\\\" it returns "\\\\\\", and for "\\\\server" it returns "\\\\server\\"
     if (path[0] == '\\' && path[1] == '\\') // UNC
     {
         const char* s = path + 2;
@@ -1485,7 +1487,7 @@ int GetRootPath(char* root, const char* path)
             s++;
         int len = (int)(s - path);
         if (len > MAX_PATH - 2)
-            len = MAX_PATH - 2; // aby se to veslo i s '\\' do MAX_PATH bufferu (ocekavana velikost), orez neva, 100% je to beztak chyba
+            len = MAX_PATH - 2; // so it fits into the MAX_PATH buffer even with '\\' (expected size); truncation is fine, this is almost certainly an error anyway
         memcpy(root, path, len);
         root[len] = '\\';
         root[len + 1] = 0;
@@ -1503,8 +1505,8 @@ int GetRootPath(char* root, const char* path)
 
 // ****************************************************************************
 
-// projede vsechny barvy z konfigurace a pokud maji nastavenu default hodnotu,
-// nastavi jim prislusne barevne hodnoty
+// Walks through all configured colors and assigns appropriate values
+// to any entries still set to their default value.
 
 COLORREF GetHilightColor(COLORREF clr1, COLORREF clr2)
 {
@@ -1559,15 +1561,15 @@ COLORREF GetHilightColor(COLORREF clr1, COLORREF clr2)
     return res;
 }
 
-COLORREF GetFullRowHighlight(COLORREF bkHighlightColor) // vraci "heuristicky" highlight pro full row mode
+COLORREF GetFullRowHighlight(COLORREF bkHighlightColor) // Returns a heuristic highlight color for full-row mode.
 {
-    // trochu heuristiky: zsvetle pozadi budeme "trochu" ztmavovat a tmave pozadi "trochu" zesvetlovat
+    // A bit of heuristic tweaking: slightly darken light backgrounds and slightly brighten dark ones
     WORD h, l, s;
     ColorRGBToHLS(bkHighlightColor, &h, &l, &s);
 
-    if (l < 121) // [TMAVA]  0-120 -> zesvetlime Luminance progresivne 0..120 -> +40..+20
+    if (l < 121) // [DARK] 0-120 -> progressively brighten luminance: 0..120 -> +40..+20
         l += 20 + 20 * (120 - l) / 120;
-    else // [SVETLA] 121-240 -> ztmavime Luminance o konstatnich 20
+    else // [LIGHT] 121-240 -> reduce luminance by a constant 20
         l -= 20;
 
     return ColorHLSToRGB(h, l, s);
@@ -1579,7 +1581,7 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
     {
         int bitsPerPixel = GetCurrentBPP();
 
-        // barvy pera pro ramecek kolem polozky prebereme ze systemove barvy textu okna
+        // Take the pen colors for the frame around the item from the system window text color.
         if (GetFValue(colors[FOCUS_ACTIVE_NORMAL]) & SCF_DEFAULT)
             SetRGBPart(&colors[FOCUS_ACTIVE_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
         if (GetFValue(colors[FOCUS_ACTIVE_SELECTED]) & SCF_DEFAULT)
@@ -1589,23 +1591,23 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
         if (GetFValue(colors[FOCUS_BK_INACTIVE_SELECTED]) & SCF_DEFAULT)
             SetRGBPart(&colors[FOCUS_BK_INACTIVE_SELECTED], GetSysColor(COLOR_WINDOW));
 
-        // texty polozek v panelu prebereme ze systemove barvy textu okna
+        // Use the system window text color for panel item text
         if (GetFValue(colors[ITEM_FG_NORMAL]) & SCF_DEFAULT)
             SetRGBPart(&colors[ITEM_FG_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
         if (GetFValue(colors[ITEM_FG_FOCUSED]) & SCF_DEFAULT)
             SetRGBPart(&colors[ITEM_FG_FOCUSED], GetSysColor(COLOR_WINDOWTEXT));
-        if (GetFValue(colors[ITEM_FG_HIGHLIGHT]) & SCF_DEFAULT) // FULL ROW HIGHLIGHT vychazi z _NORMAL
+        if (GetFValue(colors[ITEM_FG_HIGHLIGHT]) & SCF_DEFAULT) // FULL ROW HIGHLIGHT is derived from _NORMAL
             SetRGBPart(&colors[ITEM_FG_HIGHLIGHT], GetCOLORREF(colors[ITEM_FG_NORMAL]));
 
-        // pozadi polozek v panelu prebereme ze systemove barvy pozadi okna
+        // use the system window background color for panel item backgrounds
         if (GetFValue(colors[ITEM_BK_NORMAL]) & SCF_DEFAULT)
             SetRGBPart(&colors[ITEM_BK_NORMAL], GetSysColor(COLOR_WINDOW));
         if (GetFValue(colors[ITEM_BK_SELECTED]) & SCF_DEFAULT)
             SetRGBPart(&colors[ITEM_BK_SELECTED], GetSysColor(COLOR_WINDOW));
-        if (GetFValue(colors[ITEM_BK_HIGHLIGHT]) & SCF_DEFAULT) // HIGHLIGHT kopirujeme z NORMAL (aby fungovaly i custom/norton mody)
+        if (GetFValue(colors[ITEM_BK_HIGHLIGHT]) & SCF_DEFAULT) // Derive HIGHLIGHT from NORMAL (so custom/Norton modes also work)
             SetRGBPart(&colors[ITEM_BK_HIGHLIGHT], GetFullRowHighlight(GetCOLORREF(colors[ITEM_BK_NORMAL])));
 
-        // barvy progress bary
+        // progress bar colors
         if (GetFValue(colors[PROGRESS_FG_NORMAL]) & SCF_DEFAULT)
             SetRGBPart(&colors[PROGRESS_FG_NORMAL], GetSysColor(COLOR_WINDOWTEXT));
         if (GetFValue(colors[PROGRESS_FG_SELECTED]) & SCF_DEFAULT)
@@ -1615,35 +1617,35 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
         if (GetFValue(colors[PROGRESS_BK_SELECTED]) & SCF_DEFAULT)
             SetRGBPart(&colors[PROGRESS_BK_SELECTED], GetSysColor(COLOR_HIGHLIGHT));
 
-        // barva selected odstinu ikonky
+        // selected icon tint color
         if (GetFValue(colors[ICON_BLEND_SELECTED]) & SCF_DEFAULT)
         {
-            // normalne kopirujeme do selected barvu z focused+selected
+            // By default, copy the selected color from the focused+selected state
             SetRGBPart(&colors[ICON_BLEND_SELECTED], GetCOLORREF(colors[ICON_BLEND_FOCSEL]));
-            // pokud jde o cervenou (salamandrovskej profil a muzeme si to diky barevne hloubce
-            // dovolit) pouzijeme pro selected svetlejsi odstin
+            // If the color is red (the Salamander profile, and the color depth allows it),
+            // use a lighter shade for the selected state.
             if (bitsPerPixel > 8 && GetCOLORREF(colors[ICON_BLEND_FOCSEL]) == RGB(255, 0, 0))
                 SetRGBPart(&colors[ICON_BLEND_SELECTED], RGB(255, 128, 128));
         }
 
 #define COLOR_HOTLIGHT 26 // winuser.h
 
-        // titulky panelu (aktivni/neaktivni)
+        // panel captions (active/inactive)
 
-        // aktivni titulek panelu: POZADI
+        // active panel caption: BACKGROUND
         if (GetFValue(colors[ACTIVE_CAPTION_BK]) & SCF_DEFAULT)
             SetRGBPart(&colors[ACTIVE_CAPTION_BK], GetSysColor(COLOR_ACTIVECAPTION));
-        // aktivni titulek panelu: TEXT
+        // active panel caption: TEXT
         if (GetFValue(colors[ACTIVE_CAPTION_FG]) & SCF_DEFAULT)
             SetRGBPart(&colors[ACTIVE_CAPTION_FG], GetSysColor(COLOR_CAPTIONTEXT));
-        // neaktivni titulek panelu: POZADI
+        // inactive panel caption background
         if (GetFValue(colors[INACTIVE_CAPTION_BK]) & SCF_DEFAULT)
             SetRGBPart(&colors[INACTIVE_CAPTION_BK], GetSysColor(COLOR_INACTIVECAPTION));
-        // neaktivni titulek panelu: TEXT
+        // inactive panel caption: TEXT
         if (GetFValue(colors[INACTIVE_CAPTION_FG]) & SCF_DEFAULT)
         {
-            // preferujeme stejnou barvu textu jako pro aktivni titulek, ale nekdy je tato barva priliz
-            // blizka barve pozadi, potom zkusime barvu pro textu pro neaktivni titulek
+            // We prefer the same text color as for the active caption, but sometimes that color is too
+            // close to the background color, so we try the inactive caption text color instead
             COLORREF clrBk = GetCOLORREF(colors[INACTIVE_CAPTION_BK]);
             COLORREF clrFgAc = GetSysColor(COLOR_CAPTIONTEXT);
             COLORREF clrFgIn = GetSysColor(COLOR_INACTIVECAPTIONTEXT);
@@ -1653,12 +1655,12 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
             SetRGBPart(&colors[INACTIVE_CAPTION_FG], (abs(grayFgAc - grayBk) >= abs(grayFgIn - grayBk)) ? clrFgAc : clrFgIn);
         }
 
-        // barvy hot polozek
+        // hot item colors
         COLORREF hotColor = GetSysColor(COLOR_HOTLIGHT);
         if (GetFValue(colors[HOT_PANEL]) & SCF_DEFAULT)
             SetRGBPart(&colors[HOT_PANEL], hotColor);
 
-        // hilight pro active panel caption
+        // highlight for the active panel caption
         if (GetFValue(colors[HOT_ACTIVE]) & SCF_DEFAULT)
         {
             COLORREF clr = GetCOLORREF(colors[ACTIVE_CAPTION_FG]);
@@ -1666,7 +1668,7 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
                 clr = GetHilightColor(clr, GetCOLORREF(colors[ACTIVE_CAPTION_BK]));
             SetRGBPart(&colors[HOT_ACTIVE], clr);
         }
-        // hilight pro inactive panel caption
+        // highlight color for inactive panel caption
         if (GetFValue(colors[HOT_INACTIVE]) & SCF_DEFAULT)
         {
             COLORREF clr = GetCOLORREF(colors[INACTIVE_CAPTION_FG]);
@@ -1678,7 +1680,7 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
 
     if (processMasks)
     {
-        // barvy zavisle na jmenu+atributech souboru
+        // colors based on the file name and attributes
         int i;
         for (i = 0; i < highlightMasks->Count; i++)
         {
@@ -1701,7 +1703,7 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
                 SetRGBPart(&item->FocSelBk, GetCOLORREF(colors[ITEM_BK_FOCSEL]));
             if (GetFValue(item->HighlightFg) & SCF_DEFAULT)
                 SetRGBPart(&item->HighlightFg, GetCOLORREF(item->NormalFg));
-            if (GetFValue(item->HighlightBk) & SCF_DEFAULT) // FULL ROW HIGHLIGHT vychazi z _NORMAL
+            if (GetFValue(item->HighlightBk) & SCF_DEFAULT) // FULL ROW HIGHLIGHT is derived from _NORMAL
                 SetRGBPart(&item->HighlightBk, GetFullRowHighlight(GetCOLORREF(item->NormalBk)));
         }
     }
@@ -1709,20 +1711,20 @@ void UpdateDefaultColors(SALCOLOR* colors, CHighlightMasks* highlightMasks, BOOL
 
 //****************************************************************************
 //
-// Na zaklade barevne hloubky displeje urci, jestli pouzivat 256 barevne
-// nebo 16 barevne bitmapy.
+// Determine whether to use 256-color or 16-color bitmaps based on the
+// display color depth.
 //
 
 BOOL Use256ColorsBitmap()
 {
     int bitsPerPixel = GetCurrentBPP();
-    return (bitsPerPixel > 8); // vice nez 256 barev
+    return (bitsPerPixel > 8); // more than 256 colors
 }
 
 DWORD GetImageListColorFlags()
 {
-    // pokud ma image list 16bitu barevnou hloubku, zlobi alfa kanal novych ikonek pod WinXP 32-bit barevny display (32-bitova hloubka slape)
-    // pokud ma image list 32bitu barevnou hloubku, zlobi blend pri kresleni selectene polozky pod Win2K 32-bit barevny display (16-bitova hloubka slape)
+    // If the image list uses 16-bit color depth, the alpha channel of new icons misbehaves on a 32-bit color display under WinXP (32-bit depth works correctly).
+    // If the image list uses 32-bit color depth, blending when drawing a selected item misbehaves on a 32-bit color display under Win2K (16-bit depth works correctly).
     return ILC_COLOR32;
 }
 
@@ -1759,9 +1761,9 @@ int LoadColorTable(int id, RGBQUAD* rgb, int rgbCount)
 
 BOOL InitializeConstGraphics()
 {
-    // zajistime si hladky graficky vystup
-    // 20 volani GDI API by melo bohate stacit
-    // je to implicitni hodnota z NT 4.0 WS
+    // Ensure smooth graphics output.
+    // Batching up to 20 GDI API calls should be more than enough.
+    // This is the default value in Windows NT 4.0 Workstation.
     if (GdiGetBatchLimit() < 20)
     {
         TRACE_I("Increasing GdiBatchLimit");
@@ -1777,7 +1779,7 @@ BOOL InitializeConstGraphics()
     if (SystemParametersInfo(SPI_GETDRAGFULLWINDOWS, 0, &DragFullWindows, FALSE) == 0)
         DragFullWindows = TRUE;
 
-    // inicializace LogFont struktury
+    // Initialize the LOGFONT structure
     NONCLIENTMETRICS ncm;
     ncm.cbSize = sizeof(ncm);
     SystemParametersInfo(SPI_GETNONCLIENTMETRICS, ncm.cbSize, &ncm, 0);
@@ -1799,7 +1801,7 @@ BOOL InitializeConstGraphics()
   strcpy(LogFont.lfFaceName, "MS Shell Dlg 2");
   */
 
-    // tyto brushe jsou alokovane systemem a automaticky se meni pri zmene barev
+    // These brushes are allocated by the system and update automatically when the colors change.
     HDialogBrush = GetSysColorBrush(COLOR_BTNFACE);
     HButtonTextBrush = GetSysColorBrush(COLOR_BTNTEXT);
     HMenuSelectedBkBrush = GetSysColorBrush(COLOR_HIGHLIGHT);
@@ -1813,18 +1815,18 @@ BOOL InitializeConstGraphics()
         TRACE_E("Unable to create brush.");
         return FALSE;
     }
-    ItemBitmap.CreateBmp(NULL, 1, 1); // zajisteni existence bitmapy
+    ItemBitmap.CreateBmp(NULL, 1, 1); // ensure the bitmap exists
 
-    // bitmapu nacitame pouze jednou (neoprasujeme ji pri zmene rozliseni)
-    // a pokud by user prepnul barvy z 256 vejs, pri LoadBitmap (tedy bitmape
-    // kompatibilni s display DC) by bitmapa zustala v degradovanych barvach;
-    // proto ji nacteme jako DIB
+    // Load the bitmap only once; it is not reloaded when the resolution changes.
+    // If the user switched from 256 colors to a higher color depth, LoadBitmap
+    // would create a bitmap compatible with the display DC, and the bitmap would
+    // remain in degraded colors. Therefore, load it as a DIB.
     // HWorkerBitmap = HANDLES(LoadBitmap(HInstance, MAKEINTRESOURCE(IDB_WORKER)));
     //HWorkerBitmap = (HBITMAP)HANDLES(LoadImage(HInstance, MAKEINTRESOURCE(IDB_WORKER), IMAGE_BITMAP, 0, 0, LR_CREATEDIBSECTION));
     //if (HWorkerBitmap == NULL)
     //  return FALSE;
 
-    // pri zmene fontu se volaji explicitne CreatePanelFont a CreateEnvFont, prvni inicializaci provedeme zde
+    // When the font changes, CreatePanelFont and CreateEnvFonts are called explicitly; do the initial setup here.
     CreatePanelFont();
     CreateEnvFonts();
 
@@ -1907,8 +1909,8 @@ BOOL AuxAllocateImageLists()
     return TRUE;
 }
 
-// pomoci TweakUI si mohou uzivatele menit ikonku shortcuty (default, custom, zadna)
-// pokusime se ji ctit
+// Using TweakUI, users can change the shortcut icon (default, custom, or none).
+// We'll try to honor that setting.
 BOOL GetShortcutOverlay()
 {
     int i;
@@ -1921,57 +1923,58 @@ BOOL GetShortcutOverlay()
         }
     }
 
-    /*  
-  //#include <CommonControls.h>
-
-  // cteni ikon overlayu ze systemoveho image-listu, zbytecne pomale, nacteme je primo z imageres.dll
-  // tenhle kod tu nechavam jen pro pripad, ze bysme zase potrebovali zjistit kde ty ikony jsou
-  typedef DECLSPEC_IMPORT HRESULT (WINAPI *F__SHGetImageList)(int iImageList, REFIID riid, void **ppvObj);
-
-  F__SHGetImageList MySHGetImageList = (F__SHGetImageList)GetProcAddress(Shell32DLL, "SHGetImageList"); // Min: XP
-  if (MySHGetImageList != NULL)
-  {
-    int shareIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SHARE);
-    int linkIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_LINK);
-    int offlineIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SLOWFILE);
-    shareIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SHARE);
-
-    IImageList *imageList;
-    if (MySHGetImageList(1 /* SHIL_SMALL * /, IID_IImageList, (void **)&imageList) == S_OK &&
-        imageList != NULL)
-    {
-      int i;
-      imageList->GetOverlayImage(linkIndex, &i);
-      HICON icon;
-      if (imageList->GetIcon(i, 0, &icon) != S_OK)
-        icon = NULL;
-      HShortcutOverlays[ICONSIZE_16] = icon;
-      imageList->Release();
-    }
-    if (MySHGetImageList(0 /* SHIL_LARGE * /, IID_IImageList, (void **)&imageList) == S_OK &&
-        imageList != NULL)
-    {
-      int i;
-      imageList->GetOverlayImage(linkIndex, &i);
-      HICON icon;
-      if (imageList->GetIcon(i, 0, &icon) != S_OK)
-        icon = NULL;
-      HShortcutOverlays[ICONSIZE_32] = icon;
-      imageList->Release();
-    }
-    if (MySHGetImageList(2 /* SHIL_EXTRALARGE * /, IID_IImageList, (void **)&imageList) == S_OK &&
-        imageList != NULL)
-    {
-      int i;
-      imageList->GetOverlayImage(linkIndex, &i);
-      HICON icon;
-      if (imageList->GetIcon(i, 0, &icon) != S_OK)
-        icon = NULL;
-      HShortcutOverlays[ICONSIZE_48] = icon;
-      imageList->Release();
-    }
-  }
-*/
+    /*
+ * //#include <CommonControls.h>
+ *
+ * // Loading overlay icons from the system image list is unnecessarily slow, so we load them directly from imageres.dll instead.
+ * // This code is kept here in case we need to determine where those icons are again.
+ * typedef DECLSPEC_IMPORT HRESULT (WINAPI *F__SHGetImageList)(int iImageList, REFIID riid, void **ppvObj);
+ *
+ * F__SHGetImageList MySHGetImageList = (F__SHGetImageList)GetProcAddress(Shell32DLL, "SHGetImageList"); // Min: XP
+ * if (MySHGetImageList != NULL)
+ * {
+ * int shareIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SHARE);
+ * int linkIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_LINK);
+ * int offlineIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SLOWFILE);
+ * shareIndex = SHGetIconOverlayIndex(NULL, IDO_SHGIOI_SHARE);
+ *
+ * IImageList *imageList;
+ * if (MySHGetImageList(1 /* SHIL_SMALL * /, IID_IImageList, (void **)&imageList) == S_OK &&
+ * imageList != NULL)
+ * {
+ * int i;
+ * imageList->GetOverlayImage(linkIndex, &i);
+ * HICON icon;
+ * if (imageList->GetIcon(i, 0, &icon) != S_OK)
+ * icon = NULL;
+ * HShortcutOverlays[ICONSIZE_16] = icon;
+ * imageList->Release();
+ * }
+ * if (MySHGetImageList(0 /* SHIL_LARGE * /, IID_IImageList, (void **)&imageList) == S_OK &&
+ * imageList != NULL)
+ * {
+ * int i;
+ * imageList->GetOverlayImage(linkIndex, &i);
+ * HICON icon;
+ * if (imageList->GetIcon(i, 0, &icon) != S_OK)
+ * icon = NULL;
+ * HShortcutOverlays[ICONSIZE_32] = icon;
+ * imageList->Release();
+ * }
+ * if (MySHGetImageList(2 /* SHIL_EXTRALARGE * /, IID_IImageList, (void **)&imageList) == S_OK &&
+ * imageList != NULL)
+ * {
+ * int i;
+ * imageList->GetOverlayImage(linkIndex, &i);
+ * HICON icon;
+ * if (imageList->GetIcon(i, 0, &icon) != S_OK)
+ * icon = NULL;
+ * HShortcutOverlays[ICONSIZE_48] = icon;
+ * imageList->Release();
+ * }
+ * }
+ * /
+ */
 
     HKEY hKey;
     if (NOHANDLES(RegOpenKeyEx(HKEY_LOCAL_MACHINE,
@@ -1984,7 +1987,7 @@ BOOL GetShortcutOverlay()
         SalRegQueryValueEx(hKey, "29", NULL, NULL, (LPBYTE)buff, &buffLen);
         if (buff[0] != 0)
         {
-            char* num = strrchr(buff, ','); // cislo ikony je za posledni carkou
+            char* num = strrchr(buff, ','); // The icon number comes after the last comma.
             if (num != NULL)
             {
                 int index = atoi(num + 1);
@@ -2105,7 +2108,7 @@ int GetIconSizeForSystemDPI(CIconSizeEnum iconSize)
 
     int scale = GetScaleForSystemDPI();
 
-    int baseIconSize[ICONSIZE_COUNT] = {16, 32, 48}; // musi odpovidat CIconSizeEnum
+    int baseIconSize[ICONSIZE_COUNT] = {16, 32, 48}; // must match CIconSizeEnum
 
     return (baseIconSize[iconSize] * scale) / 100;
 }
@@ -2128,14 +2131,14 @@ void GetSystemDPI(HDC hDC)
 
 BOOL InitializeGraphics(BOOL colorsOnly)
 {
-    // 48x48 az od XP
-    // ve skutecnosti jsou velke ikonky podporeny uz davno, lze je nahodit
-    // Desktop/Properties/???/Large Icons; pozor, nebude pak existovat system image list
-    // pro ikonky 32x32; navic bychom meli ze systemu vytahnout realne velikosti ikonek
-    // zatim na to kasleme a 48x48 povolime az od XP, kde jsou bezne dostupne
+    // 48x48 only on XP and later
+    // Large icons have actually been supported for a long time; they can be enabled via
+    // Desktop/Properties/???/Large Icons. Note that there will then be no system image list
+    // for 32x32 icons; also, we should get the real icon sizes from the system.
+    // For now we ignore that and enable 48x48 only on XP, where they are commonly available.
 
     //
-    // Vytahneme z Registry pozadovanou barevnou hloubku ikonek
+    // Retrieve the requested icon color depth from the Registry
     //
     int iconColorsCount = 0;
     HDC hDesktopDC = GetDC(NULL);
@@ -2150,7 +2153,7 @@ BOOL InitializeGraphics(BOOL colorsOnly)
     HKEY hKey;
     if (OpenKeyAux(NULL, HKEY_CURRENT_USER, "Control Panel\\Desktop\\WindowMetrics", hKey))
     {
-        // dalsi zajimave hodnoty: "Shell Icon Size", "Shell Small Icon Size"
+        // other interesting values: "Shell Icon Size", "Shell Small Icon Size"
         char buff[100];
         if (GetValueAux(NULL, hKey, "Shell Icon Bpp", REG_SZ, buff, 100))
         {
@@ -2160,8 +2163,8 @@ BOOL InitializeGraphics(BOOL colorsOnly)
         {
             if (WindowsVistaAndLater)
             {
-                // ve viste tento klic proste neni a zatim netusim, cim je nahrazen,
-                // takze se budeme tvarit, ze ikonky jedou v plnych barvach (jinak jsme zobrazovali 16 barevne hnusy)
+                // In Vista this key simply does not exist, and I still do not know what replaced it,
+                // so we will assume the icons use full color (otherwise we were showing ugly 16-color icons)
                 iconColorsCount = 32;
             }
         }
@@ -2193,7 +2196,7 @@ BOOL InitializeGraphics(BOOL colorsOnly)
         }
 
         Shell32DLL = HANDLES(LoadLibraryEx("shell32.dll", NULL, LOAD_LIBRARY_AS_DATAFILE));
-        if (Shell32DLL == NULL) // to se snad vubec nemuze stat (zaklad win 4.0)
+        if (Shell32DLL == NULL) // This should never happen; shell32.dll is part of the Windows 4.0 base.
         {
             TRACE_E("Unable to load library shell32.dll.");
             return FALSE;
@@ -2233,8 +2236,8 @@ BOOL InitializeGraphics(BOOL colorsOnly)
             return FALSE;
         }
 
-        // prekladac hlasil chybu: error C2712: Cannot use __try in functions that require object unwinding
-        // obchazim to vlozenim alokace do funkce
+        // The compiler reported error C2712: Cannot use __try in functions that require object unwinding
+        // Work around it by moving the allocation into a function
         //    SymbolsIconList = new CIconList();
         //    LargeSymbolsIconList = new CIconList();
         if (!AuxAllocateImageLists())
@@ -2268,8 +2271,8 @@ BOOL InitializeGraphics(BOOL colorsOnly)
             TRACE_E("Unable to create image list.");
             return FALSE;
         }
-        ImageList_SetImageCount(HFindSymbolsImageList, 2); // inicializace
-                                                           //    ImageList_SetBkColor(HFindSymbolsImageList, GetSysColor(COLOR_WINDOW)); // aby pod XP chodily pruhledne ikonky
+        ImageList_SetImageCount(HFindSymbolsImageList, 2); // initialization
+                                                           //    ImageList_SetBkColor(HFindSymbolsImageList, GetSysColor(COLOR_WINDOW)); // so transparent icons work on XP
 
         int iconSize = IconSizes[ICONSIZE_16];
         HBITMAP hTmpMaskBitmap;
@@ -2318,7 +2321,7 @@ BOOL InitializeGraphics(BOOL colorsOnly)
             return FALSE;
         }
 
-        // vytahnu z shell 32 ikony:
+        // Load icons from shell32:
         int indexes[] = {symbolsExecutable, symbolsDirectory, symbolsNonAssociated, symbolsAssociated, -1};
         int resID[] = {3, 4, 1, 2, -1};
         int vistaResID[] = {15, 4, 2, 90, -1};
@@ -2351,7 +2354,7 @@ BOOL InitializeGraphics(BOOL colorsOnly)
         int sizeIndex;
         for (sizeIndex = ICONSIZE_16; sizeIndex < ICONSIZE_COUNT; sizeIndex++)
         {
-            // ikonka adresare
+            // folder icon
             hIcon = NULL;
             __try
             {
@@ -2363,20 +2366,20 @@ BOOL InitializeGraphics(BOOL colorsOnly)
                 FGIExceptionHasOccured++;
                 hIcon = NULL;
             }
-            if (hIcon != NULL) // pokud ikonku neziskame, je tam porad jeste 4-rka z shell32.dll
+            if (hIcon != NULL) // if we do not obtain the icon, the #4 one from shell32.dll remains
             {
                 SimpleIconLists[sizeIndex]->ReplaceIcon(symbolsDirectory, hIcon);
                 NOHANDLES(DestroyIcon(hIcon));
             }
 
-            // ikonka ".."
+            // ".." icon
             hIcon = (HICON)HANDLES(LoadImage(HInstance, MAKEINTRESOURCE(IDI_UPPERDIR),
                                              IMAGE_ICON, IconSizes[sizeIndex], IconSizes[sizeIndex],
                                              IconLRFlags));
             SimpleIconLists[sizeIndex]->ReplaceIcon(symbolsUpDir, hIcon);
             HANDLES(DestroyIcon(hIcon));
 
-            // ikonka archiv
+            // archive icon
             hIcon = LoadArchiveIcon(IconSizes[sizeIndex], IconSizes[sizeIndex], IconLRFlags);
             SimpleIconLists[sizeIndex]->ReplaceIcon(symbolsArchive, hIcon);
             HANDLES(DestroyIcon(hIcon));
@@ -2483,17 +2486,17 @@ BOOL InitializeGraphics(BOOL colorsOnly)
         return FALSE;
     }
 
-    clrMap[0].from = RGB(128, 128, 128); // seda -> COLOR_BTNSHADOW
+    clrMap[0].from = RGB(128, 128, 128); // gray -> COLOR_BTNSHADOW
     clrMap[0].to = GetSysColor(COLOR_BTNSHADOW);
-    clrMap[1].from = RGB(0, 0, 0); // cerna -> COLOR_BTNTEXT
+    clrMap[1].from = RGB(0, 0, 0); // black -> COLOR_BTNTEXT
     clrMap[1].to = GetSysColor(COLOR_BTNTEXT);
-    clrMap[2].from = RGB(255, 255, 255); // bila -> pruhledna
+    clrMap[2].from = RGB(255, 255, 255); // white -> transparent
     clrMap[2].to = RGB(255, 0, 255);
     HBITMAP hBottomTB = HANDLES(CreateMappedBitmap(HInstance, IDB_BOTTOMTOOLBAR, 0, clrMap, 3));
     BOOL remapWhite = FALSE;
     if (GetCurrentBPP() > 8)
     {
-        clrMap[2].from = RGB(255, 255, 255); // bila -> svetle sedivou (at to tak nerve)
+        clrMap[2].from = RGB(255, 255, 255); // white -> light gray (so it's not so harsh)
         clrMap[2].to = RGB(235, 235, 235);
         remapWhite = TRUE;
     }
@@ -2799,12 +2802,12 @@ BOOL PointToLocalDecimalSeparator(char* buffer, int bufferSize)
 
 // ****************************************************************************
 //
-// GetCmdLine - ziskani parametru z prikazove radky
+// GetCmdLine - get arguments from the command line
 //
-// buf + size - buffer pro parametry
-// argv - pole ukazatelu, ktere se naplni parametry
-// argCount - na vstupu je to pocet prvku v argv, na vystupu obsahuje pocet parametru
-// cmdLine - parametry prikazove radky (bez jmena .exe souboru - z WinMain)
+// buf + size - buffer for the arguments
+// argv - array of pointers to be filled with the arguments
+// argCount - on input, the number of elements in argv; on output, contains the number of arguments
+// cmdLine - command-line arguments (without the .exe file name - from WinMain)
 
 BOOL GetCmdLine(char* buf, int size, char* argv[], int& argCount, char* cmdLine)
 {
@@ -2817,7 +2820,7 @@ BOOL GetCmdLine(char* buf, int size, char* argv[], int& argCount, char* cmdLine)
     char term;
     while (*s != 0)
     {
-        if (*s == '"') // pocatecni '"'
+        if (*s == '"') // leading '"'
         {
             if (*++s == 0)
                 break;
@@ -2829,13 +2832,13 @@ BOOL GetCmdLine(char* buf, int size, char* argv[], int& argCount, char* cmdLine)
         if (argCount < space && c < end)
             argv[argCount++] = c;
         else
-            return c < end; // chyba jen pokud je maly buffer
+            return c < end; // Error only if the buffer is too small
 
         while (1)
         {
             if (*s == term || *s == 0)
             {
-                if (*s == 0 || term != '"' || *++s != '"') // neni-li to nahrada "" -> "
+                if (*s == 0 || term != '"' || *++s != '"') // unless this is the "" -> " substitution
                 {
                     if (*s != 0)
                         s++;
@@ -2878,18 +2881,18 @@ typedef HRESULT(CALLBACK* DLLGETVERSIONPROC)(DLLVERSIONINFO*);
 HRESULT GetComCtlVersion(LPDWORD pdwMajor, LPDWORD pdwMinor)
 {
     HINSTANCE hComCtl;
-    //load the DLL
+    // Load the DLL
     hComCtl = HANDLES(LoadLibrary(TEXT("comctl32.dll")));
     if (hComCtl)
     {
         HRESULT hr = S_OK;
         DLLGETVERSIONPROC pDllGetVersion;
         /*
-     You must get this function explicitly because earlier versions of the DLL
-     don't implement this function. That makes the lack of implementation of the
-     function a version marker in itself.
-    */
-        pDllGetVersion = (DLLGETVERSIONPROC)GetProcAddress(hComCtl, TEXT("DllGetVersion")); // nema header
+             This function must be obtained explicitly because earlier versions of the DLL
+             do not implement it. The absence of this function therefore serves as a
+             version marker.
+            */
+        pDllGetVersion = (DLLGETVERSIONPROC)GetProcAddress(hComCtl, TEXT("DllGetVersion")); // no header available
         if (pDllGetVersion)
         {
             DLLVERSIONINFO dvi;
@@ -2963,8 +2966,8 @@ BOOL PackErrorHandler(HWND parent, const WORD err, ...)
 void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
 {
     CALL_STACK_MESSAGE2("ColorsChanged(%d)", refresh);
-    // POZOR! fonts musi byt FALSE, aby nedoslo k zmene handlu fontu, o ktere
-    // se museji dozvedet toolbary, ktere jej pouzivaji
+    // WARNING! fonts must be FALSE to avoid changing the font handle,
+    // and the toolbars that use it would have to be notified of that change
     ReleaseGraphics(colorsOnly);
     InitializeGraphics(colorsOnly);
     ItemBitmap.ReCreateForScreenDC();
@@ -2982,10 +2985,10 @@ void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
         MainWindow->OnColorsChanged(reloadUMIcons);
     }
 
-    // dame vedet findum o zmene barev
+    // notify the Find dialogs about the color change
     FindDialogQueue.BroadcastMessage(WM_USER_COLORCHANGEFIND, 0, 0);
 
-    // rozesleme tuto novinku i mezi plug-iny
+    // Notify the plugins of this change as well.
     Plugins.Event(PLUGINEVENT_COLORSCHANGED, 0);
 
     if (MainWindow != NULL && MainWindow->HTopRebar != NULL)
@@ -2995,7 +2998,7 @@ void ColorsChanged(BOOL refresh, BOOL colorsOnly, BOOL reloadUMIcons)
     {
         InvalidateRect(MainWindow->HWindow, NULL, TRUE);
     }
-    // Internal Viewer a Find:  obnova vsech oken
+    // Internal Viewer and Find: refresh all windows
     BroadcastConfigChanged();
 }
 
@@ -3097,7 +3100,7 @@ CMessagesKeeper MessagesKeeper;
 
 typedef VOID(WINAPI* FDisableProcessWindowsGhosting)(VOID);
 
-void TurnOFFWindowGhosting() // kdyz se "ghosting" nevypne, schovavaji se safe-wait-okenka po peti sekundach "not responding" stavu aplikace (kdyz aplikace nezpracovava zpravy)
+void TurnOFFWindowGhosting() // If "ghosting" is not disabled, the safe-wait windows are hidden after the application has been in a "not responding" state for five seconds (when it is not processing messages)
 {
     if (User32DLL != NULL)
     {
@@ -3143,12 +3146,12 @@ void CleanUID(char* uid)
 
 //#ifdef MSVC_RUNTIME_CHECKS
 char RTCErrorDescription[RTC_ERROR_DESCRIPTION_SIZE] = {0};
-// custom reporting funkce opsana z MSDN - http://msdn.microsoft.com/en-us/library/cb00sk7k(v=VS.90).aspx
+// custom reporting function copied from MSDN - http://msdn.microsoft.com/en-us/library/cb00sk7k(v=VS.90).aspx
 #pragma runtime_checks("", off)
 int MyRTCErrorFunc(int errType, const wchar_t* file, int line,
                    const wchar_t* module, const wchar_t* format, ...)
 {
-    // Prevent re-entrance.
+    // Prevent reentrancy.
     static long running = 0;
     while (InterlockedExchange(&running, 1))
         Sleep(0);
@@ -3158,7 +3161,7 @@ int MyRTCErrorFunc(int errType, const wchar_t* file, int line,
     for (int i = 0; i < numErrors; i++)
         errors[i] = _RTC_SetErrorType((_RTC_ErrorNumber)i, _RTC_ERRTYPE_IGNORE);
 
-    // First, get the rtc error number from the var-arg list.
+    // First, retrieve the RTC error number from the variadic argument list.
     va_list vl;
     va_start(vl, format);
     _RTC_ErrorNumber rtc_errnum = va_arg(vl, _RTC_ErrorNumber);
@@ -3178,13 +3181,13 @@ int MyRTCErrorFunc(int errType, const wchar_t* file, int line,
     bufA[RTC_ERROR_DESCRIPTION_SIZE - 1] = 0;
     lstrcpyn(RTCErrorDescription, bufA, RTC_ERROR_DESCRIPTION_SIZE);
 
-    // radeji to tady zalomime s exception, bude snad jasnejsi callstack - pokud by nebyl, muzeme tady tu exception odstranit
-    // viz popis chovani _CrtDbgReportW - http://msdn.microsoft.com/en-us/library/8hyw4sy7(v=VS.90).aspx
-    RaiseException(OPENSAL_EXCEPTION_RTC, 0, 0, NULL); // nase vlastni "rtc" exception
+    // Prefer raising an exception here so the call stack is hopefully clearer; if it is not, we can remove this exception.
+    // See the description of _CrtDbgReportW behavior: http://msdn.microsoft.com/en-us/library/8hyw4sy7(v=VS.90).aspx
+    RaiseException(OPENSAL_EXCEPTION_RTC, 0, 0, NULL); // our custom "RTC" exception
 
-    // sem uz se nedostaneme, proces byl ukoncen; pokracuji jen z formalnich duvodu, kdybychom neco menili
+    // We should never get here because the process has been terminated; continuing only for form's sake in case this ever changes.
 
-    // Now, restore the RTC errortypes.
+    // Now, restore the RTC error types.
     for (int i = 0; i < numErrors; i++)
         _RTC_SetErrorType((_RTC_ErrorNumber)i, errors[i]);
     running = 0;
@@ -3199,7 +3202,7 @@ int MyRTCErrorFunc(int errType, const wchar_t* file, int line,
 
 #ifdef _DEBUG
 
-DWORD LastCrtCheckMemoryTime; // kdy jsme posledne kontrolovali pamet v IDLE
+DWORD LastCrtCheckMemoryTime; // Time of the last memory check in IDLE
 
 #endif //_DEBUG
 
@@ -3226,16 +3229,16 @@ BOOL FindPluginsWithoutImportedCfg(BOOL* doNotDeleteImportedCfg)
         sprintf(msg, LoadStr(IDS_NOTALLPLUGINSCFGIMPORTED), names, skippedNames);
         params.Text = msg;
         char aliasBtnNames[200];
-        /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   nechame pro tlacitka msgboxu resit kolize hotkeys tim, ze simulujeme, ze jde o menu
-MENU_TEMPLATE_ITEM MsgBoxButtons[] = 
-{
-  {MNTT_PB, 0
-  {MNTT_IT, IDS_STARTWITHOUTMISSINGPLUGINS
-  {MNTT_IT, IDS_SELLANGEXITBUTTON
-  {MNTT_PE, 0
-};
-*/
+        /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
+           for message-box buttons, let hotkey collisions be resolved by pretending they are a menu
+        MENU_TEMPLATE_ITEM MsgBoxButtons[] =
+        {
+          {MNTT_PB, 0
+          {MNTT_IT, IDS_STARTWITHOUTMISSINGPLUGINS
+          {MNTT_IT, IDS_SELLANGEXITBUTTON
+          {MNTT_PE, 0
+        };
+        */
         sprintf(aliasBtnNames, "%d\t%s\t%d\t%s",
                 DIALOG_OK, LoadStr(IDS_STARTWITHOUTMISSINGPLUGINS),
                 DIALOG_CANCEL, LoadStr(IDS_SELLANGEXITBUTTON));
@@ -3255,7 +3258,7 @@ void StartNotepad(const char* file)
     if (lstrlen(file) >= MAX_PATH)
         return;
 
-    GetSystemDirectory(buf, MAX_PATH); // dame mu systemovy adresar, at neblokuje mazani soucasneho pracovniho adresare
+    GetSystemDirectory(buf, MAX_PATH); // Use the system directory so it does not prevent deletion of the current working directory.
     wsprintf(buf2, "notepad.exe \"%s\"", file);
     si.cb = sizeof(STARTUPINFO);
     if (HANDLES(CreateProcess(NULL, buf2, NULL, NULL, TRUE, CREATE_DEFAULT_ERROR_MODE | NORMAL_PRIORITY_CLASS,
@@ -3268,20 +3271,20 @@ void StartNotepad(const char* file)
 
 BOOL RunningInCompatibilityMode()
 {
-    // Pokud bezime pod XP nebo nasledujicim OS, hrozi ze snazivy uzivatel zapnul
-    // Compatibility Mode. Pokud tomu tak je, zobrazime varovani.
-    // POZOR: Application Verifier nastavuje verzi Windows na novejsi nez skutecne je,
-    // dela to pri testovani aplikace pri ziskavani "Windows 7 Software Logo".
+    // If running on Windows XP or a later OS, there is a risk that an overhelpful user enabled
+    // Compatibility Mode. If so, display a warning.
+    // WARNING: Application Verifier reports the Windows version as newer than it really is.
+    // It does this while testing the application for the "Windows 7 Software Logo".
     WORD kernel32major, kernel32minor;
     if (GetModuleVersion(GetModuleHandle("kernel32.dll"), &kernel32major, &kernel32minor))
     {
         TRACE_I("kernel32.dll: " << kernel32major << ":" << kernel32minor);
-        // musime zavolat GetVersionEx, protoze vraci hodnoty podle nastaveneho Compatibility Mode
-        // (SalIsWindowsVersionOrGreater nastaveny Compatibility Mode ignoruje)
+        // GetVersionEx must be called because it returns values based on the active Compatibility Mode
+        // (SalIsWindowsVersionOrGreater ignores the active Compatibility Mode)
         OSVERSIONINFO os;
         os.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
 
-        // jen se vyhybame deprecated warningu, GetVersionEx snad bude vzdy a vsude
+        // just avoiding the deprecation warning; GetVersionEx will hopefully always be available everywhere
         typedef BOOL(WINAPI * FDynGetVersionExA)(LPOSVERSIONINFOA lpVersionInformation);
         FDynGetVersionExA DynGetVersionExA = (FDynGetVersionExA)GetProcAddress(GetModuleHandle("kernel32.dll"),
                                                                                "GetVersionExA");
@@ -3294,16 +3297,18 @@ BOOL RunningInCompatibilityMode()
         DynGetVersionExA(&os);
         TRACE_I("GetVersionEx(): " << os.dwMajorVersion << ":" << os.dwMinorVersion);
 
-        // aktualni verze Salamandera je manifestovana pro Windows 10
+        // the current version of Salamander is manifested for Windows 10
         const DWORD SAL_MANIFESTED_FOR_MAJOR = 10;
         const DWORD SAL_MANIFESTED_FOR_MINOR = 0;
 
-        // GetVersionEx nikdy nevrati vic nez os.dwMajorVersion == SAL_MANIFESTED_FOR_MAJOR
-        // a os.dwMinorVersion == SAL_MANIFESTED_FOR_MINOR, je-li tedy kernel32.dll vyssi
-        // verze, nejsme schopni 100% detekovat Compatibility Mode, je potreba mafinestovat
-        // Salamandera pro nove Windows a posunout konstanty SAL_MANIFESTED_FOR_MAJOR a
-        // SAL_MANIFESTED_FOR_MINOR, detekujeme aspon nastaveni Compatibility Mode na
-        // starsi Windows, nez pro ktera je Salamander manifestovan
+        // GetVersionEx never returns a version higher than
+        // os.dwMajorVersion == SAL_MANIFESTED_FOR_MAJOR and
+        // os.dwMinorVersion == SAL_MANIFESTED_FOR_MINOR. If kernel32.dll is newer,
+        // we cannot detect Compatibility Mode with 100% certainty; Salamander must be
+        // manifested for the newer Windows version and the constants
+        // SAL_MANIFESTED_FOR_MAJOR and SAL_MANIFESTED_FOR_MINOR must be updated.
+        // We can at least detect Compatibility Mode set to an older Windows version
+        // than the one Salamander is manifested for
         if (kernel32major > SAL_MANIFESTED_FOR_MAJOR ||
             kernel32major == SAL_MANIFESTED_FOR_MAJOR && kernel32minor > SAL_MANIFESTED_FOR_MINOR)
         {
@@ -3322,21 +3327,21 @@ void GetCommandLineParamExpandEnvVars(const char* argv, char* target, DWORD targ
     char curDir[MAX_PATH];
     if (hotpathForJumplist)
     {
-        BOOL ret = ExpandHotPath(NULL, argv, target, targetSize, FALSE); // pokud neni syntax cesty OK, vyskoci TRACE_E, coz nas netrapi
+        BOOL ret = ExpandHotPath(NULL, argv, target, targetSize, FALSE); // If the path syntax is invalid, TRACE_E will fire, which is fine here.
         if (!ret)
         {
             TRACE_E("ExpandHotPath failed.");
-            // pokud expanze selze, pouzijeme retezec bez expanze
+            // If expansion fails, use the original unexpanded string.
             lstrcpyn(target, argv, targetSize);
         }
     }
     else
     {
-        DWORD auxRes = ExpandEnvironmentStrings(argv, target, targetSize); // uzivatele si prali moznost predavat jako parametr env promenne
+        DWORD auxRes = ExpandEnvironmentStrings(argv, target, targetSize); // Users wanted to be able to pass environment variables as parameters.
         if (auxRes == 0 || auxRes > targetSize)
         {
             TRACE_E("ExpandEnvironmentStrings failed.");
-            // pokud expanze selze, pouzijeme retezec bez expanze
+            // If expansion fails, use the original string unchanged.
             lstrcpyn(target, argv, targetSize);
         }
     }
@@ -3346,15 +3351,15 @@ void GetCommandLineParamExpandEnvVars(const char* argv, char* target, DWORD targ
     }
 }
 
-// pokud jsou parametry OK, vraci TRUE, jinak vraci FALSE
+// Returns TRUE if the parameters are valid; otherwise returns FALSE
 BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams)
 {
-    // nechceme menit cesty, menit ikonu, menit prefix -- vse je potreba vynulovat
+    // We do not want to change the paths, icon, or prefix, so everything has to be zeroed out.
     ZeroMemory(cmdLineParams, sizeof(CCommandLineParams));
 
     char buf[4096];
     char* argv[20];
-    int p = 20; // pocet prvku pole argv
+    int p = 20; // number of elements in the argv array
 
     char curDir[MAX_PATH];
     GetModuleFileName(HInstance, ConfigurationName, MAX_PATH);
@@ -3363,7 +3368,7 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
     strcat(ConfigurationName, configReg);
     if (!FileExists(ConfigurationName) && GetOurPathInRoamingAPPDATA(curDir) &&
         SalPathAppend(curDir, configReg, MAX_PATH) && FileExists(curDir))
-    { // pokud neexistuje soubor config.reg u .exe, hledame ho jeste v APPDATA
+    { // If config.reg is not found next to the .exe, also look for it in APPDATA.
         lstrcpyn(ConfigurationName, curDir, MAX_PATH);
         ConfigurationNameIgnoreIfNotExists = FALSE;
     }
@@ -3403,7 +3408,7 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
                 }
             }
 
-            if (StrICmp(argv[i], "-aj") == 0) // active panel path (hot paths syntax for jumplist) - interni, nedokumentovane
+            if (StrICmp(argv[i], "-aj") == 0) // active panel path (Hot Paths syntax for Jump List) - internal, undocumented
             {
                 if (i + 1 < p)
                 {
@@ -3419,18 +3424,18 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
                 {
                     char* s = argv[i + 1];
                     if (*s == '\\' && *(s + 1) == '\\' || // UNC full path
-                        *s != 0 && *(s + 1) == ':')       // "c:\" full path
-                    {                                     // plne jmeno
+                        *s != 0 && *(s + 1) == ':')       // full path
+                    {                                     // full path
                         lstrcpyn(ConfigurationName, argv[i + 1], MAX_PATH);
                     }
-                    else // relativni jmeno
+                    else // relative path
                     {
                         GetModuleFileName(HInstance, ConfigurationName, MAX_PATH);
                         *(strrchr(ConfigurationName, '\\') + 1) = 0;
                         SalPathAppend(ConfigurationName, s, MAX_PATH);
                         if (!FileExists(ConfigurationName) && GetOurPathInRoamingAPPDATA(curDir) &&
                             SalPathAppend(curDir, s, MAX_PATH) && FileExists(curDir))
-                        { // pokud neexistuje relativne zadany soubor za -C u .exe, hledame ho jeste v APPDATA
+                        { // If the file specified after -C relative to the .exe does not exist, also look for it in APPDATA.
                             lstrcpyn(ConfigurationName, curDir, MAX_PATH);
                         }
                     }
@@ -3457,7 +3462,7 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
                 }
             }
 
-            if (StrICmp(argv[i], "-t") == 0) // title prefix
+            if (StrICmp(argv[i], "-t") == 0) // title bar prefix
             {
                 if (i + 1 < p)
                 {
@@ -3475,7 +3480,7 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
                 }
             }
 
-            if (StrICmp(argv[i], "-o") == 0) // tvarime se, jako by bylo nahozene OnlyOneIstance
+            if (StrICmp(argv[i], "-o") == 0) // behave as if OnlyOneInstance were enabled
             {
                 Configuration.ForceOnlyOneInstance = TRUE;
                 continue;
@@ -3496,13 +3501,13 @@ BOOL ParseCommandLineParameters(LPSTR cmdLine, CCommandLineParams* cmdLineParams
             }
 
             if (StrICmp(argv[i], "-run_notepad") == 0 && i + 1 < p)
-            { // Vista+: after installation: installer (SFX7ZIP) executes Salamander and asks for execution of notepad with readme file
+            { // Vista+: after installation, the installer (SFX7ZIP) runs Salamander and asks it to launch Notepad with the readme file
                 lstrcpyn(OpenReadmeInNotepad, argv[i + 1], MAX_PATH);
                 i++;
                 continue;
             }
 
-            return FALSE; // wrong parameters
+            return FALSE; // invalid parameters
         }
     }
     return TRUE;
@@ -3512,10 +3517,10 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
 {
     int myExitCode = 1;
 
-    //--- nechci zadne kriticke chyby jako "no disk in drive A:"
+    //--- I do not want any critical errors such as "no disk in drive A:"
     SetErrorMode(SetErrorMode(0) | SEM_FAILCRITICALERRORS);
 
-    // seed generatoru nahodnych cisel
+    // seed the random number generator
     srand((unsigned)time(NULL) ^ (unsigned)_getpid());
 
 #ifdef _DEBUG
@@ -3526,49 +3531,49 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     // #define _CRTDBG_CHECK_CRT_DF        0x10  /* Leak check/diff CRT blocks */
     // #define _CRTDBG_LEAK_CHECK_DF       0x20  /* Leak check at program exit */
 
-    // pri podezreni na prepis alokovane pameti lze odkomentovat nasledujici dva radky
-    // dojde ke zpomaleni Salamandera a pri kazdem free alloc se provede test konzistence heapu
+    // If you suspect overwriting allocated memory, uncomment the following two lines.
+    // Salamander will slow down and each free/alloc will run a heap consistency check.
     // int crtDbg = _CrtSetDbgFlag(_CRTDBG_REPORT_FLAG);   // Get the current bits
     // _CrtSetDbgFlag(crtDbg | _CRTDBG_CHECK_ALWAYS_DF);
     // _CrtSetDbgFlag(crtDbg | _CRTDBG_LEAK_CHECK_DF);
 
-    // dalsi zajimava funkce pro ladeni: pokud dojde k memory leaku, v zavorce je zobrazeno
-    // dekadicke cislo, ktere udava poradi alokovaneho bloku, napriklad _CRT_WARN: {104200};
-    // funkci _CrtSetBreakAlloc umoznuje breaknou na tomto bloku
+    // Another useful debugging function: if a memory leak occurs, the number in braces
+    // is the decimal order of the allocated block, for example _CRT_WARN: {104200};
+    // _CrtSetBreakAlloc lets you break on this block.
     // _CrtSetBreakAlloc(33521);
 
     LastCrtCheckMemoryTime = GetTickCount();
 
-    // na tomto pripade prepisu konce pameti zabere ochrana -- v IDLE se zobrazi messagebox
-    // a do TraceServeru se nalejou debug hlasky
+    // In this end-of-buffer overwrite case, the protection kicks in: in IDLE a message box is shown
+    // and debug messages are sent to TraceServer.
     //
 //  char *p1 = (char*)malloc( 4 );
 //  strcpy( p1 , "Oops" );
 #endif //_DEBUG
 
     /*
-   // test "Heap Block Corruptions: Full-page heap", viz http://support.microsoft.com/kb/286470
-   // alokuje vsechny bloky (musi mit aspon 16 bytu) tak, ze za nimi je nepristupna stranka, takze
-   // jakykoliv prepis konce bloku vede k exceptione
-   // instalovat Debugging Tools for Windows, v gflags.exe pro "salamand.exe" vybrat "Enable page heap",
-   // fungovalo mi to pod W2K i pod XP (pod Vistou by melo taky)
-   // NEBO: pouzit pripravene sal-pageheap-register.reg a sal-pageheap-unregister.reg (to pak neni
-   // potreba instalovat Debugging Tools for Windows)
-   //
-   // prosinec/2011: testoval jsem pod VS2008 + page heap + Win7x64 a nasledujici prepis nevyvolava exception
-   // nasel jsem popis alokace v tomto rezimu: http://msdn.microsoft.com/en-us/library/ms220938(v=VS.90).aspx
+       // test "Heap Block Corruptions: Full-page heap", see http://support.microsoft.com/kb/286470
+       // allocates all blocks (they must be at least 16 bytes) so that there is an inaccessible page after them, so
+       // any overwrite past the end of a block leads to an exception
+       // install Debugging Tools for Windows, in gflags.exe select "Enable page heap" for "salamand.exe",
+       // it worked for me on W2K and XP (it should work on Vista too)
+       // OR: use the prepared sal-pageheap-register.reg and sal-pageheap-unregister.reg files (then there is no
+       // need to install Debugging Tools for Windows)
+       //
+       // December 2011: I tested this under VS2008 + page heap + Win7x64 and the overwrite below does not raise an exception
+       // I found a description of allocation in this mode here: http://msdn.microsoft.com/en-us/library/ms220938(v=VS.90).aspx
 
-  char *test = (char *)malloc(16);
-//  char *test = (char *)HeapAlloc(GetProcessHeap(), 0, 16);
-  char bufff[100];
-  sprintf(bufff, "test=%p", test);
-  MessageBox(NULL, bufff, "a", MB_OK);
-  test[16] = 0;
-*/
+      char *test = (char *)malloc(16);
+    //  char *test = (char *)HeapAlloc(GetProcessHeap(), 0, 16);
+      char bufff[100];
+      sprintf(bufff, "test=%p", test);
+      MessageBox(NULL, bufff, "a", MB_OK);
+      test[16] = 0;
+    */
 
     char testCharValue = 129;
     int testChar = testCharValue;
-    if (testChar != 129) // pokud bude testChar zaporne, mame problem: LowerCase[testCharValue] saha mimo pole...
+    if (testChar != 129) // If testChar is negative, we have a problem: LowerCase[testCharValue] indexes outside the array bounds...
     {
         MessageBox(NULL, "Default type 'char' is not 'unsigned char', but 'signed char'. See '/J' compiler switch in MSVC.",
                    "Compilation Error", MB_OK | MB_ICONSTOP);
@@ -3578,9 +3583,9 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     HInstance = hInstance;
     CALL_STACK_MESSAGE4("WinMainBody(0x%p, , %s, %d)", hInstance, cmdLine, cmdShow);
 
-    // Tak za tohle ja nemuzu ... co delat, kdyz to dela konkurence, musime
-    // taky - inspirovano v Exploreru.
-    // A ja se divil, ze jim tak pekne chodi paint.
+    // I cannot help this one... if the competition does it, we have to do it too
+    // - inspired by Explorer.
+    // I used to wonder why their painting worked so nicely.
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
 
     SetTraceProcessName("Salamander");
@@ -3588,28 +3593,28 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     SetMessagesTitle(MAINWINDOW_NAME);
     TRACE_I("Begin");
 
-    // inicializace OLE
+    // OLE initialization
     if (FAILED(OleInitialize(NULL)))
     {
         TRACE_E("Error in CoInitialize.");
         return 1;
     }
 
-    //  HOldWPHookProc = SetWindowsHookEx(WH_CALLWNDPROC,     // HANDLES neumi!
+    //  HOldWPHookProc = SetWindowsHookEx(WH_CALLWNDPROC,     // HANDLES cannot do this!
     //                                    WPMessageHookProc,
     //                                    NULL, GetCurrentThreadId());
 
     User32DLL = NOHANDLES(LoadLibrary("user32.dll"));
     if (User32DLL == NULL)
-        TRACE_E("Unable to load library user32.dll."); // neni fatalni chyba
+        TRACE_E("Unable to load library user32.dll."); // Not a fatal error.
 
     TurnOFFWindowGhosting();
 
     NtDLL = HANDLES(LoadLibrary("NTDLL.DLL"));
     if (NtDLL == NULL)
-        TRACE_E("Unable to load library ntdll.dll."); // neni fatalni chyba
+        TRACE_E("Unable to load library ntdll.dll."); // not a fatal error
 
-    // detekce defaultniho userova charsetu pro fonty
+    // detect the user's default charset for fonts
     CHARSETINFO ci;
     memset(&ci, 0, sizeof(ci));
     char bufANSI[10];
@@ -3621,7 +3626,7 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
         }
     }
 
-    // kvuli pouzivani souboru mapovanych do pameti je nutne ziskat granularitu alokaci
+    // Get the allocation granularity needed for memory-mapped files.
     SYSTEM_INFO si;
     GetSystemInfo(&si);
     AllocationGranularity = si.dwAllocationGranularity;
@@ -3636,13 +3641,13 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     // Windows 7          6              1
     // Windows 8          6              2
     // Windows 8.1        6              3
-    // Windows 10         10             0             (poznamka: preview verze W10 z 2014 vracely verzi 6.4)
+    // Windows 10         10             0             (note: preview builds of W10 from 2014 reported version 6.4)
 
     if (!SalIsWindowsVersionOrGreater(6, 1, 0))
     {
-        // sem se to pravdepodobne nedostane, na starsich systemech budou chybet exporty staticky linkovanych
-        // knihoven a uzivatele serve nejaka nepochopitelna hlaska na urovni PE loaderu ve Windows
-        // nevolat SalMessageBox
+        // We will probably never get here; on older systems, exports from statically linked
+        // libraries will be missing and the user will get some incomprehensible PE-loader-level error in Windows.
+        // Do not call SalMessageBox.
         MessageBox(NULL, "You need at least Windows 7 to run this program.",
                    SALAMANDER_TEXT_VERSION, MB_OK | MB_ICONEXCLAMATION);
     EXIT_1:
@@ -3670,7 +3675,7 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     if (GetProcessIntegrityLevel(&integrityLevel) && integrityLevel >= SECURITY_MANDATORY_HIGH_RID)
         RunningAsAdmin = TRUE;
 
-    // pokud je to mozne, pouzijeme GetNativeSystemInfo, jinak si nechame vysledek GetSystemInfo
+    // If possible, use GetNativeSystemInfo; otherwise keep the result from GetSystemInfo.
     typedef void(WINAPI * PGNSI)(LPSYSTEM_INFO);
     PGNSI pGNSI = (PGNSI)GetProcAddress(GetModuleHandle("kernel32.dll"), "GetNativeSystemInfo"); // Min: XP
     if (pGNSI != NULL)
@@ -3680,7 +3685,7 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     if (!GetWindowsDirectory(WindowsDirectory, MAX_PATH))
         WindowsDirectory[0] = 0;
 
-    // zajima nas iface ITaskbarList3, ktery MS zavedli od Windows 7 - napriklad progress v taskbar buttons
+    // We care about the ITaskbarList3 interface, introduced by Microsoft in Windows 7, for example taskbar button progress.
     if (Windows7AndLater)
     {
         TaskbarBtnCreatedMsg = RegisterWindowMessage("TaskbarButtonCreated");
@@ -3691,22 +3696,22 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
         }
     }
 
-    // mame nastavene globalni promenne, muzeme inicializovat tento mutex
+    // The global variables are set, so we can initialize this mutex.
     if (!TaskList.Init())
         TRACE_E("TaskList.Init() failed!");
 
     if (!InitializeWinLib())
-        goto EXIT_1; // musime inicializovat WinLib pred prvnim zobrazenim
-                     // wait dialogu (musi byt registrovany tridy oken)
-                     // ImportConfiguration uz muze otevrit tento dialog
+        goto EXIT_1; // We must initialize WinLib before the wait dialog is shown for the first time
+                     // because its window classes must already be registered.
+                     // ImportConfiguration may already open this dialog.
 
     LoadSaveToRegistryMutex.Init();
 
-    // zkusime z aktualni konfigurace vytahnout hodnotu "AutoImportConfig" -> existuje v pripade, ze provadime UPGRADE
+    // Try to read the "AutoImportConfig" value from the current configuration; it exists when we are doing an upgrade.
     BOOL autoImportConfig = FALSE;
     char autoImportConfigFromKey[200];
     autoImportConfigFromKey[0] = 0;
-    if (!GetUpgradeInfo(&autoImportConfig, autoImportConfigFromKey, 200)) // user si preje exit softu
+    if (!GetUpgradeInfo(&autoImportConfig, autoImportConfigFromKey, 200)) // the user requested that the application exit
     {
         myExitCode = 0;
     EXIT_1a:
@@ -3715,22 +3720,22 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
     }
     const char* configKey = autoImportConfig ? autoImportConfigFromKey : SalamanderConfigurationRoots[0];
 
-    // zkusime z aktualni konfigurace vytahnout klic urcujici jazyk
+    // Try to get the key that specifies the language from the current configuration.
     LoadSaveToRegistryMutex.Enter();
     HKEY hSalamander;
-    DWORD langChanged = FALSE; // TRUE = startujeme Salama poprve s jinym jazykem (naloadime vsechny pluginy, at se overi ze mame tuto jazykovou verzi i pro ne, pripadne at user vyresi jake nahradni verze chce pouzivat)
+    DWORD langChanged = FALSE; // TRUE = Salamander is being started for the first time in a different language (load all plugins to verify that this language version is available for them as well, or let the user choose which fallback versions to use)
     if (OpenKey(HKEY_CURRENT_USER, configKey, hSalamander))
     {
         HKEY actKey;
-        DWORD configVersion = 1; // toto je konfig od 1.52 a starsi
+        DWORD configVersion = 1; // config from 1.52 and earlier
         if (OpenKey(hSalamander, SALAMANDER_VERSION_REG, actKey))
         {
-            configVersion = 2; // toto je konfig od 1.6b1
+            configVersion = 2; // config from 1.6b1 or later
             GetValue(actKey, SALAMANDER_VERSIONREG_REG, REG_DWORD,
                      &configVersion, sizeof(DWORD));
             CloseKey(actKey);
         }
-        if (configVersion >= 59 /* 2.53 beta 2 */ && // pred 2.53 beta 2 byla jen anglictina, tedy cteni nema smysl, nabidneme userovi defaultni jazyk systemu nebo rucni vyber jazyku
+        if (configVersion >= 59 /* Before 2.53 beta 2, only English was available, so reading this setting is pointless; offer the user the system default language or a manual language selection. */ &&
             OpenKey(hSalamander, SALAMANDER_CONFIG_REG, actKey))
         {
             GetValue(actKey, CONFIG_LANGUAGE_REG, REG_SZ,
@@ -3748,8 +3753,8 @@ int WinMainBody(HINSTANCE hInstance, HINSTANCE /*hPrevInstance*/, LPSTR cmdLine,
 
 FIND_NEW_SLG_FILE:
 
-    // pokud klic neexistuje, zobrazime vyberovy dialog
-    BOOL newSLGFile = FALSE; // TRUE pokud byl .SLG vybran pri tomto spusteni Salamandera
+    // If the key does not exist, show the selection dialog.
+    BOOL newSLGFile = FALSE; // TRUE if the .SLG file was selected during this run of Salamander
     if (Configuration.SLGName[0] == 0)
     {
         CLanguageSelectorDialog slgDialog(NULL, Configuration.SLGName, NULL);
@@ -3765,8 +3770,8 @@ FIND_NEW_SLG_FILE:
         Configuration.AltPluginSLGName[0] = 0;
 
         char prevVerSLGName[MAX_PATH];
-        if (!autoImportConfig &&                            // pri UPGRADE toto nema smysl (jazyk se cte o par radek vyse, tahle rutina by ho jen precetla znovu)
-            FindLanguageFromPrevVerOfSal(prevVerSLGName) && // importneme jazyk z predchozi verze, je dost pravdepodobne, ze ho user opet chce pouzit (jde o import stare konfigurace Salama)
+        if (!autoImportConfig &&                            // This is pointless during an upgrade (the language is read a few lines above, and this routine would only read it again)
+            FindLanguageFromPrevVerOfSal(prevVerSLGName) && // Import the language from the previous version; it will likely still be preferred when importing an old Salamander configuration.
             slgDialog.SLGNameExists(prevVerSLGName))
         {
             lstrcpy(Configuration.SLGName, prevVerSLGName);
@@ -3774,22 +3779,22 @@ FIND_NEW_SLG_FILE:
         else
         {
             int langIndex = slgDialog.GetPreferredLanguageIndex(NULL, TRUE);
-            if (langIndex == -1) // tato instalace neobsahuje jazyk souhlasici s aktualnim user-locale ve Windows
+            if (langIndex == -1) // this installation does not contain a language matching the current Windows user locale
             {
 
-// kdyz se tohle zakomentuje, nebudeme posilat lidi tahat jazykove verze z webu (napr. kdyz tam zadne nejsou)
-// JRY: pro AS 2.53, kery jde s cestinou, nemcinou a anglictinou je pro ostatni jazyky posleme na forum do sekce
-//      "Translations" https://forum.altap.cz/viewforum.php?f=23 - treba to nekoho namotivuje a pujde svuj preklad vytvorit
+// If this is commented out, users will not be sent to download language versions from the web, for example when none are available.
+// JRY: For Altap Salamander 2.53, which ships with Czech, German, and English, send users looking for other languages to the forum section
+//      "Translations" https://forum.altap.cz/viewforum.php?f=23 - perhaps this will motivate someone to create their own translation.
 #define OFFER_OTHERLANGUAGE_VERSIONS
 
 #ifndef OFFER_OTHERLANGUAGE_VERSIONS
                 if (slgDialog.GetLanguagesCount() == 1)
-                    slgDialog.GetSLGName(Configuration.SLGName); // pokud existuje jen jeden jazyk, pouzijeme ho
+                    slgDialog.GetSLGName(Configuration.SLGName); // if there is only one language available, use it
                 else
                 {
 #endif // OFFER_OTHERLANGUAGE_VERSIONS
 
-                    // otevreme dialog vyberu jazyku, aby mohl user downloadnout a nainstalovat dalsi jazyky
+                    // Open the language selection dialog so the user can download and install additional languages.
                     if (slgDialog.Execute() == IDCANCEL)
                         goto EXIT_1a;
 
@@ -3799,7 +3804,7 @@ FIND_NEW_SLG_FILE:
             }
             else
             {
-                slgDialog.GetSLGName(Configuration.SLGName, langIndex); // pokud existuje jazyk odpovidajici aktualnim user-locale ve Windows, pouzijeme ho
+                slgDialog.GetSLGName(Configuration.SLGName, langIndex); // If a language matching the current Windows user locale is available, use it.
             }
         }
         newSLGFile = TRUE;
@@ -3816,7 +3821,7 @@ FIND_NEW_SLG_FILE:
     {
         if (HLanguage != NULL)
             HANDLES(FreeLibrary(HLanguage));
-        if (!newSLGFile) // zapamatovany .SLG soubor prestal nejspis existovat, zkusime najit jiny
+        if (!newSLGFile) // The saved .SLG file probably no longer exists; try to find another one.
         {
             sprintf(errorText, "File %s was not found or is not valid language file.\nOpen Salamander "
                                "will try to search for some other language file (.SLG).",
@@ -3825,7 +3830,7 @@ FIND_NEW_SLG_FILE:
             Configuration.SLGName[0] = 0;
             goto FIND_NEW_SLG_FILE;
         }
-        else // nemelo by vubec nastat - .SLG soubor jiz byl otestovan
+        else // This should not happen at all - the .SLG file has already been validated
         {
             sprintf(errorText, "File %s was not found or is not valid language file.\n"
                                "Please run Open Salamander again and try to choose some other language file.",
@@ -3837,10 +3842,11 @@ FIND_NEW_SLG_FILE:
 
     strcpy(Configuration.LoadedSLGName, Configuration.SLGName);
 
-    // nechame jiz bezici salmon nacist zvolene SLG (zatim pouzival nejake provizorni)
+    // Let the already running Salmon load the selected SLG (so far it used a provisional one).
     SalmonSetSLG(Configuration.SLGName);
 
-    // nastavime lokalizovane hlasky do modulu ALLOCHAN (zajistuje pri nedostatku pameti hlaseni uzivateli + Retry button + kdyz vse selze tak i Cancel pro terminate softu)
+    // Set localized messages in the ALLOCHAN module (it provides out-of-memory messages for the user, a Retry button,
+    // and if everything fails, even Cancel to terminate the application).
     SetAllocHandlerMessage(LoadStr(IDS_ALLOCHANDLER_MSG), SALAMANDER_TEXT_VERSION,
                            LoadStr(IDS_ALLOCHANDLER_WRNIGNORE), LoadStr(IDS_ALLOCHANDLER_WRNABORT));
 
@@ -3863,8 +3869,8 @@ FIND_NEW_SLG_FILE:
     }
 
 #ifdef USE_BETA_EXPIRATION_DATE
-    // beta verze je casove limitovana, viz BETA_EXPIRATION_DATE
-    // pokud je dnes den urceny touto promennou nebo nejaky dalsi, zobrazime okenko a koncime
+    // Beta versions are time-limited; see BETA_EXPIRATION_DATE.
+    // If today is the date specified by this variable or any later date, show a dialog and exit.
     SYSTEMTIME st;
     GetLocalTime(&st);
     SYSTEMTIME* expire = &BETA_EXPIRATION_DATE;
@@ -3877,12 +3883,12 @@ FIND_NEW_SLG_FILE:
     }
 #endif // USE_BETA_EXPIRATION_DATE
 
-    // otevreme splash screen
+    // Open the splash screen.
 
     GetSystemDPI(NULL);
 
-    // pokud konfigurace neexistuje nebo bude nasledne pri importu ze souboru zmenena, ma uzivatel
-    // smulu a splash screen se bude ridit implicitni nebo starou hodnotou
+    // If the configuration does not exist yet or is later changed when importing from a file, the user
+    // is out of luck and the splash screen will use the implicit or old value.
     LoadSaveToRegistryMutex.Enter();
     if (OpenKey(HKEY_CURRENT_USER, configKey, hSalamander))
     {
@@ -3900,7 +3906,7 @@ FIND_NEW_SLG_FILE:
     if (Configuration.ShowSplashScreen)
         SplashScreenOpen();
 
-    // okno pro import konfigurace obsahuje listview s checkboxama, musime inicializovat COMMON CONTROLS
+    // The configuration import window contains a list view with checkboxes, so we must initialize common controls.
     INITCOMMONCONTROLSEX initCtrls;
     initCtrls.dwSize = sizeof(INITCOMMONCONTROLSEX);
     initCtrls.dwICC = ICC_BAR_CLASSES | ICC_LISTVIEW_CLASSES |
@@ -3913,42 +3919,43 @@ FIND_NEW_SLG_FILE:
         goto EXIT_2;
     }
 
-    SetWinLibStrings(LoadStr(IDS_INVALIDNUMBER), MAINWINDOW_NAME); // j.r. - posunout na spravne misto
+    SetWinLibStrings(LoadStr(IDS_INVALIDNUMBER), MAINWINDOW_NAME); // j.r. - move this to the proper place
 
-    // inicializace pakovacu; drive provadeno v konstruktorech; ted presunuto sem,
-    // kdy uz je rozhodnuto o jazykovem DLL
+    // Initialize packers; previously done in constructors; now moved here,
+    // after the language DLL has been chosen.
     PackerFormatConfig.InitializeDefaultValues();
     ArchiverConfig.InitializeDefaultValues();
     PackerConfig.InitializeDefaultValues();
     UnpackerConfig.InitializeDefaultValues();
 
-    // pokud soubor existuje, bude importovan do registry
+    // If the file exists, it will be imported into the registry.
     BOOL importCfgFromFileWasSkipped = FALSE;
     ImportConfiguration(NULL, ConfigurationName, ConfigurationNameIgnoreIfNotExists, autoImportConfig,
                         &importCfgFromFileWasSkipped);
 
-    // obslouzime prechod ze stareho configu na novy
+    // handle the transition from the old config to the new one
 
-    // Zavolame funkci, ktera se pokusi najit konfiguraci odpovidajici nasi verzi programu.
-    // Pokud se ji podari najit, bude nastavena promenna 'loadConfiguration' a funkce vrati
-    // TRUE. Pokud konfigurace jeste nebude existovat, funkce postupne prohleda stare
-    // konfigurace z pole 'SalamanderConfigurationRoots' (od nejmladsich k nejstrasim).
-    // Pokud nalezne nekterou z konfiguraci, zobrazi dialog a nabidne jeji konverzi do
-    // konfigurace soucasne a smazani z registry. Po zobrazeni posledniho dialogu vrati
-    // TRUE a nastavi promenne 'deleteConfigurations' a 'loadConfiguration' dle voleb
-    // uzivatele. Pokud uzivatel zvoli ukonceni aplikace, vrati funkce FALSE.
+    // Call a function that attempts to find a configuration matching our program version.
+    // If it succeeds, the 'loadConfiguration' variable is set and the function returns
+    // TRUE. If such a configuration does not exist yet, the function gradually searches older
+    // configurations in the 'SalamanderConfigurationRoots' array (from newest to oldest).
+    // If it finds any of these configurations, it displays a dialog and offers to convert it to
+    // the current configuration and delete it from the registry. After the last dialog is shown,
+    // the function returns TRUE and sets the 'deleteConfigurations' and 'loadConfiguration'
+    // variables according to the user's choices. If the user chooses to exit the application,
+    // the function returns FALSE.
 
-    // pole urcujici indexy konfiguraci v poli 'SalamanderConfigurationRoots',
-    // ktere maji byt smazany (0 -> zadna)
+    // Array specifying indexes of configurations in the 'SalamanderConfigurationRoots' array
+    // that should be deleted (0 -> none).
     BOOL deleteConfigurations[SALCFG_ROOTS_COUNT];
     ZeroMemory(deleteConfigurations, sizeof(deleteConfigurations));
 
     CALL_STACK_MESSAGE1("WinMainBody::FindLatestConfiguration");
 
-    // ukazatel do pole 'SalamanderConfigurationRoots' na konfiguraci, ktera ma byt
-    // nactena (NULL -> zadna; pouziji se default hodnoty)
+    // Pointer into the 'SalamanderConfigurationRoots' array to the configuration that should be
+    // loaded (NULL -> none; default values will be used).
     if (autoImportConfig)
-        SALAMANDER_ROOT_REG = autoImportConfigFromKey; // pri UPGRADE nema hledani konfigurace smysl
+        SALAMANDER_ROOT_REG = autoImportConfigFromKey; // When upgrading, searching for a configuration is pointless.
     else
     {
         if (!FindLatestConfiguration(deleteConfigurations, SALAMANDER_ROOT_REG))
@@ -3958,14 +3965,14 @@ FIND_NEW_SLG_FILE:
         }
     }
 
-    InitializeShellib(); // OLE je treba inicializovat pred otevrenim HTML helpu - CSalamanderEvaluation
+    InitializeShellib(); // OLE must be initialized before opening HTML Help - CSalamanderEvaluation
 
-    // pokud jeste neexistuje novy klic konfigurace, vytvorime ho pred pripadnym smazanim
-    // starych klicu
+    // If the new configuration key does not exist yet, create it before possibly deleting
+    // the old keys.
     BOOL currentCfgDoesNotExist = autoImportConfig || SALAMANDER_ROOT_REG != SalamanderConfigurationRoots[0];
     BOOL saveNewConfig = currentCfgDoesNotExist;
 
-    // pokud uzivatel nechce vic instanci, pouze aktivujeme predchozi
+    // If the user does not want multiple instances, only activate the previous one.
     if (!currentCfgDoesNotExist &&
         CheckOnlyOneInstance(&cmdLineParams))
     {
@@ -3976,10 +3983,10 @@ FIND_NEW_SLG_FILE:
         goto EXIT_2;
     }
 
-    // overim verzi CommonControlu
-    if (GetComCtlVersion(&CCVerMajor, &CCVerMinor) != S_OK) // JRYFIXME - testy kolem common controls posunout na W7+
+    // Check the Common Controls version.
+    if (GetComCtlVersion(&CCVerMajor, &CCVerMinor) != S_OK) // JRYFIXME - move common controls tests to W7+
     {
-        CCVerMajor = 0; // tohle asi nikdy nenastane - nemaji comctl32.dll
+        CCVerMajor = 0; // this probably never happens; comctl32.dll is missing
         CCVerMinor = 0;
     }
 
@@ -3991,7 +3998,7 @@ FIND_NEW_SLG_FILE:
     for (i = 0; i < NUMBER_OF_COLORS; i++)
         UserColors[i] = SalamanderColors[i];
 
-    //--- inicializacni cast
+    //--- initialization section
     CALL_STACK_MESSAGE1("WinMainBody::inicialization");
     IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_DATA));
 
@@ -4055,25 +4062,25 @@ FIND_NEW_SLG_FILE:
         goto EXIT_9;
     }
 
-    // pripojeni OLE SPYe
-    // posunuto pod InitializeGraphics, ktere pod WinXP vyhazovala leaky (asi zase neajake cache)
-    // OleSpyRegister();    // odpojeno, protoze po updatu Windows 2000 z 02/2005 zacal pri spusteni+zavreni Salama z MSVC vylitavat debug-breakpoint: Invalid Address specified to RtlFreeHeap( 130000, 14bc74 ) - asi MS nekde zacali volat primo RtlFreeHeap misto OLE free a diky bloku informaci spye na zacatku alokovaneho bloku se to podelalo (malloc vraci pointer posunuty za blok informaci spye)
-    //OleSpySetBreak(2754); // brakne na [n-te] alokaci z dumpu
+    // OLE Spy attachment
+    // moved below InitializeGraphics, which leaked under WinXP (probably some cache again)
+    // OleSpyRegister();    // disabled because after the Windows 2000 update from 02/2005, a debug breakpoint started appearing in MSVC when Salam was started and closed: Invalid Address specified to RtlFreeHeap( 130000, 14bc74 ) - MS probably started calling RtlFreeHeap directly somewhere instead of OLE free, and the spy info block at the start of the allocated block broke it (malloc returns a pointer shifted past the spy info block)
+    //OleSpySetBreak(2754); // breaks on the nth allocation from the dump
 
-    // inicializace workera (diskove operace)
+    // Initialize the worker (disk operations).
     InitWorker();
 
-    // inicializace knihovny pro komunikaci s SalShExt/SalamExt/SalExtX86/SalExtX64.DLL (shell copy hook + shell context menu)
+    // initialize the library for communicating with SalShExt/SalamExt/SalExtX86/SalExtX64.DLL (shell copy hook + shell context menu)
     InitSalShLib();
 
-    // inicializace knihovny pro praci s shell icon overlays (Tortoise SVN + CVS)
+    // initialize the library for working with shell icon overlays (Tortoise SVN + CVS)
     LoadIconOvrlsInfo(SALAMANDER_ROOT_REG);
     InitShellIconOverlays();
 
-    // inicializace funkci pro prochazeni pres next/prev soubor v panelu/Findu z vieweru
+    // initialize support for moving to the next/previous file in the panel or Find from the viewer
     InitFileNamesEnumForViewers();
 
-    // nacteme seznam sharovanych adresaru
+    // Load the list of shared directories
     IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_SHARES));
     Shares.Refresh();
 
@@ -4096,10 +4103,10 @@ FIND_NEW_SLG_FILE:
                                         SHELLEXECUTE_CLASSNAME,
                                         NULL);
 
-    Associations.ReadAssociations(FALSE); // nacteni asociaci z Registry
+    Associations.ReadAssociations(FALSE); // read associations from the Registry
 
-    // registrace shell extensions
-    // pokud najdeme v podadresari "utils" knihovnu, overime jeji registraci a pripadne ji zaregistrujeme
+    // Shell extension registration.
+    // If we find the library in the "utils" subdirectory, check whether it is registered and register it if needed.
     char shellExtPath[MAX_PATH];
     GetModuleFileName(HInstance, shellExtPath, MAX_PATH);
     char* shellExtPathSlash = strrchr(shellExtPath, '\\');
@@ -4128,7 +4135,7 @@ FIND_NEW_SLG_FILE:
 #endif // _WIN64
     }
 
-    //--- vytvoreni hlavniho okna
+    //--- create the main window
     if (CMainWindow::RegisterUniversalClass(CS_DBLCLKS | CS_OWNDC,
                                             0,
                                             0,
@@ -4165,12 +4172,12 @@ FIND_NEW_SLG_FILE:
                 SetMessagesParent(MainWindow->HWindow);
                 PluginMsgBoxParent = MainWindow->HWindow;
 
-                // vytahneme z registry Group Policy
+                // read Group Policy from the registry
                 IfExistSetSplashScreenText(LoadStr(IDS_STARTUP_POLICY));
                 SystemPolicies.LoadFromRegistry();
 
                 CALL_STACK_MESSAGE1("WinMainBody::load_config");
-                BOOL setActivePanelAndPanelPaths = FALSE; // aktivni panel + cesty v panelech se nastavuji v MainWindow->LoadConfig()
+                BOOL setActivePanelAndPanelPaths = FALSE; // The active panel and the panel paths are set in MainWindow->LoadConfig().
                 if (!MainWindow->LoadConfig(currentCfgDoesNotExist, !importCfgFromFileWasSkipped ? &cmdLineParams : NULL))
                 {
                     setActivePanelAndPanelPaths = TRUE;
@@ -4187,7 +4194,7 @@ FIND_NEW_SLG_FILE:
                         MainWindow->ToggleMiddleToolBar();
                     if (Configuration.BottomToolBarVisible)
                         MainWindow->ToggleBottomToolBar();
-                    MainWindow->CreateAndInsertWorkerBand(); // na zaver vlozime workera
+                    MainWindow->CreateAndInsertWorkerBand(); // finally, insert the worker band
                     MainWindow->LeftPanel->UpdateDriveIcon(TRUE);
                     MainWindow->RightPanel->UpdateDriveIcon(TRUE);
                     MainWindow->LeftPanel->UpdateFilterSymbol();
@@ -4208,7 +4215,7 @@ FIND_NEW_SLG_FILE:
 
                 if (newSLGFile)
                 {
-                    Plugins.ClearLastSLGNames(); // aby pripadne doslo k nove volbe nahradniho jazyka u vsech pluginu
+                    Plugins.ClearLastSLGNames(); // so that a new fallback language will be selected for all plugins if needed
                     Configuration.ShowSLGIncomplete = TRUE;
                 }
 
@@ -4222,27 +4229,27 @@ FIND_NEW_SLG_FILE:
                 }
                 else
                 {
-                    if (!importCfgFromFileWasSkipped) // jen pokud hned nedojde k exitu softu (to pak nema smysl)
+                    if (!importCfgFromFileWasSkipped) // Only if the application does not exit immediately; otherwise this is pointless.
                         MainWindow->ApplyCommandLineParams(&cmdLineParams, setActivePanelAndPanelPaths);
 
                     if (Windows7AndLater)
                         CreateJumpList();
 
-                    IdleRefreshStates = TRUE;  // pri pristim Idle vynutime kontrolu stavovych promennych
-                    IdleCheckClipboard = TRUE; // nechame kontrolovat take clipboard
+                    IdleRefreshStates = TRUE;  // Force a check of the state variables on the next idle cycle.
+                    IdleCheckClipboard = TRUE; // also request checking the clipboard
 
                     AccelTable1 = HANDLES(LoadAccelerators(HInstance, MAKEINTRESOURCE(IDA_MAINACCELS1)));
                     AccelTable2 = HANDLES(LoadAccelerators(HInstance, MAKEINTRESOURCE(IDA_MAINACCELS2)));
 
-                    MainWindow->CanClose = TRUE; // ted teprve povolime zavreni hl. okna
-                    // aby soubory nevyskakovali postupne (jak se nacitaji jejich ikony)
+                    MainWindow->CanClose = TRUE; // Only now do we allow the main window to be closed.
+                    // so files do not pop up one by one as their icons load
                     UpdateWindow(MainWindow->HWindow);
 
                     BOOL doNotDeleteImportedCfg = FALSE;
-                    if (autoImportConfig && // zjistime jestli nova verze nema mene pluginu nez stara a diky tomu se cast stare konfigurace neprenese
+                    if (autoImportConfig && // Check whether the new version has fewer plugins than the old one, so part of the old configuration would not be imported.
                         FindPluginsWithoutImportedCfg(&doNotDeleteImportedCfg))
-                    {                               // je potreba exit softu bez ulozeni konfigurace
-                        SALAMANDER_ROOT_REG = NULL; // tohle by melo spolehlive zamezit zapisu do konfigurace v registry
+                    {                               // The app needs to exit without saving the configuration
+                        SALAMANDER_ROOT_REG = NULL; // This should reliably prevent the configuration from being written to the registry.
                         PostMessage(MainWindow->HWindow, WM_USER_FORCECLOSE_MAINWND, 0, 0);
                     }
                     else
@@ -4252,57 +4259,57 @@ FIND_NEW_SLG_FILE:
                             || Configuration.AddX86OnlyPlugins
 #endif // _WIN64
                         )
-                        {                                            // auto-install plug-inu ze standardniho plug-in-podadresare "plugins"
+                        {                                            // auto-install plug-ins from the standard "plugins" plug-in subdirectory
 #ifndef _WIN64                                                       // FIXME_X64_WINSCP
-                            Configuration.AddX86OnlyPlugins = FALSE; // jednou staci
+                            Configuration.AddX86OnlyPlugins = FALSE; // only need to do this once
 #endif                                                               // _WIN64
                             Plugins.AutoInstallStdPluginsDir(MainWindow->HWindow);
-                            Configuration.LastPluginVer = 0;   // pri prechodu na novou verzi bude zrusen soubor plugins.ver
-                            Configuration.LastPluginVerOP = 0; // pri prechodu na novou verzi bude zrusen soubor plugins.ver i pro druhou platformu
-                            saveNewConfig = TRUE;              // nova konfigurace se musi ulozit (aby se tohle pri pristim spusteni neopakovalo)
+                            Configuration.LastPluginVer = 0;   // when upgrading to a new version, the plugins.ver file will also be removed for the other platform
+                            Configuration.LastPluginVerOP = 0; // when upgrading to a new version, the plugins.ver file will also be removed for the other platform
+                            saveNewConfig = TRUE;              // The new configuration must be saved so this does not happen again on the next startup.
                         }
-                        // nacteni souboru plugins.ver ((re)instalace plug-inu), nutne i poprve (pro pripad
-                        // instalace plug-inu pred prvnim spustenim Salamandera)
+                        // Load the plugins.ver file ((re)installing plug-ins), needed even on the first run (in case
+                        // plug-ins were installed before Salamander was started for the first time).
                         if (Plugins.ReadPluginsVer(MainWindow->HWindow, Configuration.ConfigVersion < THIS_CONFIG_VERSION))
-                            saveNewConfig = TRUE; // nova konfigurace se musi ulozit (aby se tohle pri pristim spusteni neopakovalo)
-                        // load plug-inu, ktere maji nastaveny flag load-on-start
+                            saveNewConfig = TRUE; // the new configuration must be saved (so this does not happen again on the next startup)
+                        // load plugins that have the load-on-start flag set
                         Plugins.HandleLoadOnStartFlag(MainWindow->HWindow);
-                        // pokud startujeme poprve se zmenenym jazykem, naloadime vsechny pluginy, aby se ukazalo,
-                        // jestli maji tuto jazykovou verzi + pripadne aby si user vybrat nahradni jazyky
+                        // If we are starting for the first time with a changed language, load all plug-ins so it becomes clear
+                        // whether they have this language version, and if needed let the user choose replacement languages.
                         if (langChanged)
                             Plugins.LoadAll(MainWindow->HWindow);
 
-                        // pluginy FTP a WinSCP nove volaji SalamanderGeneral->SetPluginUsesPasswordManager() aby se prihlasily k odberu eventu z password managera
-                        // zavedeno s verzi kofigurace 45 -- dame vsem pluginum moznost se prihlasit
-                        if (Configuration.ConfigVersion < 45) // zavedeni password manageru
+                        // The FTP and WinSCP plugins now call SalamanderGeneral->SetPluginUsesPasswordManager() to subscribe to password manager events.
+                        // Introduced in configuration version 45; give all plugins a chance to register.
+                        if (Configuration.ConfigVersion < 45) // introduce the password manager
                             Plugins.LoadAll(MainWindow->HWindow);
 
-                        // save uz pujde do nejnovejsiho klice
+                        // Saving will now go to the newest key.
                         SALAMANDER_ROOT_REG = SalamanderConfigurationRoots[0];
-                        // konfiguraci ulozime hned, dokud je to cista konverze stare verze -- user muze
-                        // mit vypnuty "Save Cfg on Exit" a pokud behem chodu Salamandera neco zmeni, nechce to na zaver ulozit
+                        // Save the configuration immediately while this is still a clean conversion of the old version; the user may
+                        // have "Save Cfg on Exit" disabled and may not want later changes made during the Salamander session to be saved at exit
                         if (saveNewConfig)
                         {
                             MainWindow->SaveConfig();
                         }
-                        // prohleda pole a pokud je nektery z rootu oznaceny pro smazani, smaze ho + smaze starou konfiguraci
-                        // po UPGRADE a tez smazne hodnotu "AutoImportConfig" v klici konfigurace teto verze Salama
+                        // scan the array and, if any root is marked for deletion, delete it; also delete the old configuration
+                        // after an UPGRADE and also remove the "AutoImportConfig" value from the configuration key for this Salamander version
                         MainWindow->DeleteOldConfigurations(deleteConfigurations, autoImportConfig, autoImportConfigFromKey,
                                                             doNotDeleteImportedCfg);
 
-                        // jen prvni instance Salamandera: podivame se, jestli neni potreba vycistit
-                        // TEMP od zbytecnych souboru disk-cache (pri padu nebo zamknuti jinou aplikaci
-                        // muzou soubory v TEMPu zustat)
-                        // musime testoval na globalni (skrz vsechny sessions) promennou, aby se videly dve
-                        // instance Salamanderu spustene pod FastUserSwitching
-                        // Problem nahlasen na foru: https://forum.altap.cz/viewtopic.php?t=2643
+                        // only the first Salamander instance: check whether TEMP needs to be cleaned up
+                        // of unnecessary disk cache files (after a crash or when locked by another application,
+                        // files may remain in TEMP)
+                        // we must test a global variable (shared across all sessions) so that two
+                        // Salamander instances started under Fast User Switching can see each other
+                        // Problem reported on the forum: https://forum.altap.cz/viewtopic.php?t=2643
                         if (FirstInstance_3_or_later)
                         {
                             DiskCache.ClearTEMPIfNeeded(MainWindow->HWindow, MainWindow->GetActivePanelHWND());
                         }
 
-                        if (importCfgFromFileWasSkipped) // pokud jsme preskocili import config.reg nebo jineho .reg souboru (parametr -C)
-                        {                                // informujeme usera o nutnosti noveho startu Salama a nechame ho exitnout soft
+                        if (importCfgFromFileWasSkipped) // if importing config.reg or another .reg file was skipped (-C parameter)
+                        {                                // notify the user that Salamander needs to be restarted, then let them exit the application
                             MSGBOXEX_PARAMS params;
                             memset(&params, 0, sizeof(params));
                             params.HParent = MainWindow->HWindow;
@@ -4310,57 +4317,57 @@ FIND_NEW_SLG_FILE:
                             params.Caption = SALAMANDER_TEXT_VERSION;
                             params.Text = LoadStr(IDS_IMPORTCFGFROMFILESKIPPED);
                             char aliasBtnNames[200];
-                            /* slouzi pro skript export_mnu.py, ktery generuje salmenu.mnu pro Translator
-   nechame pro tlacitka msgboxu resit kolize hotkeys tim, ze simulujeme, ze jde o menu
-MENU_TEMPLATE_ITEM MsgBoxButtons[] = 
-{
-  {MNTT_PB, 0
-  {MNTT_IT, IDS_SELLANGEXITBUTTON
-  {MNTT_PE, 0
-};
-*/
+                            /* used by the export_mnu.py script, which generates salmenu.mnu for Translator
+                               for message box buttons, handle hotkey collisions by simulating a menu
+                            MENU_TEMPLATE_ITEM MsgBoxButtons[] =
+                            {
+                              {MNTT_PB, 0
+                              {MNTT_IT, IDS_SELLANGEXITBUTTON
+                              {MNTT_PE, 0
+                            };
+                            */
                             sprintf(aliasBtnNames, "%d\t%s", DIALOG_OK, LoadStr(IDS_SELLANGEXITBUTTON));
                             params.AliasBtnNames = aliasBtnNames;
                             SalMessageBoxEx(&params);
                             PostMessage(MainWindow->HWindow, WM_USER_FORCECLOSE_MAINWND, 0, 0);
                         }
                         /*
-            // je-li treba, vyvolame zobrazeni dialogu Tip of the Day
-            // 0xffffffff = open quiet - pokud to nedopadne, neserveme usera
-            if (Configuration.ShowTipOfTheDay)
-              PostMessage(MainWindow->HWindow, WM_COMMAND, CM_HELP_TIP, 0xffffffff);
-  */
+                                    // If needed, show the Tip of the Day dialog
+                                    // 0xffffffff = quiet open; if it fails, do not disturb the user
+                                    if (Configuration.ShowTipOfTheDay)
+                                      PostMessage(MainWindow->HWindow, WM_COMMAND, CM_HELP_TIP, 0xffffffff);
+                          */
                     }
 
-                    // odted se uz budou pamatovat zavirane cesty
+                    // paths being closed will now be remembered
                     MainWindow->CanAddToDirHistory = TRUE;
 
-                    // uzivatele chteji mit start-up cestu v historii i v pripade, ze ji neuspinili
+                    // Users want the startup path kept in the history even if they have not worked with it yet
                     MainWindow->LeftPanel->UserWorkedOnThisPath = TRUE;
                     MainWindow->RightPanel->UserWorkedOnThisPath = TRUE;
 
-                    // dame seznamu procesu vedet, ze bezime a mame hlavni okno (je mozne nas aktivovat pri OnlyOneInstance)
+                    // Tell the process list that we are running and have a main window (so it can activate us in OnlyOneInstance mode)
                     TaskList.SetProcessState(PROCESS_STATE_RUNNING, MainWindow->HWindow);
 
-                    // pozadame Salmon o kontrolu, zda na disku nejsou stare bug reporty, ktere by bylo potreba odeslat
+                    // Ask Salmon to check whether there are any old bug reports on disk that need to be sent.
                     SalmonCheckBugs();
 
                     if (IsSLGIncomplete[0] != 0 && Configuration.ShowSLGIncomplete)
                         PostMessage(MainWindow->HWindow, WM_USER_SLGINCOMPLETE, 0, 0);
 
-                    //--- aplikacni smycka
+                    //--- message loop
                     CALL_STACK_MESSAGE1("WinMainBody::message_loop");
                     DWORD activateParamsRequestUID = 0;
                     BOOL skipMenuBar;
                     MSG msg;
-                    BOOL haveMSG = FALSE; // FALSE pokud se ma volat GetMessage() v podmince cyklu
+                    BOOL haveMSG = FALSE; // FALSE if GetMessage() should be called in the loop condition
                     while (haveMSG || GetMessage(&msg, NULL, 0, 0))
                     {
                         haveMSG = FALSE;
                         if (msg.message != WM_USER_SHOWWINDOW && msg.message != WM_USER_WAKEUP_FROM_IDLE && /*msg.message != WM_USER_SETPATHS &&*/
                             msg.message != WM_QUERYENDSESSION && msg.message != WM_USER_SALSHEXT_PASTE &&
                             msg.message != WM_USER_CLOSE_MAINWND && msg.message != WM_USER_FORCECLOSE_MAINWND)
-                        { // krom "connect", "shutdown", "do-paste" a "close-main-wnd" messages jsou vsechny zacatkem BUSY rezimu
+                        { // All messages except "connect", "shutdown", "do-paste", and "close-main-wnd" put Salamander into BUSY mode.
                             SalamanderBusy = TRUE;
                             LastSalamanderIdleTime = GetTickCount();
                         }
@@ -4368,22 +4375,22 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                         if ((msg.message == WM_SYSKEYDOWN || msg.message == WM_KEYDOWN) &&
                             msg.wParam != VK_MENU && msg.wParam != VK_CONTROL && msg.wParam != VK_SHIFT)
                         {
-                            SetCurrentToolTip(NULL, 0); // zhasneme tooltip
+                            SetCurrentToolTip(NULL, 0); // Hide the tooltip.
                         }
 
                         skipMenuBar = FALSE;
                         if (Configuration.QuickSearchEnterAlt && msg.message == WM_SYSCHAR)
                             skipMenuBar = TRUE;
 
-                        // zajistime zaslani zprav do naseho menu (obchazime tim potrebu hooku pro klavesnici)
+                        // Ensure messages are sent to our menu (this avoids the need for a keyboard hook).
                         if (MainWindow == NULL || MainWindow->MenuBar == NULL || !MainWindow->CaptionIsActive ||
                             MainWindow->QuickRenameWindowActive() ||
-                            skipMenuBar || GetCapture() != NULL || // je-li captured mouse - mohli bychom zpusobit vizualni problemy
+                            skipMenuBar || GetCapture() != NULL || // if the mouse is captured, we could cause visual glitches
                             !MainWindow->MenuBar->IsMenuBarMessage(&msg))
                         {
                             CWindowsObject* wnd = WindowsManager.GetWindowPtr(GetActiveWindow());
 
-                            // Bottom Toolbar - zmena textu podle VK_CTRL, VK_MENU a VK_SHIFT
+                            // Bottom toolbar: update text based on VK_CTRL, VK_MENU, and VK_SHIFT
                             if ((msg.message == WM_SYSKEYDOWN || msg.message == WM_KEYDOWN ||
                                  msg.message == WM_SYSKEYUP || msg.message == WM_KEYUP) &&
                                 MainWindow != NULL)
@@ -4391,7 +4398,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 
                             if ((wnd == NULL || !wnd->Is(otDialog) ||
                                  !IsDialogMessage(wnd->HWindow, &msg)) &&
-                                (MainWindow == NULL || !MainWindow->CaptionIsActive || // pridano "!MainWindow->CaptionIsActive", aby se v nemodalnich oknech pluginu neprekladaly akceleratory (F7 v "FTP Logs" neni nic moc)
+                                (MainWindow == NULL || !MainWindow->CaptionIsActive || // Added "!MainWindow->CaptionIsActive" so accelerators are not processed in non-modal plugin windows (F7 in "FTP Logs" is not a great idea).
                                  MainWindow->QuickRenameWindowActive() ||
                                  !TranslateAccelerator(MainWindow->HWindow, AccelTable1, &msg) &&
                                      (MainWindow->EditMode || !TranslateAccelerator(MainWindow->HWindow, AccelTable2, &msg))))
@@ -4402,7 +4409,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                         }
 
                         if (MainWindow != NULL && MainWindow->CanClose)
-                        { // je-li Salamander nastartovany, muzeme ho prohlasit za NE BUSY
+                        { // if Salamander has started, it can be marked as not busy
                             SalamanderBusy = FALSE;
                         }
 
@@ -4410,16 +4417,16 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                         if (PeekMessage(&msg, NULL, 0, 0, PM_REMOVE))
                         {
                             if (msg.message == WM_QUIT)
-                                break;      // ekvivalent situace, kdy GetMessage() vraci FALSE
-                            haveMSG = TRUE; // mame zpravu, jdeme ji zpracovat (bez volani GetMessage())
+                                break;      // equivalent to when GetMessage() returns FALSE
+                            haveMSG = TRUE; // We have a message, so process it without calling GetMessage().
                         }
-                        else // pokud ve fronte neni zadna message, provedeme Idle processing
+                        else // If there is no message in the queue, perform idle processing
                         {
 #ifdef _DEBUG
-                            // jednou za tri vteriny osetrime konzistenci heapu
+                            // Check heap consistency every three seconds.
                             if (_CrtSetDbgFlag(_CRTDBG_REPORT_FLAG) & _CRTDBG_ALLOC_MEM_DF)
                             {
-                                if (GetTickCount() - LastCrtCheckMemoryTime > 3000) // kazde tri vteriny
+                                if (GetTickCount() - LastCrtCheckMemoryTime > 3000) // every three seconds
                                 {
                                     if (!_CrtCheckMemory())
                                     {
@@ -4435,40 +4442,40 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
 
                             if (MainWindow != NULL)
                             {
-                                CannotCloseSalMainWnd = TRUE; // musime zamezit zavreni hlavniho okna Salamandera behem provadeni nasledujicich rutin
+                                CannotCloseSalMainWnd = TRUE; // Prevent the Salamander main window from closing while the following routines run.
                                 MainWindow->OnEnterIdle();
 
-                                // na pusteni ESC cekame jen pokud refresh listingu v panelu primo
-                                // navazuje (coz pres IDLE nehrozi)
+                                // Wait for ESC to be released only if a panel listing refresh follows immediately
+                                // which cannot happen via IDLE.
                                 if (WaitForESCReleaseBeforeTestingESC)
                                     WaitForESCReleaseBeforeTestingESC = FALSE;
 
-                                // zjistime, zda nas nezada cizi "OnlyOneInstance" Salamander o aktivaci a nastaveni cest v panelech?
-                                // FControlThread by v takovem pripade nastavil parametry do globalni CommandLineParams a zvysil RequestUID
-                                // pokud byl hlavni thread v IDLE, probral se diky postnute WM_USER_WAKEUP_FROM_IDLE
+                                // check whether another "OnlyOneInstance" Salamander is requesting activation and panel path setup?
+                                // In that case, FControlThread would store the parameters in the global CommandLineParams and increment RequestUID.
+                                // If the main thread was idle, it woke up because WM_USER_WAKEUP_FROM_IDLE was posted.
                                 if (!SalamanderBusy && CommandLineParams.RequestUID > activateParamsRequestUID)
                                 {
                                     CCommandLineParams paramsCopy;
                                     BOOL applyParams = FALSE;
 
                                     NOHANDLES(EnterCriticalSection(&CommandLineParamsCS));
-                                    // tesne pred vstupem do kriticke sekce mohlo dojit k timeoutu v control threadu, overime ze jeste stoji o vysledek
-                                    // zaroven overime, ze pozadavak neexpiroval (volajici vlakno ceka pouze do TASKLIST_TODO_TIMEOUT a potom cekani
-                                    // vzda a spusti novou instanci Salamander; nechceme v takovem pripade pozadavek vyplnit)
+                                    // A timeout may have occurred in the control thread just before entering the critical section; verify that it still wants the result.
+                                    // Also verify that the request has not expired (the calling thread waits only until TASKLIST_TODO_TIMEOUT, then
+                                    // gives up and starts a new Salamander instance; in that case we do not want to fulfill the request).
                                     DWORD tickCount = GetTickCount();
                                     if (CommandLineParams.RequestUID != 0 && tickCount - CommandLineParams.RequestTimestamp < TASKLIST_TODO_TIMEOUT)
                                     {
                                         memcpy(&paramsCopy, &CommandLineParams, sizeof(CCommandLineParams));
                                         applyParams = TRUE;
 
-                                        // ulozime UID, ktere jsme jiz odbavili, abychom necyklili
+                                        // Remember the UID that has already been handled so we do not loop.
                                         activateParamsRequestUID = CommandLineParams.RequestUID;
-                                        // dame control threadu zpravu, ze jsme cesty prijali
+                                        // signal to the control thread that the paths have been accepted
                                         SetEvent(CommandLineParamsProcessed);
                                     }
                                     NOHANDLES(LeaveCriticalSection(&CommandLineParamsCS));
 
-                                    // uvolnili jsme sdilene prostredky, muzeme se jit parat s cestama
+                                    // the shared resources have been released; the paths can now be handled
                                     if (applyParams && MainWindow != NULL)
                                     {
                                         SendMessage(MainWindow->HWindow, WM_USER_SHOWWINDOW, 0, 0);
@@ -4476,7 +4483,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                     }
                                 }
 
-                                // zajistime unik z odstranenych drivu na fixed drive (po vysunuti device - USB flash disk, atd.)
+                                // Ensure we switch away from removed drives to a fixed drive (after device ejection - USB flash drive, etc.).
                                 if (!SalamanderBusy && ChangeLeftPanelToFixedWhenIdle)
                                 {
                                     ChangeLeftPanelToFixedWhenIdle = FALSE;
@@ -4500,35 +4507,35 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                         PostMessage(MainWindow->HWindow, WM_USER_CONFIGURATION, 6, 0);
                                 }
 
-                                // pokud nejaky plug-in chtel unload nebo rebuild menu, provedeme ho... (jen neni-li "busy")
+                                // If any plugin requested an unload or a menu rebuild, handle it... (but only when we're not "busy")
                                 if (!SalamanderBusy && ExecCmdsOrUnloadMarkedPlugins)
                                 {
                                     int cmd;
                                     CPluginData* data;
                                     Plugins.GetCmdAndUnloadMarkedPlugins(MainWindow->HWindow, &cmd, &data);
                                     ExecCmdsOrUnloadMarkedPlugins = (cmd != -1);
-                                    if (cmd >= 0 && cmd < 500) // spusteni prikazu Salamandera na zadost plug-inu
+                                    if (cmd >= 0 && cmd < 500) // Execute a Salamander command at the request of a plugin
                                     {
                                         int wmCmd = GetWMCommandFromSalCmd(cmd);
                                         if (wmCmd != -1)
                                         {
-                                            // vygenerujeme WM_COMMAND a nechame ho hned zpracovat
+                                            // Generate a WM_COMMAND and process it immediately
                                             msg.hwnd = MainWindow->HWindow;
                                             msg.message = WM_COMMAND;
-                                            msg.wParam = (DWORD)LOWORD(wmCmd); // radsi orizneme horni WORD (0 - cmd z menu)
+                                            msg.wParam = (DWORD)LOWORD(wmCmd); // better strip off the high WORD (0 for menu commands)
                                             msg.lParam = 0;
                                             msg.time = GetTickCount();
                                             GetCursorPos(&msg.pt);
 
-                                            haveMSG = TRUE; // mame zpravu, jdeme ji zpracovat (bez volani GetMessage())
+                                            haveMSG = TRUE; // We already have a message, so process it without calling GetMessage().
                                         }
                                     }
                                     else
                                     {
-                                        if (cmd >= 500 && cmd < 1000500) // spusteni prikazu menuExt na zadost plug-inu
+                                        if (cmd >= 500 && cmd < 1000500) // Execute the menuExt command at the plugin's request
                                         {
                                             int id = cmd - 500;
-                                            SalamanderBusy = TRUE; // jdeme provest prikaz menu - uz jsme zase "busy"
+                                            SalamanderBusy = TRUE; // We are about to execute the menu command, so we are busy again.
                                             LastSalamanderIdleTime = GetTickCount();
                                             if (data != NULL && data->GetLoaded())
                                             {
@@ -4537,13 +4544,13 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                                     CALL_STACK_MESSAGE4("CPluginInterfaceForMenuExt::ExecuteMenuItem(, , %d,) (%s v. %s)",
                                                                         id, data->DLLName, data->Version);
 
-                                                    // snizime prioritu threadu na "normal" (aby operace prilis nezatezovaly stroj)
+                                                    // lower the thread priority to "normal" so operations do not put too much load on the machine
                                                     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 
                                                     CSalamanderForOperations sm(MainWindow->GetActivePanel());
                                                     data->GetPluginInterfaceForMenuExt()->ExecuteMenuItem(&sm, MainWindow->HWindow, id, 0);
 
-                                                    // opet zvysime prioritu threadu, operace dobehla
+                                                    // raise the thread priority back to above normal; the operation has finished
                                                     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_ABOVE_NORMAL);
                                                 }
                                                 else
@@ -4554,16 +4561,16 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                             }
                                             else
                                             {
-                                                // nemusi byt naloaden, staci aby se PostMenuExtCommand zavolal z Release pluginu,
-                                                // ktery je vyvolany postnutym unloadem
+                                                // It does not have to be loaded; it is enough for PostMenuExtCommand to be called from the Release plug-in,
+                                                // which is triggered by the posted unload.
                                                 // TRACE_E("Unexpected situation during call of menu command in \"sal-idle\".");
                                             }
-                                            if (MainWindow != NULL && MainWindow->CanClose) // konec provadeni prikazu menu
-                                            {                                               // je-li Salamander nastartovany, muzeme ho prohlasit za NE BUSY
+                                            if (MainWindow != NULL && MainWindow->CanClose) // end of menu command processing
+                                            {                                               // if Salamander has started up, we can mark it as not busy
                                                 SalamanderBusy = FALSE;
                                             }
                                             CannotCloseSalMainWnd = FALSE;
-                                            goto TEST_IDLE; // zkusime znovu "idle" (napr. aby se mohl zpracovat dalsi postnuty prikaz/unload)
+                                            goto TEST_IDLE; // try "idle" again (e.g. so another posted command/unload can be processed)
                                         }
                                     }
                                 }
@@ -4573,18 +4580,18 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                     int pluginIndex;
                                     Plugins.OpenPackOrUnpackDlgForMarkedPlugins(&data, &pluginIndex);
                                     OpenPackOrUnpackDlgForMarkedPlugins = (data != NULL);
-                                    if (data != NULL) // otevreni Pack/Unpack dialogu na zadost plug-inu
+                                    if (data != NULL) // Open the Pack/Unpack dialog at the plugin's request
                                     {
-                                        SalamanderBusy = TRUE; // jdeme provest prikaz menu - uz jsme zase "busy"
+                                        SalamanderBusy = TRUE; // We're about to execute the menu command, so we're busy again
                                         LastSalamanderIdleTime = GetTickCount();
                                         if (data->OpenPackDlg)
                                         {
                                             CFilesWindow* activePanel = MainWindow->GetActivePanel();
                                             if (activePanel != NULL && activePanel->Is(ptDisk))
-                                            { // otevreni Pack dialogu
+                                            { // open the Pack dialog
                                                 MainWindow->CancelPanelsUI();
                                                 activePanel->UserWorkedOnThisPath = TRUE;
-                                                activePanel->StoreSelection(); // ulozime selection pro prikaz Restore Selection
+                                                activePanel->StoreSelection(); // Store the selection for the Restore Selection command.
                                                 activePanel->Pack(MainWindow->GetNonActivePanel(), pluginIndex,
                                                                   data->Name, data->PackDlgDelFilesAfterPacking);
                                             }
@@ -4599,10 +4606,10 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                             {
                                                 CFilesWindow* activePanel = MainWindow->GetActivePanel();
                                                 if (activePanel != NULL && activePanel->Is(ptDisk))
-                                                { // otevreni Unpack dialogu
+                                                { // opening the Unpack dialog
                                                     MainWindow->CancelPanelsUI();
                                                     activePanel->UserWorkedOnThisPath = TRUE;
-                                                    activePanel->StoreSelection(); // ulozime selection pro prikaz Restore Selection
+                                                    activePanel->StoreSelection(); // Save the selection for the Restore Selection command
                                                     activePanel->Unpack(MainWindow->GetNonActivePanel(), pluginIndex,
                                                                         data->Name, data->UnpackDlgUnpackMask);
                                                 }
@@ -4614,16 +4621,16 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
                                                 data->UnpackDlgUnpackMask = NULL;
                                             }
                                         }
-                                        if (MainWindow != NULL && MainWindow->CanClose) // konec otevirani Pack/Unpack dialogu
-                                        {                                               // je-li Salamander nastartovany, muzeme ho prohlasit za NE BUSY
+                                        if (MainWindow != NULL && MainWindow->CanClose) // Pack/Unpack dialog opening has finished.
+                                        {                                               // if Salamander has started up, we can mark it as not busy
                                             SalamanderBusy = FALSE;
                                         }
                                         CannotCloseSalMainWnd = FALSE;
-                                        goto TEST_IDLE; // zkusime znovu "idle" (napr. aby se mohl zpracovat dalsi postnuty prikaz/unload/Pack/Unpack)
+                                        goto TEST_IDLE; // try idle again (e.g. so another posted command, unload, or Pack/Unpack request can be processed)
                                     }
                                 }
                                 if (!SalamanderBusy && OpenReadmeInNotepad[0] != 0)
-                                { // spustime notepad se souborem 'OpenReadmeInNotepad' pro instalak pod Vista+
+                                { // Vista+: for the installer, launch Notepad with the file path stored in OpenReadmeInNotepad
                                     StartNotepad(OpenReadmeInNotepad);
                                     OpenReadmeInNotepad[0] = 0;
                                 }
@@ -4643,35 +4650,35 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     else
         TRACE_E("Unable to register main window class.");
 
-    // pro pripad chyby zkusim zavrit dialog
+    // try to close the dialog if an error occurs
     SplashScreenCloseIfExist();
 
-    // vratime prioritu do puvodniho stavu
+    // restore the thread priority to its original setting
     SetThreadPriority(GetCurrentThread(), THREAD_PRIORITY_NORMAL);
 
-    //--- vsem oknum dame 1 sekundu na to, aby se uzavreli, pak je nechame odpojit
+    //--- give all windows 1 second to close, then let them detach
     int timeOut = 10;
     int winsCount = WindowsManager.GetCount();
     while (timeOut-- && winsCount > 0)
     {
         Sleep(100);
         int c = WindowsManager.GetCount();
-        if (winsCount > c) // zatim jeste ubyvaji okna, budeme cekat dale aspon 1 sekundu
+        if (winsCount > c) // Window count is still decreasing, so wait at least 1 more second.
         {
             winsCount = c;
             timeOut = 10;
         }
     }
 
-//--- informace
+//--- information
 #ifdef __DEBUG_WINLIB
     TRACE_I("WindowsManager: " << WindowsManager.maxWndCount << " windows, " << WindowsManager.search << " searches, " << WindowsManager.cache << " cached searches.");
 #endif
     //---
-    DestroySafeWaitWindow(TRUE); // povel "terminate" safe-wait-message threadu
-    Sleep(1000);                 // nechame vsem threadum viewru cas, aby se ukoncili
-    NBWNetAC3Thread.Close(TRUE); // bezici thread nechame zabit (presun do AuxThreads), dalsi akce zablokujeme
-    TerminateAuxThreads();       // zbytek nasilne terminujeme
+    DestroySafeWaitWindow(TRUE); // send the "terminate" command to the safe-wait-message thread
+    Sleep(1000);                 // give all viewer threads time to shut down
+    NBWNetAC3Thread.Close(TRUE); // Let shutdown kill any still-running thread by moving it to AuxThreads, and block further actions.
+    TerminateAuxThreads();       // forcibly terminate the rest
                                  //---
     TerminateThread();
     ReleaseFileNamesEnumForViewers();
@@ -4691,7 +4698,7 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     HANDLES(FreeLibrary(HLanguage));
     HLanguage = NULL;
 
-    // pro jistotu zavreme az jako posledni, ale asi zbytecne obavy
+    // just to be safe, close it last, though that's probably unnecessary caution
     ReleaseSalOpen();
 
     if (NtDLL != NULL)
@@ -4706,9 +4713,9 @@ MENU_TEMPLATE_ITEM MsgBoxButtons[] =
     }
 
     //OleSpyStressTest(); // multi-threaded stress test
-    // OleSpyRevoke();     // odpojime OLESPY
-    OleUninitialize(); // deinicializace OLE
-    // OleSpyDump();       // vypiseme leaky
+    // OleSpyRevoke();     // detach OLESPY
+    OleUninitialize(); // Uninitialize OLE
+    // OleSpyDump();       // dump leaks
 
     TRACE_I("End");
     return 0;
@@ -4735,7 +4742,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, int cmdShow
     {
         TRACE_I("Thread Main: calling ExitProcess(1).");
         //    ExitProcess(1);
-        TerminateProcess(GetCurrentProcess(), 1); // tvrdsi exit (tenhle jeste neco vola)
+        TerminateProcess(GetCurrentProcess(), 1); // more forceful exit
         return 1;
     }
 #endif // CALLSTK_DISABLE


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salamdr1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 398 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 651 comment units, 651 review results, 651 resolved results, and 651 apply results.
- Branch-target comment guard passed for `src/salamdr1.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/salamdr1.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 48035 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 21316 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 5 calls, 26719 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
