### PR TITLE
[translation] Fix src/plugins/shared/lukas/resedit.cpp comments

### DIFF
--- a/src/plugins/shared/lukas/resedit.cpp
+++ b/src/plugins/shared/lukas/resedit.cpp
@@ -93,7 +93,7 @@ try_again:
         if (lastError == ERROR_INVALID_HANDLE && ++num_of_retries <= 10)
         {
             CloseHandle(File);
-            Sleep(100); // cekame 10x 100ms na "zvalidneni" handlu (asi do toho zasahuje antivir?)
+            Sleep(100); // Wait up to 10 x 100 ms for the handle to "become valid" (perhaps the antivirus is interfering?)
             goto try_again;
         }
         TRACE_E("Error reading headers.");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/resedit.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 34 comment units, 34 review results, 34 resolved results, and 34 apply results.
- Branch-target comment guard passed for `src/plugins/shared/lukas/resedit.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/lukas/resedit.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 16 provider calls, 153431 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 21876 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 15 calls, 131555 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
