### PR TITLE
[translation] Fix src/common/heap.h comments

### DIFF
--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -4,13 +4,17 @@
 
 #pragma once
 
-// Define _CRTDBG_MAP_ALLOC in the DEBUG build; otherwise the leak source is not shown.
+// Define _CRTDBG_MAP_ALLOC in debug builds, otherwise leak reports will not show the source location.
 
 #if defined(_DEBUG) && !defined(HEAP_DISABLE)
 
-#define GCHEAP_MAX_USED_MODULES 100 // maximum number of modules to remember so they can be loaded before reporting memory leaks
+#define GCHEAP_MAX_USED_MODULES 100 // maximum number of modules remembered so they can be reloaded before printing leak reports
 
-// Call this for modules that may report memory leaks. If leaks are detected, all modules registered this way are loaded "as image" (without module initialization; the modules are already unloaded when leaks are checked) before the leak report is printed. This shows .cpp module names instead of "#File Error#" messages, and MSVC does not flood the output with generated exceptions because the module names are available. Can be called from any thread.
+// Register modules that may report memory leaks. If leaks are detected, all
+// registered modules are reloaded "as image" (without running initialization)
+// before the leak report is printed. That preserves .cpp module names instead
+// of "#File Error#" messages and avoids noisy MSVC-generated exceptions.
+// Safe to call from any thread.
 void AddModuleWithPossibleMemoryLeaks(const TCHAR* fileName);
 
 #endif // defined(_DEBUG) && !defined(HEAP_DISABLE)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/heap.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Cross-checked the rewritten comments against the Czech baseline commit `a28afcb958578dd219311a7b500320b162de812b`.
- `git diff --check` completed before commit.
- Inline review comments prepared: 2.
