### PR TITLE
[translation] Fix src/lang/lang.rc2 comments

### DIFF
--- a/src/lang/lang.rc2
+++ b/src/lang/lang.rc2
@@ -1,4 +1,5 @@
-﻿//
+﻿// CommentsTranslationProject: TRANSLATED
+//
 // lang.rc2 - resources Microsoft Visual C++ does not edit directly
 //
 
@@ -35,7 +36,7 @@ IDM_VIEWERMENU MENU
   MENUITEM "&Refresh\tCtrl+R", CM_REREADFILE
   MENUITEM SEPARATOR
   
-// POZOR: pokud se zmeni index tohoto submenu, je potreba zmenit VIEWER_FILE_MENU_OTHFILESINDEX
+// WARNING: if the index of this submenu changes, VIEWER_FILE_MENU_OTHFILESINDEX must also be updated
   POPUP "Ot&her Files"
   {
    MENUITEM "&Previous\tBackspace", CM_PREVFILE


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/lang/lang.rc2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment unit in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/lang/lang.rc2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/lang/lang.rc2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
