### PR TITLE
[translation] Fix src/fileswn8.cpp comments

### DIFF
--- a/src/fileswn8.cpp
+++ b/src/fileswn8.cpp
@@ -71,7 +71,7 @@ BOOL CFilesWindow::DeleteThroughRecycleBin(int* selection, int selCount, CFileDa
         char textBuf[2 * MAX_PATH + 200];
         sprintf(textBuf, LoadStr(IDS_RECYCLEBINERROR), path);
         SalMessageBox(MainWindow->HWindow, textBuf, LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
-        return FALSE; // quick dirty bloody hack - Recycle Bin simply cannot handle names ending with a space or dot (it deletes a different name created by trimming those characters, which we definitely don't want)
+        return FALSE; // temporary workaround - Recycle Bin cannot handle names ending with a space or dot (it deletes a different name created by trimming those characters, which we definitely do not want)
     }
     CDynamicStringImp names;
     do
@@ -86,7 +86,7 @@ BOOL CFilesWindow::DeleteThroughRecycleBin(int* selection, int selCount, CFileDa
             char textBuf[2 * MAX_PATH + 200];
             sprintf(textBuf, LoadStr(IDS_RECYCLEBINERROR), oneFile->Name);
             SalMessageBox(MainWindow->HWindow, textBuf, LoadStr(IDS_ERRORTITLE), MB_OK | MB_ICONEXCLAMATION);
-            return FALSE; // quick dirty bloody hack - Recycle Bin simply cannot handle names ending with a space or dot (it deletes a different name created by trimming those characters, which we definitely do not want)
+            return FALSE; // temporary workaround - Recycle Bin cannot handle names ending with a space or dot (it deletes a different name created by trimming those characters, which we definitely do not want)
         }
         // oneFile points to the selected item or the caret item in the filebox
         if (!names.Add(path, pathLen) ||


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn8.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Manual root-level `src/` review against baseline commit `a28afcb958578dd219311a7b500320b162de812b` identified `src/fileswn8.cpp` as a comment-quality candidate.
- `git diff --check -- src/fileswn8.cpp` completed without diff integrity failures.
- `git diff -- src/fileswn8.cpp` confirms a comment-only change.

## Telemetry
- Root-level `src/` triage for this repository sweep classified `src/fileswn8.cpp` as `needs-pr` before editing.
- Local verification for this PR used Git diff inspection only; no separate pipeline telemetry was recorded.
