### PR TITLE
[translation] Fix src/plugins/shared/spl_gui.h comments

### DIFF
--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1149,11 +1149,11 @@ public:
     //
     virtual BOOL WINAPI GetItemRect(int index, RECT& r) = 0;
 
-    // prepne menu do Menu mode (jako by user stisknul a pustil Alt)
+    // switches the menu to Menu mode (as if the user pressed and released Alt)
     virtual void WINAPI EnterMenu() = 0;
     // returns TRUE if the menu is in Menu mode
     virtual BOOL WINAPI IsInMenuLoop() = 0;
-    // prepina menu do Help mode (Shift + F1)
+    // switches the menu to Help mode (Shift + F1)
     virtual void WINAPI SetHelpMode(BOOL helpMode) = 0;
 
     //
@@ -1847,7 +1847,7 @@ public:
 // ****************************************************************************
 // CGUIIconListAbstract
 //
-// Nas interni 32-bitovy image list. 8 bitu na kazdy RGB kanal a 8 bitu alfa transparence.
+// Our internal 32-bit image list: 8 bits for each RGB channel and 8 bits for alpha transparency.
 
 class CGUIIconListAbstract
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_gui.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment units in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 295 comment units, 295 review results, 295 resolved results, and 295 apply results.
- Branch-target comment guard passed for `src/plugins/shared/spl_gui.h` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/spl_gui.h` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 7 provider calls, 15976 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 1 call, 1789 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 14187 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
