### PR TITLE
[translation] Fix src/plugins/winscp/copy-to-petr-pc.bat comments

### DIFF
--- a/src/plugins/winscp/copy-to-petr-pc.bat
+++ b/src/plugins/winscp/copy-to-petr-pc.bat
@@ -1,3 +1,4 @@
+@rem CommentsTranslationProject: TRANSLATED
 @echo off
 call :langcopy_bat english
 call :langcopy_bat czech
@@ -24,7 +25,7 @@ for %%v in (vc2019) do (
 exit /b
 
 
-rem ---------------------------- Copy rutina pro jazyky
+rem ---------------------------- Copy routine for languages
 
 :langcopy_bat
 
@@ -40,7 +41,7 @@ for %%v in (vc2019) do (
 exit /b
 
 
-rem ---------------------------- Copy rutina
+rem ---------------------------- Copy routine
 
 :mycopy_bat
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/winscp/copy-to-petr-pc.bat`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 2 comment units, 2 review results, 2 resolved results, and 2 apply results.
- Branch-target comment guard passed for `src/plugins/winscp/copy-to-petr-pc.bat` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/winscp/copy-to-petr-pc.bat` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
