### PR TITLE
[translation] Fix src/common/trace.h comments

### DIFF
--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -632,10 +632,10 @@ protected:
     const char* File;                    // helper variables for passing the file name (ANSI)
     const WCHAR* FileW;                  // helper variables for passing the file name (Unicode)
     int Line;                            // and the line number from which TRACE_X() is called
-    C__StringStreamBuf TraceStringBuf;   // string buffer drzici data trace streamu (ANSI)
-    C__StringStreamBufW TraceStringBufW; // string buffer drzici data trace streamu (unicode)
-    C__TraceStream TraceStrStream;       // vlastni trace stream (ANSI)
-    C__TraceStreamW TraceStrStreamW;     // vlastni trace stream (unicode)
+    C__StringStreamBuf TraceStringBuf;   // string buffer holding trace stream data (ANSI)
+    C__StringStreamBufW TraceStringBufW; // string buffer holding trace stream data (Unicode)
+    C__TraceStream TraceStrStream;       // trace stream object (ANSI)
+    C__TraceStreamW TraceStrStreamW;     // trace stream object (Unicode)
     DWORD StoredLastError;               // GetLastError() value before the TRACE_? macro
 
 public:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/trace.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 110 comment units, 110 review results, 110 resolved results, and 110 apply results.
- Branch-target comment guard passed for `src/common/trace.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/trace.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 119762 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 9 calls, 119762 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
