### PR TITLE
[translation] Fix src/common/ms_init.cpp comments

### DIFF
--- a/src/common/ms_init.cpp
+++ b/src/common/ms_init.cpp
@@ -6,8 +6,8 @@
 
 #include <windows.h>
 
-// MS_INIT ensures that constructors of static objects are called in the correct order
-// and at the "lib" level (before "user")
+// MS_INIT ensures that static-object constructors run in the correct order
+// and in the "lib" init segment (before "user")
 
 #pragma warning(3 : 4706) // warning C4706: assignment within conditional expression
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/ms_init.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Cross-checked the rewritten comment against the Czech baseline commit `a28afcb958578dd219311a7b500320b162de812b`.
- `git diff --check` completed before commit.
- Inline review comments prepared: 1.
