### PR TITLE
[translation] Fix src/plugins/shared/versinfo.rc2 comments

### DIFF
--- a/src/plugins/shared/versinfo.rc2
+++ b/src/plugins/shared/versinfo.rc2
@@ -63,7 +63,7 @@ BEGIN
             VALUE "SLGCRCofImpSLT", "none\0"
 #ifdef _LANG_SALAMANDER
             VALUE "SLGHelpDir", "ENGLISH\0"
-            VALUE "SLGIncomplete", "\0" // pri nekompletnim prekladu davat: "https://forum.altap.cz/viewforum.php?f=23\0"
+            VALUE "SLGIncomplete", "\0" // For incomplete translations, use: "https://forum.altap.cz/viewforum.php?f=23\0"
 #endif
 #endif
         END


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/versinfo.rc2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 5 comment units, 5 review results, 5 resolved results, and 5 apply results.
- Branch-target comment guard passed for `src/plugins/shared/versinfo.rc2` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/shared/versinfo.rc2` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 4 provider calls, 25794 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 2 calls, 22859 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 2 calls, 2935 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
