### PR TITLE
[translation] Fix src/plugins/shared/lukas/lcutils.h comments

### DIFF
--- a/src/plugins/shared/lukas/lcutils.h
+++ b/src/plugins/shared/lukas/lcutils.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-// menu item skill level ALL (zahrnuje beginned, intermediate a advanced)
+// menu item skill level ALL (includes beginner, intermediate, and advanced)
 #define MNTS_ALL (MNTS_B | MNTS_I | MNTS_A)
 
 #ifndef QWORD
@@ -115,8 +115,8 @@ public:
 
 // ****************************************************************************
 //
-// CDialogEx -- automaticky centrovany dialog, automaticky pridava a odebira
-// HWND do/z DialogStack
+// CDialogEx -- automatically centered dialog, automatically adds and removes
+// HWND to/from DialogStack
 //
 
 class CDialogEx : public CDialog


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/lcutils.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks.

## Model
OpenAI GPT-5.4

## Verification
- `node --experimental-strip-types scripts/check-czech-comment-residue.ts --file /mnt/d/Source/OpenSal/salamander_janrysavy/src/plugins/shared/lukas/lcutils.h --audit-exe /mnt/d/Source/OpenSal/salamander_upstream/tools/.venv/bin/comment-find-czech-words` reports `OK ... comments=18`.
- A `clang-format` comparison produced no formatting delta for `src/plugins/shared/lukas/lcutils.h`.
- The final `git diff` review confirms the branch changes only comment text in `src/plugins/shared/lukas/lcutils.h`.
- The delivered file retains `// CommentsTranslationProject: TRANSLATED` and no longer contains real Czech comment residue.

## Telemetry
- Provider-backed review stages were not used for this manual cleanup.
- Codex-family calls: 0; estimated tokens: 0.
- Copilot request units: 0.