### PR TITLE
[translation] Refine html documentation

### DIFF
--- a/help/src/hh/salamand/basicwork_openarchive.htm
+++ b/help/src/hh/salamand/basicwork_openarchive.htm
@@ -15,14 +15,14 @@
 <h1>Opening Archive Files</h1>
 
 <p>You can open and browse <a href="glossary_a.htm">archive files</a> in panels
-as if they were normal directories. Just focus the archive file and press Enter or
+as if they were normal directories. Focus the archive file and press Enter or
 double-click it. Also see
 <a href="navigating_changedir.htm">Changing Directory</a> for other ways to open
 (change directory to) an archive file, mainly Commands/Change Directory (Shift+F7)
 and Edit/Paste (Ctrl+V).</p>
 
 <p>Once you have opened an archive file, you can work with the files and directories in it.
-Just focus or select them and use <a href="basicwork_open.htm">Open</a>,
+Focus or select them and use <a href="basicwork_open.htm">Open</a>,
 <a href="basicwork_view.htm">View</a>,
 <a href="basicwork_edit.htm">Edit</a>,
 <a href="basicwork_copy.htm">Copy</a> (in both directions, pack and unpack),

--- a/help/src/hh/salamand/basicwork_openfs.htm
+++ b/help/src/hh/salamand/basicwork_openfs.htm
@@ -25,7 +25,7 @@ a file system in this menu or bar, find the appropriate plugin in the
 and Edit/Paste (Ctrl+V).</p>
 
 <p>When you open a file system in a panel, you can work with the files and directories in it.
-Just focus or select them and use <a href="basicwork_view.htm">View</a>,
+Focus or select them and use <a href="basicwork_view.htm">View</a>,
 <a href="basicwork_copy.htm">Copy</a>, and
 <a href="basicwork_move.htm">Move</a>
 (it works in both directions, to and from the other panel), <a href="basicwork_delete.htm">Delete</a>,

--- a/help/src/hh/salamand/basicwork_qsearch.htm
+++ b/help/src/hh/salamand/basicwork_qsearch.htm
@@ -14,7 +14,7 @@
 <h1>Quick Search for a File or Directory Name</h1>
 
 <p>You can quickly find any desired name in the list of files and directories.
-Just start typing the name, and the first item with the typed prefix is
+Start typing the name, and the first item with the typed prefix is
 focused. You can extend the prefix with the Right arrow key and shorten it
 with the Left arrow key or Backspace. To focus the next
 or previous name with the same prefix, use the Down or Up arrow key. To leave quick
@@ -58,4 +58,3 @@ quick search mode.
 </div>
 </body>
 </html>
-

--- a/help/src/hh/salamand/configuration_gener.htm
+++ b/help/src/hh/salamand/configuration_gener.htm
@@ -74,7 +74,7 @@ selected. You can use the Ctrl+A keyboard shortcut to select all.
 
 <dt><i>Use fast directory move on Novell Netware</i></dt>
 <dd>When checked and you are moving a directory within a single Novell Netware drive,
-Salamander moves the directory simply by renaming it directly to the target path
+Salamander moves the directory simply by renaming it to the target path
 (this is fast, but it does not always work). Otherwise, Salamander renames only files,
 creates all necessary directories on the target path, and deletes them from the source
 directory after the contained files are moved (this can be much slower, but it always works).

--- a/help/src/hh/salamand/configuration_mainwnd.htm
+++ b/help/src/hh/salamand/configuration_mainwnd.htm
@@ -25,7 +25,7 @@ is displayed when starting Open Salamander.</dd>
 <dt><i>Show icon of Open Salamander in the Status area of Taskbar</i></dt>
 <dd>When Open Salamander is minimized, the taskbar button is removed from
 the taskbar. Instead, an icon is displayed in the status area of the taskbar,
-near the clock. A click on this icon restores Open Salamander window.</dd>
+near the clock. Clicking this icon restores the Open Salamander window.</dd>
 
 <dt><i>Display current path in main window title as</i></dt>
 <dd>When checked, the current path in the active panel is displayed in the main

