### PR TITLE
[translation] Fix src/plugins/ieviewer/markdown.cpp comments

### DIFF
--- a/src/plugins/ieviewer/markdown.cpp
+++ b/src/plugins/ieviewer/markdown.cpp
@@ -116,7 +116,7 @@ IStream* ConvertMarkdownToHTML(const char* name)
     sprintf_s(buff, "<!DOCTYPE html><html lang=\"cs\" dir=\"ltr\"><head><meta charset=\"utf-8\"><style>\n");
     oStream->Write(buff, (ULONG)strlen(buff), &written);
 
-    // if we find CSS, inline it
+    // Inline CSS directly into the HTML when a stylesheet is found.
     FILE* fpCSS = OpenMarkdownCSS();
     if (fpCSS != NULL)
     {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ieviewer/markdown.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: manual_pro

## Verification
- OSTranslationReview publish flow applied packet `packet-pr-upstream-smoke-run-1777200953390` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ieviewer/markdown.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\pr-publish-upstream-smoke\run-1777200953390\packet\imported\normalized-response.json`.
