### PR TITLE
[translation] Fix src/plugins/undelete/library/volenum.cpp comments

### DIFF
--- a/src/plugins/undelete/library/volenum.cpp
+++ b/src/plugins/undelete/library/volenum.cpp
@@ -1,5 +1,6 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "..\undelete.rh2"
@@ -73,7 +74,7 @@ BOOL GetDiskFreeSpace95(const char* path, LPDWORD lpSectorsPerCluster,
             memset(&gdfs, 0, sizeof(gdfs));
             gdfs.ExtFree_Level = 0; // required
 
-            reg.reg_EBX = 0;                      // jen tak pro formu
+            reg.reg_EBX = 0;                      // just for completeness
             reg.reg_EDX = (DWORD)(DWORD_PTR)path; // type cast is OK, we will not run it on x64
             reg.reg_ECX = sizeof(gdfs);
             reg.reg_EDI = (DWORD)(DWORD_PTR)&gdfs; // type cast is OK, we will not run it on x64


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/volenum.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/plugins/undelete/library/volenum.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/undelete/library/volenum.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