--- a/help/src/hh/salamand/configuration_panels.htm
+++ b/help/src/hh/salamand/configuration_panels.htm
@@ -64,7 +64,7 @@ in Windows.</dd>
 
 <dt><i>Rename by slowly clicking the name twice</i></dt>
 <dd>When checked, you can rename files and directories directly in the panel when
-you click on a focused name. If the name is not focused, click the first time to
+you click a focused name. If the name is not focused, click it once to
 focus it, wait a moment (to prevent opening the file or directory by double-clicking),
 and then click the second time to rename it.</dd>
 

--- a/help/src/hh/salamand/customize_usrmn.htm
+++ b/help/src/hh/salamand/customize_usrmn.htm
@@ -343,7 +343,7 @@ shell (more precisely, by using a batch file):</p>
 
 <h4>Remarks</h4>
 <p>When <a href="windows_usrmenu.htm">User Menu Bar</a> is visible, you can
-add a new User Menu item using a drag &amp; drop operation. Simply drag the application
+add a new User Menu item through a drag &amp; drop operation. Simply drag the application
 or document to the User Menu Bar.</p>
 
 

--- a/help/src/hh/salamand/dlgboxes_copy.htm
+++ b/help/src/hh/salamand/dlgboxes_copy.htm
@@ -78,7 +78,7 @@ GB/s). Otherwise, files will be copied without speed limit.
 <dd>When checked, the target files and directories will have the same
 set of Archive, Compressed, and Encrypted attributes as the source
 files and directories. Otherwise attributes of files and directories moved
-in scope of one drive (they are just renamed) are not changed and
+within a single drive (they are just renamed) are not changed and
 Archive attribute will be added and Compressed and Encrypted attributes will
 be inherited from the destination directory for all other copied or moved files
 and directories (except when copying Encrypted files and directories, Encrypted
@@ -90,7 +90,7 @@ Directories</a> for details).
 <dt><i>Preserve owners and permissions (not inherited) on NTFS drives</i></dt>
 <dd>When checked, owners and permissions (not inherited) are copied from source
 to destination files and directories on NTFS drives. Otherwise owners and permissions of
-files and directories moved in scope of one drive (they are just renamed) are
+files and directories moved within a single drive (they are just renamed) are
 not changed and for all other files and directories the default owners and permissions
 (system sets them when file or directory is created) are used.
 </dd>

--- a/help/src/hh/salamand/dlgboxes_move.htm
+++ b/help/src/hh/salamand/dlgboxes_move.htm
@@ -78,7 +78,7 @@ GB/s). Otherwise, files will be moved without speed limit.
 <dd>When checked, the target files and directories will have the same
 set of Archive, Compressed, and Encrypted attributes as the source
 files and directories. Otherwise attributes of files and directories moved
-in scope of one drive (they are just renamed) are not changed and
+within a single drive (they are just renamed) are not changed and
 Archive attribute will be added and Compressed and Encrypted attributes will
 be inherited from the destination directory for all other copied or moved files
 and directories (except when copying Encrypted files and directories, Encrypted
@@ -90,7 +90,7 @@ Directories</a> for details).
 <dt><i>Preserve owners and permissions (not inherited) on NTFS drives</i></dt>
 <dd>When checked, owners and permissions (not inherited) are copied from source
 to destination files and directories on NTFS drives. Otherwise owners and permissions of
-files and directories moved in scope of one drive (they are just renamed) are
+files and directories moved within a single drive (they are just renamed) are
 not changed and for all other files and directories the default owners and permissions
 (system sets them when file or directory is created) are used.
 </dd>

--- a/help/src/hh/salamand/othertask_tasklist.htm
+++ b/help/src/hh/salamand/othertask_tasklist.htm
@@ -16,7 +16,7 @@
 <p>Open Salamander Task List is intended to
 control all running Open Salamander tasks (version 2.52 or later).
 Its most important feature is that it lets you break an unresponsive task from
