### PR TITLE
[translation] Fix src/cache.h comments

### DIFF
--- a/src/cache.h
+++ b/src/cache.h
@@ -7,9 +7,9 @@
 // initializes the disk cache, returns success
 BOOL InitializeDiskCache();
 
-// how long time to wait between checking the state of watched objects
+// how long to wait between checks of watched objects
 #define CACHE_HANDLES_WAIT 500
-// (100 MB) max . size of disk-cache in bytes, should be moved to configuration
+// (100 MB) maximum size of the disk cache in bytes; should be moved to configuration
 #define MAX_CACHE_SIZE CQuadWord(104857600, 0)
 
 // error state codes for method CDiskCache::GetName()


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/cache.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/cache.h` as a comment-quality candidate.
- `git diff --check -- src/cache.h` completed without diff integrity failures.
- `git diff -- src/cache.h` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/cache.h` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
