### PR TITLE
[translation] Fix src/plugins/checksum/checksum.rh2 comments

### DIFF
--- a/src/plugins/checksum/checksum.rh2
+++ b/src/plugins/checksum/checksum.rh2
@@ -1,4 +1,5 @@
-﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+﻿// CommentsTranslationProject: TRANSLATED
+// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __CHECKSUM_RH2
 #define __CHECKSUM_RH2
 
@@ -86,17 +87,17 @@
 
 
 #define IDC_CFG_SUM_1                   100
-//#define IDC_CFG_CRC                     IDC_CFG_SUM_1  // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_CRC                     IDC_CFG_SUM_1  // this form will not compile in HTML Help Compiler
 #define IDC_CFG_CRC                     100
-//#define IDC_CFG_MD5                     (IDC_CFG_CRC+1) // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_MD5                     (IDC_CFG_CRC+1) // this form won't compile in HTML Help Compiler
 #define IDC_CFG_MD5                     101
-//#define IDC_CFG_SHA1                    (IDC_CFG_MD5+1) // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_SHA1                    (IDC_CFG_MD5+1) // HTML Help Compiler won't compile this form
 #define IDC_CFG_SHA1                    102
-//#define IDC_CFG_SHA256                  (IDC_CFG_SHA1+1) // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_SHA256                  (IDC_CFG_SHA1+1) // HTML Help Compiler won't compile this form
 #define IDC_CFG_SHA256                  103
-//#define IDC_CFG_SHA512                  (IDC_CFG_SHA256+1) // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_SHA512                  (IDC_CFG_SHA256+1) // HTML Help Compiler won't compile this form
 #define IDC_CFG_SHA512                  104
-//#define IDC_CFG_SUM_COUNT               (IDC_CFG_SHA512+1) // tenhle zapis nezkompiluje HTML Help Compiler
+//#define IDC_CFG_SUM_COUNT               (IDC_CFG_SHA512+1) // this form won't compile in HTML Help Compiler
 #define IDC_CFG_SUM_COUNT               105
 
 #endif // __CHECKSUM_RH2


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/checksum/checksum.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 7 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 14 comment units, 14 review results, 14 resolved results, and 14 apply results.
- Branch-target comment guard passed for `src/plugins/checksum/checksum.rh2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/checksum/checksum.rh2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 128281 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 43262 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 7 calls, 85019 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
