### PR TITLE
[translation] Fix src/plugins/zip/unreduce.cpp comments

### DIFF
--- a/src/plugins/zip/unreduce.cpp
+++ b/src/plugins/zip/unreduce.cpp
@@ -279,7 +279,7 @@ int Unreduce(CDecompressionObject* decompress) /* expand probabilistically reduc
 /******************************/
 /*  Function LoadFollowers()  */
 /******************************/
-#pragma warning(disable : 4244) //aby to nervalo ze prirazuju short do charu
+#pragma warning(disable : 4244) //to avoid warnings about assigning short values to chars
 
 int LoadFollowers(CDecompressionObject* decompress,
                   f_array* followers,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/unreduce.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 36 comment units, 36 review results, 36 resolved results, and 36 apply results.
- Branch-target comment guard passed for `src/plugins/zip/unreduce.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- src/plugins/zip/unreduce.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 9 provider calls, 96256 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 3 calls, 49203 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 6 calls, 47053 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
