### PR TITLE
[translation] Fix src/plugins/shared/spl_fs.h comments

### DIFF
--- a/src/plugins/shared/spl_fs.h
+++ b/src/plugins/shared/spl_fs.h
@@ -28,8 +28,8 @@ class CPluginDataInterfaceAbstract;
 // ****************************************************************************
 // CSalamanderForViewFileOnFSAbstract
 //
-// set of methods from Salamander for supporting ViewFile in CPluginFSInterfaceAbstract,
-// the interface is valid only within the method to which it is passed as a parameter
+// methods provided by Salamander to support ViewFile in CPluginFSInterfaceAbstract,
+// this interface is valid only for the duration of the method that receives it
 
 class CSalamanderForViewFileOnFSAbstract
 {
@@ -50,11 +50,11 @@ public:
     // the FTP download has already been performed), or FALSE if the file still needs to be prepared
     // (for example by downloading it); 'parent' is the parent of error message boxes (for example, an overly long
     // file name)
-    // WARNING: if it did not return NULL (no system error occurred), it is necessary to later call
-    //          FreeFileNameInCache (for the same 'uniqueFileName')
+    // WARNING: if it returns non-NULL (no system error occurred), you must later call
+    //          FreeFileNameInCache (with the same 'uniqueFileName')
     // NOTE: if the FS uses the disk cache, it should at least call
-    //       CSalamanderGeneralAbstract::RemoveFilesFromCache("fs-name:") when the plugin is unloaded, otherwise
-    //       its file copies will needlessly clutter the disk cache
+    //       CSalamanderGeneralAbstract::RemoveFilesFromCache("fs-name:") when the plugin is unloaded; otherwise,
+    //       its file copies will unnecessarily clutter the disk cache
     virtual const char* WINAPI AllocFileNameInCache(HWND parent, const char* uniqueFileName, const char* nameInCache,
                                                     const char* rootTmpPath, BOOL& fileExists) = 0;
 


### PR DESCRIPTION
## Summary
- polish the translated API notes in `src/plugins/shared/spl_fs.h`
- keep the diff comment-only and preserve the existing wrapping

## Why these edits
- `sada metod ze Salamandera pro podporu provedeni ViewFile...` -> the current English read like a literal translation; this rewrites it into natural API wording and clarifies that the interface is valid only for the receiving method call
- `pokud nevratila NULL ... je nutne pozdeji zavolat` -> the current English used awkward negative phrasing; this changes it to a direct contract statement (`if it returns non-NULL ... you must later call`)
- `jinak budou jeho kopie souboru zbytecne prekazet v disk-cache` -> the current English was understandable but clumsy; this keeps the same meaning while using more idiomatic technical English

## Baseline Czech
> sada metod ze Salamandera pro podporu provedeni ViewFile v CPluginFSInterfaceAbstract, platnost interfacu je omezena na metodu, ktere je interface predan jako parametr

> POZOR: pokud nevratila NULL (nenastala systemova chyba), je nutne pozdeji zavolat FreeFileNameInCache (pro stejne `uniqueFileName`)

> POZN.: pokud FS vyuziva disk-cache, mel by alespon pri unloadu pluginu zavolat CSalamanderGeneralAbstract::RemoveFilesFromCache("fs-name:"), jinak budou jeho kopie souboru zbytecne prekazet v disk-cache