### PR TITLE
[translation] Fix src/plugins/unmime/unmime.rh2 comments

### DIFF
--- a/src/plugins/unmime/unmime.rh2
+++ b/src/plugins/unmime/unmime.rh2
@@ -1,4 +1,5 @@
-﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+﻿// CommentsTranslationProject: TRANSLATED
+// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __UNMIME_RH2
 #define __UNMIME_RH2
 
@@ -7,11 +8,11 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define IDC_STATIC_1 2000
-#include "statics.rh2"   // 2000 az 2039 jsou timto zabrane !!!
+#include "statics.rh2"   // 2000 to 2039 are reserved by this include.
 
 // ********************************************************************************
 //
-//  TEXTY
+//  STRINGS
 //
 
 #define IDS_PLUGINNAME                  1


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/unmime.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 5 comment units, 5 review results, 5 resolved results, and 5 apply results.
- Branch-target comment guard passed for `src/plugins/unmime/unmime.rh2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/unmime/unmime.rh2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 2 provider calls, 22341 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 21052 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 1 call, 1289 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
