### PR TITLE
[translation] Fix src/plugins/ieviewer/markdown.cpp comments

### DIFF
--- a/src/plugins/ieviewer/markdown.cpp
+++ b/src/plugins/ieviewer/markdown.cpp
@@ -134,7 +134,7 @@ IStream* ConvertMarkdownToHTML(const char* name)
     sprintf_s(buff, "</article></body></html>\n");
     oStream->Write(buff, (ULONG)strlen(buff), &written);
 
-    // set the pointer to the start of the stream; IE will read from it
+    // Reset the stream pointer so IE can read from the beginning.
     LARGE_INTEGER seek;
     seek.QuadPart = 0;
     oStream->Seek(seek, STREAM_SEEK_SET, NULL);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ieviewer/markdown.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: manual_pro

## Verification
- OSTranslationReview publish flow applied packet `packet-pr-markdown-stream-reset-run-1777201289246-markdown-stream-reset` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ieviewer/markdown.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\pr-publish-upstream-smoke\run-1777201289246-markdown-stream-reset\packet\imported\normalized-response.json`.
