### PR TITLE
[translation] Fix src/common/trace.cpp comments

### DIFF
--- a/src/common/trace.cpp
+++ b/src/common/trace.cpp
@@ -494,7 +494,7 @@ BOOL C__Trace::Connect(BOOL onUserRequest)
         // try to open the mutex for access to the shared memory
         HANDLE hOpenConnectionMutex;
         hOpenConnectionMutex = OpenMutex(/*MUTEX_ALL_ACCESS*/ SYNCHRONIZE, FALSE, __OPEN_CONNECTION_MUTEX);
-        if (hOpenConnectionMutex != NULL) // server available
+        if (hOpenConnectionMutex != NULL) // server found
         {
             // acquire ConnectionMutex
             DWORD waitRet;
@@ -1150,7 +1150,7 @@ C__Trace::SendMessageToServer(C__MessageType type, BOOL crash)
             if (msgBoxOpened)
             {
                 while (1)
-                    Sleep(1000); // blokace vede na deadlock napr. kdyz je (a nema byt) TRACE_C v DLL_THREAD_DETACH
+                    Sleep(1000); // Blocking causes a deadlock, for example if TRACE_C is used in DLL_THREAD_DETACH, where it must not be.
             }
         }
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/trace.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 178 comment units, 178 review results, 178 resolved results, and 178 apply results.
- Branch-target comment guard passed for `src/common/trace.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/trace.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 8 provider calls, 161109 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 4 calls, 76992 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 4 calls, 84117 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
