### PR TITLE
[translation] Fix src/texts.rh2 comments

### DIFF
--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -1,4 +1,5 @@
-﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+﻿// CommentsTranslationProject: TRANSLATED
+// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
 #ifndef __TEXTS_RH2
 #define __TEXTS_RH2
 
@@ -1078,7 +1079,7 @@
 #define IDS_BUTTON_CONTINUE           10847
 #define IDS_BUTTON_YES                10848
 #define IDS_BUTTON_NO                 10849
-// nechat jeste par polozek rezervu
+// keep a few items reserved
 
 #define IDS_ESCAPE                    10860
 #define IDS_F11                       10861
@@ -1182,7 +1183,7 @@
 #define IDS_BROWSEONERRGOTOTITLE      10950
 // Configuration: Drives: text of Browse (...) path window: Select the path you want to visit when current path in panel is inaccessible
 #define IDS_BROWSEONERRGOTOTEXT       10951
-// 10952 je uz pouzite
+// 10952 is already used
 
 // Error Opening Alternate Data Stream dialog: second item in menu on Ignore button: Ignore &All
 #define IDS_ERROPENADS_IGNOREALL      10955
@@ -1339,7 +1340,7 @@
 #define IDS_PACK_EXE_UZP16           11067
 #define IDS_PACK_EXE_BROWSE          11068
 
-// 11070 je zabrany pro IDS_PACKRET_BREAK2
+// 11070 is reserved for IDS_PACKRET_BREAK2
 
 #define IDS_PACKQRY_PREFIX           11101
 // User query, whether discard root dir in archive while compressing
@@ -1562,7 +1563,7 @@
 // plugins manager/test all: all plugins seem to work correctly
 #define IDS_PLUGINTESTALLOK          12108
 
-// 12109 je zabrane !!!
+// 12109 is reserved !!!
 
 // plugins manager/column name
 #define IDS_PLUGINS_NAME             12110
@@ -1702,7 +1703,7 @@
 // There are no items in this panel.
 #define IDS_NOITEMSINPANEL           12233
 
-// text, ktery je pridan ke jmenu plug-inu, aby zvyraznil ze jde o plug-in - " (Plug-in)"
+// text appended to the plug-in name to highlight that it is a plug-in - " (Plug-in)"
 #define IDS_PLUGINSUFFIX             12235
 
 // task list dialog: You cannot break this task. Use another


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/texts.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 6 comment units, 6 review results, 6 resolved results, and 6 apply results.
- Branch-target comment guard passed for `src/texts.rh2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/texts.rh2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
