### PR TITLE
[translation] Fix src/plugins/regedt/regedt.rh2 comments

### DIFF
--- a/src/plugins/regedt/regedt.rh2
+++ b/src/plugins/regedt/regedt.rh2
@@ -1,4 +1,5 @@
-﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+﻿// CommentsTranslationProject: TRANSLATED
+// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __REGEDT_RH2
 #define __REGEDT_RH2
 
@@ -7,7 +8,7 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define IDC_STATIC_1 700
-#include "statics.rh2"   // 700 az 739 jsou timto zabrane !!!
+#include "statics.rh2"   // 700 to 739 are reserved by this include.
 
 #define IDI_REGEDT 500
 #define IDI_SZ 501
@@ -16,7 +17,7 @@
 #define IDI_FIND  504
 #define IDB_REGEDT 505
 
-// menu commandy
+// menu commands
 #define CMD_EXPORT  800
 #define CMD_SEARCH  801
 #define CMD_NEWVALUE  802
@@ -183,7 +184,7 @@
 #define IDS_EXP_BROWSE 1164
 #define IDS_EXP_SALDIR 1165
 
-// IDcka pro propojeni s helpem
+// IDs for linking to Help
 #define IDH_SEARCHREG  1500
 #define IDH_NEWKEY     1501
 #define IDH_NEWVALUE   1502


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/regedt/regedt.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 6 comment units, 6 review results, 6 resolved results, and 6 apply results.
- Branch-target comment guard passed for `src/plugins/regedt/regedt.rh2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/regedt/regedt.rh2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 43230 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 42236 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 994 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
