### PR TITLE
[translation] Fix src/plugins/diskmap/DiskMap/GUI.ShellMenu.h comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/GUI.ShellMenu.h
+++ b/src/plugins/diskmap/DiskMap/GUI.ShellMenu.h
@@ -102,7 +102,7 @@ protected:
     //      piMalloc - Pointer to the allocator interface that should allocate memory.
     //  cbSize   - Size of the ITEMIDLIST to create.
     //  RETURN VALUE:
-    //      Returns a pointer to the new ITEMIDLIST, or NULL if a problem occured.
+    //      Returns a pointer to the new ITEMIDLIST, or NULL if a problem occurred.
     LPITEMIDLIST PIDL_Create(DWORD size)
     {
         LPITEMIDLIST res = (LPITEMIDLIST)CoTaskMemAlloc(size);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/diskmap/DiskMap/GUI.ShellMenu.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/diskmap/DiskMap/GUI.ShellMenu.h`.
- `git diff --check -- src/plugins/diskmap/DiskMap/GUI.ShellMenu.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
