### PR TITLE
[translation] Fix tools/salbreak/salbreak.h comments

### DIFF
--- a/tools/salbreak/salbreak.h
+++ b/tools/salbreak/salbreak.h
@@ -1,28 +1,33 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
-// vrati SID (jako retezec) pro nas proces
-// vraceny SID je potreba uvolnit pomoci volani LocalFree
+// returns the SID (as a string) for the current process
+// the returned SID must be freed by calling LocalFree
 //   LPTSTR sid;
 //   if (GetStringSid(&sid))
 //     LocalFree(sid);
 BOOL GetStringSid(LPTSTR* stringSid);
 
-// vrati MD5 hash napocitany ze SID, cimz dostavame z variable-length SIDu pole 16 bajtu
-// 'sidMD5' musi ukazovat do pole 16 bajtu
-// v pripade uspechu vraci TRUE, jinak FALSE a nuluje cele pole 'sidMD5'
+// returns the MD5 hash computed from the SID, which gives us a 16-byte array
+// from the variable-length SID
+// 'sidMD5' must point to a 16-byte array
+// returns TRUE on success; otherwise returns FALSE and zeroes the entire 'sidMD5' array
 BOOL GetSidMD5(BYTE* sidMD5);
 
-// pripravi SECURITY_ATTRIBUTES tak aby pomoci nich vytvareny objekt (mutex, mapovana pamet) byl zabezpecny
-// znamena to, ze skupine Everyone je odebran pristup WRITE_DAC | WRITE_OWNER, jinak je vse povoleno
-// jde o tridu lepsi zabezpecni nez "NULL DACL", kde je objekt uplne otevren vsem
-// lze volat pod kazdym OS, ukazatel vrati od W2K vejs, jinak vraci NULL
-// pokud vrati 'psidEveryone' nebo 'paclNewDacl' ruzne od NULL, je treba je destruovat
+// prepares SECURITY_ATTRIBUTES so that an object created with them (mutex,
+// mapped memory) is secured
+// this means the Everyone group is denied WRITE_DAC | WRITE_OWNER access;
+// everything else is allowed
+// this is a class of security better than a "NULL DACL", where the object is
+// completely open to everyone
+// can be called on any OS; returns the pointer on W2K and later, otherwise NULL
+// if it returns 'psidEveryone' or 'paclNewDacl' different from NULL, they must be destroyed
 SECURITY_ATTRIBUTES* CreateAccessableSecurityAttributes(SECURITY_ATTRIBUTES* sa, SECURITY_DESCRIPTOR* sd,
                                                         DWORD allowedAccessMask, PSID* psidEveryone, PACL* paclNewDacl);
 
-// V pripade uspechu vrati TRUE a naplni DWORD na ktery odkazuje 'integrityLevel'
-// jinak (pri selhani nebo pod OS strasima nez Vista) vrati FALSE
+// returns TRUE on success and fills the DWORD pointed to by 'integrityLevel'
+// otherwise (on failure or on OSes older than Vista) returns FALSE
 BOOL GetProcessIntegrityLevel(DWORD* integrityLevel);


### PR DESCRIPTION
## Summary
- Refines translated comments in `tools/salbreak/salbreak.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 4 comment units, 4 review results, 4 resolved results, and 4 apply results.
- Branch-target comment guard passed for `tools/salbreak/salbreak.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- tools/salbreak/salbreak.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
