### PR TITLE
[translation] Fix src/plugins/dbviewer/parser.cpp comments

### DIFF
--- a/src/plugins/dbviewer/parser.cpp
+++ b/src/plugins/dbviewer/parser.cpp
@@ -925,7 +925,7 @@ CParserInterfaceCSV::OpenFile(const char* fileName)
         if (Csv->GetStatus() != CSVE_OK)
         {
             status = TranslateCSVStatus(Csv->GetStatus());
-            CloseFile(); // po Close bude Csv=NULL
+            CloseFile(); // after Close Csv will be NULL
         }
     }
     else


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/dbviewer/parser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 48 comment units, 48 review results, 48 resolved results, and 48 apply results.
- Branch-target comment guard passed for `src/plugins/dbviewer/parser.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/dbviewer/parser.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 20 provider calls, 273492 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 8 calls, 167934 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 12 calls, 105558 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
