### PR TITLE
[translation] Fix src/plugins/7zip/open.h comments

### DIFF
--- a/src/plugins/7zip/open.h
+++ b/src/plugins/7zip/open.h
@@ -37,7 +37,7 @@ private:
     UString& Password;
 
 public:
-    // If entered, the password gets propagated towards password
+    // If entered, the password is returned through the password parameter
     CArchiveOpenCallbackImp(UString& password);
     ~CArchiveOpenCallbackImp();
 };


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/7zip/open.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/7zip/open.h`.
- `git diff --check -- src/plugins/7zip/open.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
