### PR TITLE
[translation] Fix src/execute.h comments

### DIFF
--- a/src/execute.h
+++ b/src/execute.h
@@ -189,7 +189,7 @@ BOOL ExpandInfoLineItems(HWND msgParent, const char* varText, CPluginDataInterfa
                          int* varPlacementsCount, DWORD validFileData, BOOL isDisk);
 
 // validates varText containing variables from the MakeFileListItems array
-// msgParent - parent of themessage box for errors; if NULL, errors are not shown
+// msgParent - parent of the message box for errors; if NULL, errors are not shown
 BOOL ValidateMakeFileList(HWND msgParent, const char* varText, int& errorPos1, int& errorPos2);
 
 // expands varText containing variables from MakeFileListItems and stores the result in buffer


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/execute.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/execute.h` as a comment-quality candidate.
- `git diff --check -- src/execute.h` completed without diff integrity failures.
- `git diff -- src/execute.h` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/execute.h` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
