### PR TITLE
[translation] Fix src/drivelst.cpp comments

### DIFF
--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -923,8 +923,8 @@ BOOL CheckAndConnectUNCNetworkPath(HWND parent, const char* UNCPath, BOOL& pathI
 }
 
 // ****************************************************************************
-// tenhle kod je vzaty z Knowledge Base a slouzi k ziskani informaci o typu media
-// floppy mechaniky (3.5", 5.25", 8")
+// this code is taken from the Knowledge Base and is used to obtain information about the media type
+// of floppy drives (3.5", 5.25", 8")
 
 /*
   GetDriveFormFactor returns the drive form factor.
@@ -1073,7 +1073,7 @@ CDrivesList::CDrivesList(CFilesWindow* filesWindow, const char* currentPath,
     CachedDrivesMask = 0;
     CachedCloudStoragesMask = 0;
 
-    // standardne nejde o post-cmd, proto nulujeme
+    // this is normally not a post-command, so clear it
     *PostCmd = 0;
     *PostCmdParam = NULL;
     *FromContextMenu = FALSE;
@@ -1658,7 +1658,7 @@ BOOL CDrivesList::BuildData(BOOL noTimeout, TDirectArray<CDriveData>* copyDrives
     else
     {
         // remembered and not refreshed network drives will not be returned from GetLogicalDrives()
-        DWORD netDrives; // bitove pole network disku
+        DWORD netDrives; // bit array of network drives
         char netRemotePath['z' - 'a' + 1][MAX_PATH];
         GetNetworkDrives(netDrives, netRemotePath);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/drivelst.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks.

## Model
OpenAI GPT-5.4

## Verification
- `node --experimental-strip-types scripts/check-czech-comment-residue.ts --file /mnt/d/Source/OpenSal/salamander_janrysavy/src/drivelst.cpp --audit-exe /mnt/d/Source/OpenSal/salamander_upstream/tools/.venv/bin/comment-find-czech-words` reports `OK ... comments=332`.
- A `clang-format` comparison produced no formatting delta for `src/drivelst.cpp`.
- The final `git diff` review confirms the branch changes only comment text in `src/drivelst.cpp`.
- The delivered file retains comment-only behavior and no longer contains real Czech comment residue.

## Telemetry
- Provider-backed review stages were not used for this manual cleanup.
- Codex-family calls: 0; estimated tokens: 0.
- Copilot request units: 0.