### PR TITLE
[translation] Fix src/plugins/zip/common.h comments

### DIFF
--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -168,7 +168,7 @@ public:
     CEOCentrDirRecordEx EOCentrDir; //end of central directory record
     QWORD CentrDirSize;
     QWORD CentrDirOffs;
-    int CentrDirStartDisk; //jen pro list a extract
+    int CentrDirStartDisk; //only for list and extract
                            // number of the disk with the start of the central directory
     bool Zip64;
     QWORD ExtraBytes;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/common.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment unit in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/plugins/zip/common.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/common.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
