### PR TITLE
[translation] Fix src/plugins/shared/spl_fs.h comments

### DIFF
--- a/src/plugins/shared/spl_fs.h
+++ b/src/plugins/shared/spl_fs.h
@@ -347,8 +347,8 @@ public:
     // receives information about a change on path 'path' (if 'includingSubdirs' is TRUE, it
     // also includes changes in subdirectories of path 'path'); this method should decide
     // whether this FS needs to be refreshed (for example via method
-    // CSalamanderGeneralAbstract::PostRefreshPanelFS); tyka se jak aktivnich FS, tak
-    // detached FSs; 'fsName' is the current FS name
+    // CSalamanderGeneralAbstract::PostRefreshPanelFS); this applies to both active
+    // FSs and detached FSs; 'fsName' is the current FS name
     // NOTE: for the plugin as a whole, there is also the method
     //           CPluginInterfaceAbstract::AcceptChangeOnPathNotification()
     virtual void WINAPI AcceptChangeOnPathNotification(const char* fsName, const char* path,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_fs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment unit in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/plugins/shared/spl_fs.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_fs.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
