### PR TITLE
[translation] Fix src/salinflt.h comments

### DIFF
--- a/src/salinflt.h
+++ b/src/salinflt.h
@@ -41,12 +41,12 @@ struct CDecompressionObject
     char* OutputMemPtr;  // current position in the buffer for unpacked data
     DWORD OutputMemSize; // size of the buffer for unpacked data
 
-    //public fields, should be intialized before calling Inflate()
-    uch* SlideWin;    //circular buffer
-    unsigned WinSize; //size of sliding window, should be at least 32K
+    // public fields; should be initialized before calling Inflate()
+    uch* SlideWin;    // circular buffer
+    unsigned WinSize; // size of sliding window, should be at least 32K
 
-    //internal fields
-    unsigned WinPos; //current position in sliding window
+    // internal fields
+    unsigned WinPos; // current position in sliding window
 
     ulg BitBuf;        //bit buffer
     unsigned BitCount; //number of bits in bit buffer */


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salinflt.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/salinflt.h` as a comment-quality candidate.
- `git diff --check -- src/salinflt.h` completed without diff integrity failures.
- `git diff -- src/salinflt.h` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/salinflt.h` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
