### PR TITLE
[translation] Fix src/common/dep/sqlite/precomp.h comments

### DIFF
--- a/src/common/dep/sqlite/precomp.h
+++ b/src/common/dep/sqlite/precomp.h
@@ -1,4 +1,4 @@
-// sqlite precomp.h nepouziva, ale overime, ze je v projektu nastaven define pro exporty dll
+// sqlite precomp.h is not used, but verify that the project defines the DLL export macro
 #ifndef SQLITE_API
 #pragma message ( __FILE__ "SQLITE_API not defined!" )
 #endif


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dep/sqlite/precomp.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 1 comment unit, 1 review result, 1 resolved result, and 1 apply result.
- Branch-target comment guard passed for `src/common/dep/sqlite/precomp.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/common/dep/sqlite/precomp.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 0 provider calls, 0 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