-another responsive Open Salamander task. Breaking the task should open the Bug
+another Open Salamander task that is still responsive. Breaking the task should open the Bug
 Report dialog in the target task so you can send us a Bug Report about the "hung"
 Open Salamander task. This should help us eliminate such bugs.</p>
 

--- a/src/plugins/checkver/help/hh/checkver/dlgboxes_config.htm
+++ b/src/plugins/checkver/help/hh/checkver/dlgboxes_config.htm
@@ -42,19 +42,19 @@ start checking.
 
 <dt><i>Close window if no new version is found, otherwise show window</i></dt>
 
-<dd>When checked, the plugin is quiet until it finds newer versions. If
+<dd>When checked, the plugin remains quiet until it finds newer versions. If
 new versions are available, it shows the <a href="dlgboxes_checkver.htm">Check For New Versions</a>
-window with the found updates. When not checked, you must manually close the <a href="dlgboxes_checkver.htm">Check
-For New Versions</a> window every time using the Close button.
+window with the available updates. When not checked, you must manually close the <a href="dlgboxes_checkver.htm">Check
+For New Versions</a> window each time by clicking the Close button.
 </dd>
 
 <dt><i>Filters</i></dt>
 
-<dd>The Filters list box contains versions of modules you are not interested in and should be
-filtered (ignored). You can add all versions of a module (if no version is specified) or just one version
+<dd>The Filters list box contains versions of modules you are not interested in and want to ignore.
+You can add either all versions of a module (if no version is specified) or just one version
 of a module (other versions will not be filtered). To add one or all versions of a module to this list,
 right-click the module name in the <i>Log window</i> in the <a href="dlgboxes_checkver.htm">Check For
-New Versions</a> window when it displays the list of newer versions (results of checking).
+New Versions</a> window when it displays the list of newer versions.
 </dd>
 
 <dt><i>Remove Selected Item From Filters</i></dt>

--- a/src/plugins/demoview/help/hh/demoview/basic_viewbmpfromclip.htm
+++ b/src/plugins/demoview/help/hh/demoview/basic_viewbmpfromclip.htm
@@ -14,7 +14,7 @@
 
 <h1>Viewing Bitmap from Clipboard</h1>
 
-<p>Raster images (bitmaps) copied to the clipboard can be opened in the viewer.</p>
+<p>You can open raster images (bitmaps) copied to the clipboard in the viewer.</p>
 
 <h3>To view a bitmap from the clipboard:</h3>
 

--- a/src/plugins/ftp/help/hh/ftp/appendix_parsing.htm
+++ b/src/plugins/ftp/help/hh/ftp/appendix_parsing.htm
@@ -68,7 +68,7 @@ and only the plain text listing is displayed in the panel (such listing is
 unusable for any operation).</p>
 
 <p>The server type is autodetected only for the first listing from the server.
-The same server type is used for all other listings (it allows to display
+The same server type is used for all other listings (this allows the plugin to display
 the same columns also for empty listings, etc.). If the listing
 cannot be parsed with the same server type, the plugin tries to
 autodetect another server type.</p>
@@ -139,14 +139,14 @@ types are always visible in panel. Columns are defined in the
  <tr><th>Type</th><th>Description</th></tr>
  <tr><td>Name</td><td>string; file or directory name; exactly one column of this type is
          necessary; it cannot be hidden; the definition of the empty value for
-	 this column has no sense; parser must assign a value to this column for
+	 this column makes no sense; the parser must assign a value to this column for
 	 each file and directory; if no value is assigned, parsing using the current
 	 rule does not add any file nor directory (it is used for skipping empty lines and other
-	 not important parts of the plain text listing); assigning of the empty string ("") is
-	 considered to be an error in parsing</td></tr>
+	 not important parts of the plain text listing); assigning the empty string ("") is
+	 considered an error in parsing</td></tr>
  <tr><td>Extension</td><td>string; file extension; values are automatically generated from
          values in the column of the Name type; it cannot be hidden; the definition of the
