### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h
+++ b/src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h
@@ -89,7 +89,7 @@ public:
     CZRoot(TCHAR const* name, CLogger* logger, int sortorder = FILESIZE_DISK) : CZDirectory(NULL, name, NULL, NULL)
     {
         this->_clustersize = 0;
-        this->_minimalfilesize = 0; //TODO: pro NTFS = 512
+        this->_minimalfilesize = 0; // TODO: use 512 for NTFS
 
         this->_allfilecount = 0;
         this->_alldircount = 0;
@@ -109,7 +109,7 @@ public:
     }
     int GetSortOrder() { return this->_sortorder; }
 
-    //FIXME: toto je hack :(
+    // FIXME: this is a hack.
     void SetClusterSize(int clustersize)
     {
         this->_clustersize = clustersize;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h`.
- `git diff --check -- src/plugins/diskmap/DiskMap/TreeMap.FileData.CZRoot.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
