### PR TITLE
[translation] Fix src/plugins/ftp/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/ftp/help/hh/salamander_help_shared.css
+++ b/src/plugins/ftp/help/hh/salamander_help_shared.css
@@ -1,3 +1,4 @@
+/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 
@@ -206,14 +207,14 @@
 
 #help_page td.hdr
 {
-  /* tmavsi seda na leve strane */
+  /* darker gray on the left side */
   margin: .25em;
   background: #dddddd;
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* zuzime levou stranu tabulky na minimum */
-  padding-right :10px;  /* ale nechame tam alespon 10 bodu, at to trochu vypada */
+  width: 10%;           /* narrow the left side of the table to the minimum */
+  padding-right :10px;  /* but keep at least 10 points there so it still looks decent */
   white-space: nowrap;
 }
 
@@ -322,4 +323,3 @@
   padding-left: 4px;
   text-align: left;
 }
-


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 3 comment units, 3 review results, 3 resolved results, and 3 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/help/hh/salamander_help_shared.css` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/ftp/help/hh/salamander_help_shared.css` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
