### PR TITLE
[translation] Restore UI terms in html documentation

### DIFF
--- a/src/plugins/automation/help/hh/automation/appendix_samples.htm
+++ b/src/plugins/automation/help/hh/automation/appendix_samples.htm
@@ -20,7 +20,7 @@ with the Automation plugin.
 <h2>Convert Images</h2>
 <p>Converts selected images (and images in selected directories) using the open-source
 ImageMagick tools. This script can easily be adapted for other file operations,
-especially conversion tasks. Features: recursive directory traversal, file-mask matching,
+especially conversion tasks. Features: recursive directory traversal, file masks matching,
 calling external applications (ImageMagick convert command), progress dialog box,
 overwrite dialog box with Yes, All, Skip, Skip All and Cancel buttons, error state
 handling, output log with operation summary.
@@ -29,7 +29,7 @@ Requires: <a href="http://www.imagemagick.org/">ImageMagick</a> (either x86 or x
 
 <h2>Count Lines</h2>
 <p>Counts lines of selected files (and files in selected directories).
-Features: recursive directory traversal, file-mask matching, progress dialog box,
+Features: recursive directory traversal, file masks matching, progress dialog box,
 error handling via an error dialog with Retry, Skip, Skip All, and Cancel,
 regular expressions, output log with operation summary.
 </p>
@@ -59,7 +59,7 @@ method and iterating through the <a href="ref_itemcollection.htm">items collecti
 <h2>Unpack Multiple Archives</h2>
 <p>Unpacks selected archives (and archives in selected directories) using the open-source
 7-Zip archiver. This script can easily be adapted for other unpackers. Features:
-recursive directory traversal, file-mask matching, calling external applications
+recursive directory traversal, file masks matching, calling external applications
 (7-Zip archiver), error state handling, output log with operation summary.
 Requires: <a href="http://www.7-zip.org/">7-Zip</a> (either x86 or x64).
 </p>

--- a/src/plugins/zip/help/hh/zip/usingzip_config.htm
+++ b/src/plugins/zip/help/hh/zip/usingzip_config.htm
@@ -73,7 +73,7 @@ self-extracting archive. Options are: <i>Always ask before changing texts</i>,
 </dd>
 
 <dt><i>Display dialog with extended options before packing</i></dt>
-<dd>Displays the Create New Archive/Add File to Archive dialog before each operation that packs files into ZIP archives.
+<dd>Displays the Create New Archive/Add File to Archive dialog before each pack operation to ZIP archives.
 This lets you specify many packing options offered by the ZIP plugin
 (such as archive spanning, self-extracting archives, or encryption).</dd>
 


### PR DESCRIPTION
## Summary
- retroactively audit merged help PRs #1099 through #1103 for unintended UI-string edits
- restore the protected `file mask` terminology in Automation sample script help
- restore the `Pack` command reference in ZIP configuration help

## Test Plan
- [x] `cd /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files && python3 -m unittest test_help_ui_regression_cases.py -v`
- [x] `cd /home/jan/.config/superpowers/worktrees/salamander/help-review-retro-ui-audit-20260501 && python3 /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files/staged-html-checks/verify_staged_html_structure.py --repo .`
- [x] `cd /home/jan/.config/superpowers/worktrees/salamander/help-review-retro-ui-audit-20260501 && python3 /home/jan/.copilot/session-state/beb487e3-87e7-4852-8c17-5eee847d6343/files/staged-html-checks/verify_staged_html_formatting.py --repo .`
- [x] `cd /home/jan/.config/superpowers/worktrees/salamander/help-review-retro-ui-audit-20260501 && git --no-pager diff --cached --check`
