### PR TITLE
[translation] Fix tools/salbreak/salbreak.cpp comments

### DIFF
--- a/tools/salbreak/salbreak.cpp
+++ b/tools/salbreak/salbreak.cpp
@@ -350,8 +350,8 @@ BOOL GetSidMD5(BYTE* sidMD5)
 // Dr. GUI thinks that in your case you should only set the security for specific objects because you are developing a DLL, which may not want to change the security for every object in the process.
 // The following function wraps CreateMutex with the additional functionality of creating security that is more relaxed than is the default for a service:
 /*
-    // pridelime mutexu vsechna mozna prava (aby napriklad fungovalo otevirani mezi AsAdmin a User ucty)
-    // cistejsi by bylo zavolani funkce ObtainAccessableMutex(), viz jeji obsahly komentar
+    // grant the mutex all possible access rights (so opening it works, for example, between AsAdmin and User accounts)
+    // a cleaner solution would be to call ObtainAccessableMutex(), see its detailed comment
     SECURITY_ATTRIBUTES secAttr;
     char secDesc[ SECURITY_DESCRIPTOR_MIN_LENGTH ];
     secAttr.nLength = sizeof(secAttr);


### PR DESCRIPTION
## Summary
- Refines translated comments in `tools/salbreak/salbreak.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Full OSTranslation sequential review pipeline with requested review mode `codex`, actual review providers `codex`, `--prompt-log-mode summary`, `--copilot-event-log summary`, AST grounding through clang, Codex model `gpt-5.4` with `--codex-reasoning medium`, Copilot model `gpt-5.4-mini`, and `--copilot-reasoning high`.
- 46 comment units, 46 review results, 46 resolved results, and 46 apply results.
- Branch-target comment guard passed for `tools/salbreak/salbreak.cpp` in strict and ignore-whitespace modes with 0 violations and 0 preprocessing failures.
- `git diff --check -- tools/salbreak/salbreak.cpp` completed without diff integrity failures.

## Telemetry
- Cumulative across all provider stages: 13 provider calls, 170333 estimated tokens, and 0 billing units.
- Review stage actual providers: Codex-family 5 calls, 79521 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
- Non-review stages: Codex-family 8 calls, 90812 estimated tokens; Copilot SDK 0 calls, 0 Copilot request units.
