### PR TITLE
[translation] Fix src/plugins/dbviewer/renmain.cpp comments

### DIFF
--- a/src/plugins/dbviewer/renmain.cpp
+++ b/src/plugins/dbviewer/renmain.cpp
@@ -1844,7 +1844,7 @@ CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (xPos >= RowHeight && yPos >= RowHeight)
         {
-            // select pres bunky
+            // selection across cells
             int x, y;
             if (HitTest(xPos, yPos, &x, &y, FALSE))
             {
@@ -1869,7 +1869,7 @@ CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (xPos >= RowHeight && yPos >= RowHeight)
         {
-            // select pres bunky
+            // selection across cells
             int x, y;
             if (HitTest(xPos, yPos, &x, &y, FALSE))
             {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/dbviewer/renmain.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 74 comment units, 74 review results, 74 resolved results, and 74 apply results.
- Branch-target comment guard passed for `src/plugins/dbviewer/renmain.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/dbviewer/renmain.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 17 provider calls, 204848 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 8 calls, 114518 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 9 calls, 90330 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
