### PR TITLE
[translation] Fix src/fileswn4.cpp comments

### DIFF
--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -1844,29 +1844,29 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
             out0Len = 0;
         }
 
-        // vnejsi obdelnik, od ktereho mazu smerem k vnitrnimu
+        // outer rectangle from which I erase toward the inner one
         RECT outerRect = rect;
         outerRect.left += TILE_LEFT_MARGIN + IconSizes[iconSize];
 
         //int oldRTop = r.top;
 
-        // vnitrni obdelnik, ke kterememu mazu
+        // inner rectangle toward which I erase
         RECT r;
         r.left = outerRect.left + 2;
         r.right = r.left + 2 + widthNeeded + 2 + 1;
 
-        int visibleLines = 1; // nazev je viditelny urcite
+        int visibleLines = 1; // the name is definitely visible
         if (out1[0] != 0)
             visibleLines++;
         if (out2[0] != 0)
             visibleLines++;
         int textH = visibleLines * FontCharHeight + 4;
         int textX = r.left + 2;
-        int textY = rect.top + (rect.bottom - rect.top - textH) / 2; // centrujeme
+        int textY = rect.top + (rect.bottom - rect.top - textH) / 2; // center vertically
 
         r.top = textY;
         r.bottom = textY + textH;
-        RECT focusR = r; // zazalohujeme pro kresleni focusu
+        RECT focusR = r; // save for focus-frame drawing
 
         if (drawFocusFrame)
         {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunks.

## Model
OpenAI GPT-5.4

## Verification
- `node --experimental-strip-types scripts/check-czech-comment-residue.ts --file /mnt/d/Source/OpenSal/salamander_janrysavy/src/fileswn4.cpp --audit-exe /mnt/d/Source/OpenSal/salamander_upstream/tools/.venv/bin/comment-find-czech-words` reports `OK ... comments=270`.
- A `clang-format` comparison produced no formatting delta for `src/fileswn4.cpp`.
- The final `git diff` review confirms the branch changes only comment text in `src/fileswn4.cpp`.
- The delivered file retains comment-only behavior and no longer contains real Czech comment residue.

## Telemetry
- Provider-backed review stages were not used for this manual cleanup.
- Codex-family calls: 0; estimated tokens: 0.
- Copilot request units: 0.