### PR TITLE
[translation] Fix src/plugins/pictview/pvw32cnv.rh2 comments

### DIFF
--- a/src/plugins/pictview/pvw32cnv.rh2
+++ b/src/plugins/pictview/pvw32cnv.rh2
@@ -1,6 +1,7 @@
-﻿// Petr: tento soubor existuje jen pro generovani symbols\plugins\pictview\symbols.inc davkou tools\export_translator\export_inc.py
+﻿// CommentsTranslationProject: TRANSLATED
+// Petr: this file exists only to generate symbols\plugins\pictview\symbols.inc using tools\export_translator\export_inc.py
 
-// Petr: pridal jsem IDS_PVW32Cnv_XXXX, aby nervala quiet-validace v Translatoru
+// Petr: I added IDS_PVW32Cnv_XXXX so the quiet validation in Translator wouldn't complain.
 #define IDS_PVW32Cnv_4003          4003
 #define IDS_PVW32Cnv_4004          4004
 #define IDS_PVW32Cnv_4006          4006


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/pictview/pvw32cnv.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 2 comment units, 2 review results, 2 resolved results, and 2 apply results.
- Branch-target comment guard passed for `src/plugins/pictview/pvw32cnv.rh2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/pictview/pvw32cnv.rh2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 3 provider calls, 62533 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 21750 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 40783 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
