### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -461,7 +461,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                     while (--ext >= fileData.cFileName && *ext != '.')
                         ;
                     if (ext < fileData.cFileName)
-                        ext = fileData.cFileName + len; // ".cvspass" in Windows is an extension ...
+                        ext = fileData.cFileName + len; // ".cvspass" is treated as an extension in Windows...
                     else
                         ext++;
                     if (!Filter.AgreeMasks(fileData.cFileName, ext))
@@ -472,7 +472,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                     }
                 }
 
-                //--- if the name is occupied in the array HiddenNames, we will discard it
+                //--- if the name is already present in the HiddenNames array, we discard it
                 if (HiddenNames.Contains(isDir, fileData.cFileName))
                 {
                     if (isDir)
@@ -517,7 +517,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                     while (--s >= st && *s != '.')
                         ;
                     if (s >= st)
-                        file.Ext = file.Name + (s - st + 1); // ".cvspass" in Windows is an extension ...
+                        file.Ext = file.Name + (s - st + 1); // ".cvspass" is treated as an extension in Windows...
                                                              //          if (s > st) file.Ext = file.Name + (s - st + 1);
                     else
                         file.Ext = file.Name + file.NameLen;
@@ -926,7 +926,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                 goto FIND_NEXT_WIN64_REDIRECTEDDIR;
             }
 
-            //--- if the name is occupied in the array HiddenNames, we will discard it
+            //--- if the name is already present in the HiddenNames array, we discard it
             if (HiddenNames.Contains(TRUE, fileData.cFileName))
             {
                 if (!dirWithSameNameExists)
@@ -1013,7 +1013,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         continue;
                     }
 
-                    //--- if the name is occupied in the array HiddenNames, we will discard it
+                    //--- if the name is already present in the HiddenNames array, we discard it
                     if (HiddenNames.Contains(FALSE, f->Name))
                     {
                         HiddenFilesCount++;
@@ -1062,7 +1062,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                         continue;
                     }
 
-                    //--- if the name is occupied in the array HiddenNames, we will discard it
+                    //--- if the name is already present in the HiddenNames array, we discard it
                     if (HiddenNames.Contains(TRUE, f->Name))
                     {
                         HiddenDirsCount++;
@@ -1280,7 +1280,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                             continue;
                         }
 
-                        //--- if the name is occupied in the array HiddenNames, we will discard it
+                        //--- if the name is already present in the HiddenNames array, we discard it
                         if (HiddenNames.Contains(FALSE, f->Name))
                         {
                             HiddenFilesCount++;
@@ -1303,7 +1303,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                             continue;
                         }
 
-                        //--- if the name is occupied in the array HiddenNames, we will discard it
+                        //--- if the name is already present in the HiddenNames array, we discard it
                         if (HiddenNames.Contains(TRUE, f->Name))
                         {
                             HiddenDirsCount++;
@@ -1545,7 +1545,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                                         if (FilterEnabled && !Filter.AgreeMasks(f->Name, f->Ext))
                                             continue;
                                     }
-                                    //--- if the name is occupied in the array HiddenNames, we will discard it
+                                    //--- if the name is already present in the HiddenNames array, we discard it
                                     if (HiddenNames.Contains(isDir, f->Name))
                                         continue;
                                     debugCount++;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 9 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/fileswn3.cpp` as a comment-quality candidate.
- `git diff --check -- src/fileswn3.cpp` completed without diff integrity failures.
- `git diff -- src/fileswn3.cpp` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/fileswn3.cpp` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
