### PR TITLE
[translation] Fix src/common/winlib.cpp comments

### DIFF
--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -72,7 +72,7 @@ BOOL InitializeWinLib()
 
 void ReleaseWinLib()
 {
-    // we must detach open windows from WinLib because WinLib is shutting down ...
+    // Detach open windows from WinLib because WinLib is shutting down ...
     int c = WindowsManager.GetCount();
     if (c > 0)
         TRACE_ET(_T("ReleaseWinLib(): WindowsManager still contains opened windows: ") << c);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: manual_pro

## Verification
- OSTranslationReview publish flow applied packet `packet-pr-winlib-detach-windows-run-1777201428768-winlib-detach-windows` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/winlib.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\pr-publish-upstream-smoke\run-1777201428768-winlib-detach-windows\packet\imported\normalized-response.json`.