-	 empty value for this column has no sense</td></tr>
+	 empty value for this column makes no sense</td></tr>
  <tr><td>File Size in Bytes</td><td>64-bit unsigned integer; file size in bytes; the value is zero
          and is displayed as "DIR" in panel for all directories; the default empty
 	 value is zero</td></tr>
@@ -156,7 +156,7 @@ types are always visible in panel. Columns are defined in the
  <tr><td>Last Write Time</td><td>time; last write (modification) time; the default empty value is 0:00:00</td></tr>
  <tr><td>File Type</td><td>string; file type description (defined by Windows for file extensions);
          values are automatically generated from values in the column of the Name type;
-	 the definition of the empty value for this column has no sense</td></tr>
+	 the definition of the empty value for this column makes no sense</td></tr>
  <tr><td>Any Text</td><td>string; general purpose; the default empty value is the empty string ("")</td></tr>
  <tr><td>Any Date</td><td>date; general purpose; a date value must be valid (if not,
          it is replaced by the value January 1, 1602); the default empty value is the empty
@@ -233,7 +233,7 @@ complete text lines.</p>
 
 <p>The parsing of the incomplete listing is handled at the level of using
 rules. In a simple case the pointer is moved (by using rules) to the end
-of the incomplete listing and it means the successful end of parsing.
+of the incomplete listing, which means the successful end of parsing.
 Otherwise during evaluation of some function from currently used rule,
 the pointer should be moved to the next line. But this is not possible
 because the listing is incomplete, so parsing is successfully ended
@@ -260,8 +260,8 @@ moves the pointer and if not explicitly stated, it is assumed that the pointer
 cannot move behind the end of line (to the next line).</p>
 
 <p>Before using the column identifier in the expression, it is necessary to
-assign a value to this column. Otherwise the expression has no sense (such
-expression can be replaced by the boolean constant which is calculated using
+assign a value to this column. Otherwise the expression makes no sense (such
+an expression can be replaced by the boolean constant that is calculated using
 the column default empty value in the expression).</p>
 
 <p>Note: in the following table, the whitespace is the space or tab character.</p>
@@ -544,8 +544,8 @@ the column default empty value in the expression).</p>
 <h4>Operators Used in Parsing</h4>
 
 <p>Before using the column identifier in the expression, it is necessary to
