### PR TITLE
[translation] Fix src/common/moore.h comments

### DIFF
--- a/src/common/moore.h
+++ b/src/common/moore.h
@@ -51,7 +51,7 @@ public:
     void SetFlags(WORD flags);
     void Set(const char* pattern, WORD flags);
     // for patterns containing '\0'
-    // the pattern buffer must be (length + 1) characters long (for string compatibility)
+    // the pattern buffer must be (length + 1) characters long (for compatibility with C strings)
     void Set(const char* pattern, const int length, WORD flags);
 
     inline int SearchForward(const char* text, int length, int start);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/moore.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Cross-checked the rewritten comment against the Czech baseline commit `a28afcb958578dd219311a7b500320b162de812b`.
- `git diff --check` completed before commit.
- Inline review comments prepared: 1.
