### PR TITLE
[translation] Fix src/plugins/ftp/servers/path_types.txt comments

### DIFF
--- a/src/plugins/ftp/servers/path_types.txt
+++ b/src/plugins/ftp/servers/path_types.txt
@@ -1,23 +1,25 @@
+CommentsTranslationProject: TRANSLATED
+
 UNIX:
 /pub/d
-d - relativni
+d - relative
 / - root
 
 VMS:
 PUB$DEVICE:[PUB.VMS]
 PUB$DEVICE:[PUB]
 [PUB.VMS]
-PUB$DEVICE:[PUB]FILE.TXT;1 - soubor
-[.VMS] - relativni
+PUB$DEVICE:[PUB]FILE.TXT;1 - file
+[.VMS] - relative
 [000000] - root
 PUB$DEVICE:[000000] - root
-PUB$DEVICE:[PUB.aa^.bb] - "aa^.bb" je jmeno adresare ("^." je escape-sekvence pro '.')
-PUB$DEVICE:[PUB]FI^.LE.TXT;1 - "FI^.LE.TXT;1" je jmeno souboru ("^." je escape-sekvence pro '.')
+PUB$DEVICE:[PUB.aa^.bb] - "aa^.bb" is the directory name ("^." is the escape sequence for '.')
+PUB$DEVICE:[PUB]FI^.LE.TXT;1 - "FI^.LE.TXT;1" is the file name ("^." is the escape sequence for '.')
 
 MVS:
 'VEA0016.MAIN.CLIST'
 'VEA0016.MAIN.CLIST.'
-MAIN.CLIST - relativni
+MAIN.CLIST - relative
 '' - root
 
 NOVELL/WINDOWS-NT:
@@ -25,24 +27,24 @@ NOVELL/WINDOWS-NT:
 /PUB/DIR
 \PUB\DIR\
 /PUB/DIR/
-DIR - relativni
+DIR - relative
 / - root
 \ - root
 
 IBM z/VM (CMS):
 ACADEM:ANONYMOU.PICS
-ACADEM:ANONYMOU. - root (pozor: '.' na konci povinna)
+ACADEM:ANONYMOU. - root (note: the trailing '.' is required)
 
 OS/2:
 C:/dir1/dir2
-dir2 - relativni
+dir2 - relative
 C:/ - root
-(pro sychr pocitame i s backslashem:)
+(for safety we also handle backslashes:)
 C:\dir1\dir2
-dir2 - relativni
+dir2 - relative
 C:\ - root
 
 Tandem:
 \SYSTEM.$VVVVV.SUBVOLUM.FILENAME
-SUBVOLUM - relativni
-\SYSTEM ('\\' + text do prvni tecky) - root cesty
+SUBVOLUM - relative
+\SYSTEM ('\\' + text up to the first dot) - path root


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/servers/path_types.txt`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment unit in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/plugins/ftp/servers/path_types.txt` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/ftp/servers/path_types.txt` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
