### PR TITLE
[translation] Fix src/plugins/ftp/operats5.cpp comments

### DIFF
--- a/src/plugins/ftp/operats5.cpp
+++ b/src/plugins/ftp/operats5.cpp
@@ -1779,7 +1779,7 @@ void DoCreateFile(CFTPDiskWork& localWork, char* fullName, BOOL& workDone, BOOL&
             // break;  // resume or overwrite - if resume fails we try overwrite as well
         }
         // case 3:  // resume or overwrite - if resume fails we try overwrite as well
-        case 4: // overwrite (pri already exists, transfer failed i force action)
+        case 4: // overwrite (for already exists, transfer failed, and force action)
         {
             if (action == 4) // check whether it is read-only (via the attribute only), but only if we have not done so already
             {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/operats5.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 261 comment units, 261 review results, 261 resolved results, and 261 apply results.
- Branch-target comment guard passed for `src/plugins/ftp/operats5.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/ftp/operats5.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 63 provider calls, 610057 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 51 calls, 514663 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 12 calls, 95394 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
