### PR TITLE
[translation] Fix src/menubar.cpp comments

### DIFF
--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -584,7 +584,7 @@ void CMenuBar::EnterMenuInternal(int index, BOOL openWidthSelect, BOOL byMouse)
         PostMessage(hWndUnderCursor, WM_MOUSEMOVE, 0, MAKELPARAM(cursorPos.x, cursorPos.y));
     }
 
-    // we willdeliver the delayed message
+    // we will deliver the delayed message
     if (DispatchDelayedMsg)
     {
         TranslateMessage(&DelayedMsg);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/menubar.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/menubar.cpp` as a comment-quality candidate.
- `git diff --check -- src/menubar.cpp` completed without diff integrity failures.
- `git diff -- src/menubar.cpp` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/menubar.cpp` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
