### PR TITLE
[translation] Fix src/plugins/shared/lukas/resedit.cpp comments

### DIFF
--- a/src/plugins/shared/lukas/resedit.cpp
+++ b/src/plugins/shared/lukas/resedit.cpp
@@ -93,7 +93,7 @@ try_again:
         if (lastError == ERROR_INVALID_HANDLE && ++num_of_retries <= 10)
         {
             CloseHandle(File);
-            Sleep(100); // Wait up to 10 x 100 ms for the handle to "become valid" (perhaps the antivirus is interfering?)
+            Sleep(100); // Wait up to 10 x 100 ms for the handle to become usable (perhaps the antivirus is interfering?)
             goto try_again;
         }
         TRACE_E("Error reading headers.");


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/lukas/resedit.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Cross-checked the rewritten comment against the Czech baseline commit `a28afcb958578dd219311a7b500320b162de812b`.
- `git diff --check` completed before commit.
- Inline review comments prepared: 1.
