### PR TITLE
[translation] Fix src/plugins/7zip/7zclient.h comments

### DIFF
--- a/src/plugins/7zip/7zclient.h
+++ b/src/plugins/7zip/7zclient.h
@@ -24,12 +24,12 @@
 #include "structs.h"
 
 #ifndef FILE_ATTRIBUTE_UNIX_EXTENSION
-// Transfered from p7zip (portable 7zip)
+// Transferred from p7zip (portable 7zip)
 #define FILE_ATTRIBUTE_UNIX_EXTENSION 0x8000 /* trick for Unix */
 #endif
 
 #ifndef S_ISLNK
-// Transfered from sys/stat.h on Mac (and other Unix systems)
+// Transferred from sys/stat.h on Mac (and other Unix systems)
 #define S_ISLNK(m) (((m) & 0170000) == 0120000) /* symbolic link */
 #endif
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/7zip/7zclient.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/7zip/7zclient.h`.
- `git diff --check -- src/plugins/7zip/7zclient.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
