### PR TITLE
[translation] Fix src/plugins/pak/spl/pak.cpp comments

### DIFF
--- a/src/plugins/pak/spl/pak.cpp
+++ b/src/plugins/pak/spl/pak.cpp
@@ -80,12 +80,12 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     { // reject older versions
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
-                   "PAK" /* neprekladat! */, MB_OK | MB_ICONERROR);
+                   "PAK" /* do not translate! */, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
     // let the language module (.slg) load
-    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "PAK" /* neprekladat! */);
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "PAK" /* do not translate! */);
     if (HLanguage == NULL)
         return NULL;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/pak/spl/pak.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pak/spl/pak.cpp`.
- `git diff --check -- src/plugins/pak/spl/pak.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
