### PR TITLE
[translation] Fix src/plugins/shared/spl_menu.h comments

### DIFF
--- a/src/plugins/shared/spl_menu.h
+++ b/src/plugins/shared/spl_menu.h
@@ -33,13 +33,13 @@ class CSalamanderForOperationsAbstract;
 class CSalamanderBuildMenuAbstract
 {
 public:
-    // ikony se zadavaji metodou CSalamanderBuildMenuAbstract::SetIconListForMenu, zbytek
-    // popisu viz CSalamanderConnectAbstract::AddMenuItem
+    // icons are provided through CSalamanderBuildMenuAbstract::SetIconListForMenu; for the
+    // rest of the description, see CSalamanderConnectAbstract::AddMenuItem
     virtual void WINAPI AddMenuItem(int iconIndex, const char* name, DWORD hotKey, int id, BOOL callGetState,
                                     DWORD state_or, DWORD state_and, DWORD skillLevel) = 0;
 
-    // ikony se zadavaji metodou CSalamanderBuildMenuAbstract::SetIconListForMenu, zbytek
-    // popisu viz CSalamanderConnectAbstract::AddSubmenuStart
+    // icons are provided through CSalamanderBuildMenuAbstract::SetIconListForMenu; for the
+    // rest of the description, see CSalamanderConnectAbstract::AddSubmenuStart
     virtual void WINAPI AddSubmenuStart(int iconIndex, const char* name, int id, BOOL callGetState,
                                         DWORD state_or, DWORD state_and, DWORD skillLevel) = 0;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_menu.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks.

## Model
OpenAI GPT-5.4

## Verification
- `node --experimental-strip-types scripts/check-czech-comment-residue.ts --file /mnt/d/Source/OpenSal/salamander_janrysavy/src/plugins/shared/spl_menu.h --audit-exe /mnt/d/Source/OpenSal/salamander_upstream/tools/.venv/bin/comment-find-czech-words` reports `OK ... comments=25`.
- A `clang-format` comparison produced no formatting delta for `src/plugins/shared/spl_menu.h`.
- The final `git diff` review confirms the branch changes only comment text in `src/plugins/shared/spl_menu.h`.
- The delivered file retains `// CommentsTranslationProject: TRANSLATED` and no longer contains real Czech comment residue.

## Telemetry
- Provider-backed review stages were not used for this manual cleanup.
- Codex-family calls: 0; estimated tokens: 0.
- Copilot request units: 0.