### PR TITLE
[translation] Fix tools/salbreak/tasklist.h comments

### DIFF
--- a/tools/salbreak/tasklist.h
+++ b/tools/salbreak/tasklist.h
@@ -1,49 +1,51 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
+// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 
 //
 // ****************************************************************************
 
-// TRUE = prvni bezici instance verze 3.0 nebo novejsi
-// urcuje se na zaklade mutexu v globalnim namespace, takze se vidi s mutexty
-// z ostatnich sessions (remote desktop, fast user switching)
+// TRUE = the first running instance of version 3.0 or newer
+// determined based on a mutex in the global namespace, so it is visible together
+// with mutexes from other sessions (remote desktop, fast user switching)
 extern BOOL FirstInstance_3_or_later;
 
-// sdilena pamet obsahuje:
-//  DWORD                  - PID procesu, ktery se ma breaknout
-//  DWORD                  - pocet polozek v listu
-//  MAX_TL_ITEMS * CTLItem - list polozek
+// shared memory contains:
+//  DWORD                  - PID of the process that should be broken
+//  DWORD                  - number of items in the list
+//  MAX_TL_ITEMS * CTLItem - item list
 
-#define MAX_TL_ITEMS 500 // maximalni pocet polozek ve sdilene pameti, nelze menit!
+#define MAX_TL_ITEMS 500 // maximum number of items in shared memory, cannot be changed!
 
-#define TASKLIST_TODO_HIGHLIGHT 1 // okno procesu daneho v 'PID' se ma vysvitit
-#define TASKLIST_TODO_BREAK 2     // proces dany v 'PID' se ma breaknout
-#define TASKLIST_TODO_TERMINATE 3 // proces dany v 'PID' se ma terminovat
-#define TASKLIST_TODO_ACTIVATE 4  // proces dany v 'PID' se ma aktivovat
+#define TASKLIST_TODO_HIGHLIGHT 1 // the window of the process given in 'PID' should be highlighted
+#define TASKLIST_TODO_BREAK 2     // the process given in 'PID' should be broken
+#define TASKLIST_TODO_TERMINATE 3 // the process given in 'PID' should be terminated
+#define TASKLIST_TODO_ACTIVATE 4  // the process given in 'PID' should be activated
 
-#define TASKLIST_TODO_TIMEOUT 5000 // 5 vterin, ktere maji procesy pro zpracovani todo
+#define TASKLIST_TODO_TIMEOUT 5000 // 5 seconds that processes have to handle todo
 
-#define PROCESS_STATE_STARTING 1 // nas proces startuje, jeste neexistuje hlavni okno
-#define PROCESS_STATE_RUNNING 2  // nas proces bezi, mame hlavni okno
-#define PROCESS_STATE_ENDING 3   // nas proces konci, nemame uz hlavni okno
+#define PROCESS_STATE_STARTING 1 // our process is starting, the main window does not exist yet
+#define PROCESS_STATE_RUNNING 2  // our process is running, we have the main window
+#define PROCESS_STATE_ENDING 3   // our process is ending, we no longer have the main window
 
-#pragma pack(push, enter_include_tasklist) // aby byly struktury nezavisle na nastavenem zarovnavani
+#pragma pack(push, enter_include_tasklist) // keep the structures independent of the current packing setting
 #pragma pack(4)
 
 //extern HANDLE HSalmonProcess;
 