-assign a value to this column. Otherwise the expression has no sense (such
-expression can be replaced by the boolean constant which is calculated using
+assign a value to this column. Otherwise the expression makes no sense (such
+an expression can be replaced by the boolean constant that is calculated using
 the column default empty value in the expression).</p>
 
 <p>We have the following operators:</p>

--- a/src/plugins/ftp/help/hh/ftp/config_confirmations.htm
+++ b/src/plugins/ftp/help/hh/ftp/config_confirmations.htm
@@ -44,7 +44,7 @@ before renaming a file or directory to an existing name in the Quick Rename comm
 
 <dt><i>Show message "Connection to FTP server has been lost"</i></dt>
 <dd>Clear this check box if you do not want to receive a message when the connection
-to the FTP server in panel has been lost. Usually the FTP server closes the connection
+to the FTP server in the panel has been lost. Usually the FTP server closes the connection
 if the FTP client is not active or is not transferring any data for some time, usually
 5 or 10 minutes. See <i>Keep connections alive</i> in
 <a href="config_defaults.htm">Configuration/Defaults</a> for details on how to prevent

--- a/src/plugins/ftp/help/hh/ftp/dlgboxes_testparser.htm
+++ b/src/plugins/ftp/help/hh/ftp/dlgboxes_testparser.htm
@@ -44,7 +44,7 @@ the <i>Raw listing</i> edit box.
 </dd>
 
 <dt><i>Results of parsing</i></dt>
-<dd>Contains results of parsing. These lines will be displayed in panel. When you
+<dd>Contains results of parsing. These lines will be displayed in the panel. When you
 click on a line, the part of the listing used to get this line will be selected
 in the <i>Raw listing</i> edit box.
 </dd>

--- a/src/plugins/zip/help/hh/zip/sfx_creating.htm
+++ b/src/plugins/zip/help/hh/zip/sfx_creating.htm
@@ -28,7 +28,7 @@ extended options before packing</i> in your <a href="usingzip_config.htm">ZIP
 Configuration</a>.</p>
 
 <h3>Creating a self-extracting archive from the command prompt</h3>
-<p>This feature is not available in the ZIP plugin itself but is provided by a
+<p>This feature is not available directly in the ZIP plugin; it is provided by a
 standalone application called Zip2Sfx, which is located in the plugins\zip\zip2sfx
 subdirectory of Open Salamander's installation directory.</p>
 

--- a/src/plugins/zip/help/hh/zip/sfx_sfx.htm
+++ b/src/plugins/zip/help/hh/zip/sfx_sfx.htm
@@ -14,8 +14,8 @@
 <h1>Self-Extractor</h1>
 
 <p>The Self-Extractor is part of each ZIP self-extracting archive. It starts
-when the user opens the self-extracting archive. It unpacks the archive to the target directory
-of the user's choice (or optionally to a designated directory without any user prompt).</p>
+when the self-extracting archive is opened. It unpacks the archive to the target directory
+chosen by the user (or optionally to a designated directory without prompting).</p>
 
 <h3>Features:</h3>
 <ul>

--- a/src/plugins/zip/help/hh/zip/usingzip_config.htm
+++ b/src/plugins/zip/help/hh/zip/usingzip_config.htm
@@ -44,7 +44,7 @@ affect empty directories that are already stored in the archive.</dd>
 <dt><i>Set archive time to the newest file time when modifying archive</i></dt>
 <dd>After any action that modifies an archive (packing or deleting files), the ZIP plugin
 sets the archive file time to the time of the newest file in the archive. This option
-can be useful for purposes such as backup management.</dd>
+can be useful for tasks such as backup management.</dd>
 
 <dt><i>Use WinZip compatible file names for multi-volume archives</i></dt>
 <dd>Multi-volume archive parts are named using WinZip naming
@@ -73,8 +73,8 @@ self-extracting archive. Options are: <i>Always ask before changing texts</i>,
 </dd>
 
 <dt><i>Display dialog with extended options before packing</i></dt>
-<dd>Displays the Create New Archive/Add File to Archive dialog before each pack operation to ZIP archives.
-This allows you to specify many options for packing ZIP archives that the ZIP plugin offers
+<dd>Displays the Create New Archive/Add File to Archive dialog before each operation that packs files into ZIP archives.
+This lets you specify many packing options offered by the ZIP plugin
 (such as archive spanning, self-extracting archives, or encryption).</dd>
 
 <dt><i>Show column Packed when listing archive</i></dt>

--- a/src/plugins/zip/help/hh/zip/usingzip_packdlg.htm
+++ b/src/plugins/zip/help/hh/zip/usingzip_packdlg.htm
@@ -13,7 +13,7 @@
 <div class="page">
 <h1>Create New Archive Dialog</h1>
 
-<p>This dialog is displayed just before packing to a ZIP archive begins (using the Pack or Copy command).
+<p>This dialog is displayed just before packing to a ZIP archive starts (using the Pack or Copy command).
 This dialog is labeled <b>Add Files to Archive</b> when adding files to an existing archive (i.e., using the Copy command).
 You can specify packing options here. Packing starts immediately with the default
 settings if the display of this dialog is disabled in the ZIP plugin configuration.</p>


### PR DESCRIPTION
## Summary
- refine another set of English help pages across core topics and selected plugins
- keep all changes prose-only while preserving UI-bound strings and HTML structure
- run the fifth-pass UI-span and HTML drift guardrails before opening the PR

## Test Plan
- [x] `python3 /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files/help-ui-drift-audit.py .`
- [x] `python3 /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files/staged-html-checks/verify_staged_html_structure.py --repo .`
- [x] `python3 /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files/staged-html-checks/verify_staged_html_formatting.py --repo .`
- [x] `git --no-pager diff --cached --check`
