### PR TITLE
[translation] Fix src/geticon.h comments

### DIFF
--- a/src/geticon.h
+++ b/src/geticon.h
@@ -30,13 +30,13 @@
 //      cx/cyIcon are the size of the icon to extract, two sizes
 //      can be extracted by putting size 1 in the loword and size 2 in the
 //      hiword, ie MAKELONG(24, 48) would extract 24 and 48 size icons.
-//      yea this is a stupid hack it is done so IExtractIcon::Extract
-//      can be called by outside people with custom large/small icon
-//      sizes that are not what the shell uses internaly.
+//      yes, this is a hack; it allows IExtractIcon::Extract
+//      to be called by external callers with custom large/small
+//      icon sizes that differ from what the shell uses internally.
 //
 UINT WINAPI ExtractIcons(LPCTSTR szFileName, int nIconIndex, int cxIcon, int cyIcon,
                          HICON* phicon, UINT* piconid, UINT nIcons, UINT flags);
 
-// see comment spl_gen.h/GetFileIcon
+// see the comment in spl_gen.h/GetFileIcon
 BOOL GetFileIcon(const char* path, BOOL pathIsPIDL, HICON* hIcon, CIconSizeEnum iconSize,
                  BOOL fallbackToDefIcon, BOOL defIconIsDir);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/geticon.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/geticon.h` as a comment-quality candidate.
- `git diff --check -- src/geticon.h` completed without diff integrity failures.
- `git diff -- src/geticon.h` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/geticon.h` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