-// POZOR, pomoci struktury komunikuji x64 a x86 procesy, pozor na typy (napr. HANDLE), ktere maji ruzne sirky
+// WARNING: x64 and x86 processes communicate through this structure, so watch out
+// for types (for example HANDLE) that have different widths
 struct CProcessListItem
 {
-    DWORD PID;            // ProcessID, unikatni po dobu behu procesu, pak muze byt znovu pouzito
-    SYSTEMTIME StartTime; // Kdy byl proces nastartovan
-    DWORD IntegrityLevel; // Integrity Level procesu, slouzi k rozliseni procesu spustenych na ruzne urovni opravneni
-    BYTE SID_MD5[16];     // MD5 napocitana ze SID procesu, slouzi nam k rozliseni procesu bezicich pod ruznymi uzivateli; SID ma neznamou delku, proto tato obezlicka
-    DWORD ProcessState;   // Stav v jakem se Salamander nachazi, viz PROCESS_STATE_xxx
-    UINT64 HMainWindow;   // (x64 friendly) Handle hlavniho okna, pokud jiz/jeste existuje (nastavuje se pri jeho vytvareni/destrukci)
-    DWORD SalmonPID;      // ProcessID salmonu, aby mu brakujici proces mohl garantovat pravo pro SetForegroundWindow
+    DWORD PID;            // ProcessID, unique for the lifetime of the process, then it may be reused
+    SYSTEMTIME StartTime; // when the process was started
+    DWORD IntegrityLevel; // process Integrity Level, used to distinguish processes running with different privilege levels
+    BYTE SID_MD5[16];     // MD5 computed from the process SID, used to distinguish processes running under different users; the SID has unknown length, hence this workaround
+    DWORD ProcessState;   // state Salamander is currently in, see PROCESS_STATE_xxx
+    UINT64 HMainWindow;   // (x64 friendly) handle of the main window, if it already/still exists (set when it is created/destroyed)
+    DWORD SalmonPID;      // Salmon ProcessID, so the breaking process can grant it the SetForegroundWindow right
 
     CProcessListItem()
     {
@@ -55,27 +57,27 @@ struct CProcessListItem
         HMainWindow = NULL;
         SalmonPID = 0;
         //    if (HSalmonProcess != NULL)
-        //      SalmonPID = GetProcessId(HSalmonProcess); // v tuto dobu jiz Salmon bezi
+        //      SalmonPID = GetProcessId(HSalmonProcess); // Salmon is already running at this point
     }
 };
 
 // Open Salamander Process List
-// !!! POZOR, ke strukture lze pouze pridavat polozky, protoze na ni chodi i starsi verze Salamandera
+// !!! WARNING: items may only be added to this structure, because older Salamander versions also use it
 struct CProcessList
 {
-    DWORD Version; // novejsi verze Salamandera mohou zvysovat 'Version' a zacit vyuzivat promenne ReservedX
+    DWORD Version; // newer Salamander versions may increase 'Version' and start using ReservedX variables
 
-    DWORD ItemsCount;    // pocet validnich polozek v poli Items
-    DWORD ItemsStateUID; // "verze" Items seznamu; zvysuje se s kazdou zmenou; slouzi pro Tasks dialog jako signal, ze se ma refreshnout
+    DWORD ItemsCount;    // number of valid items in the Items array
+    DWORD ItemsStateUID; // "version" of the Items list; increments on every change; used by the Tasks dialog as a signal that it should refresh
     CProcessListItem Items[MAX_TL_ITEMS];
 
-    DWORD Todo;          // urcuje co se ma delat po odpaleni eventu pomoci FireEvent, obsahuje jednu z hodnot TASKLIST_TODO_*
-    DWORD TodoUID;       // poradi zaslaneho pozadavku, pro kazdy dalsi pozadavek ze zvysuje
-    DWORD TodoTimestamp; // GetTickCount() hodnota ze chvile, kdy byl zakladan Todo pozadavek
-    DWORD PID;           // PID, pro ktery se ma provest cinnost z Todo
-                         //CCommandLineParams CommandLineParams;// cesty pro panely a dalsi parametry pro aktivaci
-                         // POZOR, pokud bude potreba rozsirovat tuto strukturu, bylo by rozumne napred rozsirit CCommandLineParams, napriklad
-                         // reservovat nejake NAX_PATH buffery a par DWORDu, pokud bychom chteli predavat nove command line parametry
+    DWORD Todo;          // determines what should be done after the event is triggered via FireEvent; contains one of the TASKLIST_TODO_* values
+    DWORD TodoUID;       // sequence number of the sent request; increments for each further request
+    DWORD TodoTimestamp; // GetTickCount() value from the moment the Todo request was created
+    DWORD PID;           // PID for which the Todo action should be performed
+                         //CCommandLineParams CommandLineParams;// paths for panels and other activation parameters
+                         // WARNING: if this structure ever needs to be extended, it would be sensible to extend CCommandLineParams first, for example
+                         // reserve some MAX_PATH buffers and a few DWORDs if we wanted to pass new command-line parameters
 };
 
 #pragma pack(pop, enter_include_tasklist)
