### PR TITLE
[translation] Fix src/codetbl.h comments

### DIFF
--- a/src/codetbl.h
+++ b/src/codetbl.h
@@ -25,7 +25,7 @@ protected:
     TIndirectArray<CCodeTablesData> Data;
     char WinCodePage[101];            // Windows code page name (for Czech CP1250 - regional encoding)
     DWORD WinCodePageIdentifier;      // 1250, 1251, 1252, ...
-    char WinCodePageDescription[101]; // human - readable description (Central Europe, West Europe & U.S.)
+    char WinCodePageDescription[101]; // human-readable description (Central Europe, West Europe & U.S.)
     char DirectoryName[MAX_PATH];     // directory name XXX: convert\XXX\convert.cfg
     CCodeTableStateEnum State;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/codetbl.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/codetbl.h` as a comment-quality candidate.
- `git diff --check -- src/codetbl.h` completed without diff integrity failures.
- `git diff -- src/codetbl.h` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/codetbl.h` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
