### PR TITLE
[translation] Fix src/plugins/regedt/regedt.cpp comments

### DIFF
--- a/src/plugins/regedt/regedt.cpp
+++ b/src/plugins/regedt/regedt.cpp
@@ -220,12 +220,12 @@ CPluginInterfaceAbstract* WINAPI SalamanderPluginEntry(CSalamanderPluginEntryAbs
     { // cannot call Error here because it uses SG->SalMessageBox (SG not initialized + incompatible interface)
         MessageBox(salamander->GetParentWindow(),
                    REQUIRE_LAST_VERSION_OF_SALAMANDER,
-                   "Registry Editor" /* neprekladat! */, MB_OK | MB_ICONERROR);
+                   "Registry Editor" /* do not translate! */, MB_OK | MB_ICONERROR);
         return NULL;
     }
 
     // load the language module (.slg)
-    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "Registry Editor" /* neprekladat! */);
+    HLanguage = salamander->LoadLanguageModule(salamander->GetParentWindow(), "Registry Editor" /* do not translate! */);
     if (HLanguage == NULL)
         return NULL;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/regedt/regedt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/regedt/regedt.cpp`.
- `git diff --check -- src/plugins/regedt/regedt.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