@@ -83,14 +85,14 @@ struct CProcessList
 class CTaskList
 {
 protected:
-    HANDLE FMO;                // file-mapping-object, sdilena pamet
-    CProcessList* ProcessList; // ukazatel do sdilene pameti
-    HANDLE FMOMutex;           // mutex pro reseni pristupu k FMO
-    HANDLE Event;              // event, je-li signaled, mely by se ostatni procesy podivat,
-                               // jestli se nemaji provest cinnost danou v Todo
-    HANDLE EventProcessed;     // pokud jeden z procesu provede cinnost v Todo, nastavi tento
-                               // event na signaled na znameni ridicimu procesu, ze je hotovo
-    BOOL OK;                   // probehla konstrukce o.k.?
+    HANDLE FMO;                // file-mapping object, shared memory
+    CProcessList* ProcessList; // pointer into shared memory
+    HANDLE FMOMutex;           // mutex for synchronizing access to the FMO
+    HANDLE Event;              // if this event is signaled, the other processes should check
+                               // whether they should perform the action given in Todo
+    HANDLE EventProcessed;     // if one of the processes performs the action in Todo, it sets this
+                               // event to signaled to inform the controlling process that it is done
+    BOOL OK;                   // did construction complete successfully?
 
 public:
     CTaskList();
@@ -98,21 +100,21 @@ public:
 
     BOOL Init();
 
-    // naplni polozky task-listu, items - pole alespon MAX_TL_ITEMS struktur CTLItem, vraci pocet polozek
-    // 'items' muze byt NULL, pokud nas zajima pouze 'itemsStateUID'
-    // vrati "verzi" sestavy procesu; verze se zvysuje s kazdou zmenou v seznamu (pokud je pridana nebo odebrana polozka)
-    // slouzi pro dialog jako informace, ze ma refreshnout seznam; 'itemsStateUID' muze byt NULL
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // fills the task-list items; items is an array of at least MAX_TL_ITEMS CTLItem structures; returns the item count
+    // 'items' may be NULL if we are interested only in 'itemsStateUID'
+    // returns the process-list "version"; the version increases with every change in the list (when an item is added or removed)
+    // serves as information for the dialog that it should refresh the list; 'itemsStateUID' may be NULL
+    // if 'timeouted' is not NULL, sets whether the failure was caused by a timeout while waiting for shared memory
     int GetItems(CProcessListItem* items, DWORD* itemsStateUID, BOOL* timeouted = NULL);
 
-    // pozada proces 'pid' o provedeni akce dle 'todo' (mimo TASKLIST_TODO_ACTIVATE)
-    // pokud je 'timeouted' ruzny od NULL, nastavi zda k neuspechu vedl timeout pri cekani na sdilenou pamet
+    // asks process 'pid' to perform the action specified by 'todo' (except TASKLIST_TODO_ACTIVATE)
+    // if 'timeouted' is not NULL, sets whether the failure was caused by a timeout while waiting for shared memory
     BOOL FireEvent(DWORD todo, DWORD pid, BOOL* timeouted = NULL);
 
 protected:
-    // projde seznam procesu a vytridi neexistujici polozky
-    // nutne volat po uspesnem vstupu kriticke sekce 'FMOMutex'!
-    // nastavi 'changed' na TRUE, pokud byla nejaka polozka zahozena, jinak na FALSE
+    // walks the process list and filters out non-existing items
+    // must be called only after successfully entering the 'FMOMutex' critical section!
+    // sets 'changed' to TRUE if some item was discarded, otherwise FALSE
     BOOL RemoveKilledItems(BOOL* changed);
 };
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `tools/salbreak/tasklist.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 5 comment units, 5 review results, 5 resolved results, and 5 apply results.
- Branch-target comment guard passed for `tools/salbreak/tasklist.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- tools/salbreak/tasklist.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
