### PR TITLE
[translation] Fix src/plugins/shared/dbg.h comments

### DIFF
--- a/src/plugins/shared/dbg.h
+++ b/src/plugins/shared/dbg.h
@@ -493,8 +493,8 @@ protected:
     const char* File;                    // helper variable for passing the file name (ANSI)
     const WCHAR* FileW;                  // helper variable for passing the file name (Unicode)
     int Line;                            // and the line number from which TRACE_X() is called
-    C__StringStreamBuf TraceStringBuf;   // string buffer drzici data trace streamu (ANSI)
-    C__StringStreamBufW TraceStringBufW; // string buffer drzici data trace streamu (unicode)
+    C__StringStreamBuf TraceStringBuf;   // string buffer holding trace stream data (ANSI)
+    C__StringStreamBufW TraceStringBufW; // string buffer holding trace stream data (Unicode)
     C__TraceStream TraceStrStream;           // trace stream object (ANSI)
     C__TraceStreamW TraceStrStreamW;         // trace stream object (Unicode)
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/dbg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers none, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 105 comment units, 105 review results, 105 resolved results, and 105 apply results.
- Branch-target comment guard passed for `src/plugins/shared/dbg.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/dbg.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 25 provider calls, 281815 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 0 calls, 0 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 25 calls, 281815 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
