### PR TITLE
[translation] Fix src/common/winlib.h comments

### DIFF
--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -4,7 +4,7 @@
 
 #pragma once
 
-// __DEBUG_WINLIB enables several checks for tricky WinLib bugs
+// The __DEBUG_WINLIB macro enables several checks for subtle WinLib bugs
 
 // WinLib string constants (for internal WinLib use only)
 enum CWLS
@@ -15,7 +15,7 @@ enum CWLS
     WLS_COUNT
 };
 
-// set custom WinLib strings
+// Set custom strings used by WinLib
 void SetWinLibStrings(const TCHAR* invalidNumber, // "not a number" (for numeric transfer buffers)
                       const TCHAR* error);        // title "error" (for numeric transfer buffers)
 
@@ -30,11 +30,11 @@ extern const WCHAR* CWINDOW_CLASSNAME2W; // Unicode universal window class name 
 
 class CWinLibHelp;
 
-// must be called before using WinLib
+// Must be called before WinLib is used
 BOOL InitializeWinLib();
-// must be called after using WinLib
+// Must be called after WinLib is no longer used
 void ReleaseWinLib();
-// must be called before using help
+// Must be called before help is used
 BOOL SetupWinLibHelp(CWinLibHelp* winLibHelp);
 
 class CWinLibHelp


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Cross-checked the rewritten comments against the Czech baseline commit `a28afcb958578dd219311a7b500320b162de812b`.
- `git diff --check` completed before commit.
- Inline review comments prepared: 3.
