### PR TITLE
[translation] Fix src/common/dep/sqlite/readme.txt comments

### DIFF
--- a/src/common/dep/sqlite/readme.txt
+++ b/src/common/dep/sqlite/readme.txt
@@ -1,11 +1,14 @@
-Zdrojaky SQLite z webu http://www.sqlite.org/download.html
-Pouzivame sqlite-amalgamation-*.zip
-Koncepcne bychom meli pro nove verze Salamander pouzivat nejnovejsi verze SQLite, 
-abychom byli schopni cist nejnovejsi binarni verze SQLite databazi.
+CommentsTranslationProject: TRANSLATED
 
-Updatnout:
+SQLite sources are available at http://www.sqlite.org/download.html
+Use sqlite-amalgamation-*.zip.
+Conceptually, new Salamander versions should use the newest SQLite versions
+so we can read the newest binary versions of SQLite databases.
+
+Update:
 salamand\sqlite\sqlite3.c
 salamand\plugins\shared\sqlite\sqlite3.h
 
-Pridat na to-do list:
--otestovat novou verzi SQLite na Google Drive, podivat do TRACE, ze cteme cestu k jeho slozce
+Add to the to-do list:
+- test the new SQLite version on Google Drive and inspect TRACE to confirm that
+  we read the path to its folder


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dep/sqlite/readme.txt`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/common/dep/sqlite/readme.txt` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/dep/sqlite/readme.txt` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
