### PR TITLE
[translation] Fix src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt comments

### DIFF
--- a/src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt
+++ b/src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt
@@ -1,12 +1,14 @@
-Pri prechodu na VC2013 (z VC2008) jsem si dovolil zmenit pro Release a ReleaseEx
-randomizaci adresy modulu (zavedeni randomizace) a tim okamzikem prestalo na
-vygenerovanych sfxsmall.exe a sfxbig.exe fungovat sfxmake.exe a nasledne upx.exe
-(vsechny verze). Takze toto:
+CommentsTranslationProject: TRANSLATED
+
+When moving to VC2013 (from VC2008), I changed address randomization for
+Release and ReleaseEx (enabled randomization), and from that moment
+sfxmake.exe and subsequently upx.exe (all versions) stopped working on the
+generated sfxsmall.exe and sfxbig.exe. So this:
 
       <RandomizedBaseAddress>false</RandomizedBaseAddress>
       <BaseAddress>%40..\..\..\shared\baseaddr_x86.txt,$(ProjectName)</BaseAddress>
 
-se NESMI ani v Release a ReleaseEx zmenit na:
+MUST NOT, even in Release and ReleaseEx, be changed to:
 
       <RandomizedBaseAddress>true</RandomizedBaseAddress>
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
