### PR TITLE
[translation] Fix src/plugins/nethood/nethoodfs2.h comments

### DIFF
--- a/src/plugins/nethood/nethoodfs2.h
+++ b/src/plugins/nethood/nethoodfs2.h
@@ -152,7 +152,7 @@ public:
     /// \param bufSize Size of the buffer, in characters.
     /// \return If the method succeeds it should return nonzero value,
     ///         otherwise it should return zero.
-    /// Implement this method to get the Alt+Insert behavior. Is is also
+    /// Implement this method to get the Alt+Insert behavior. It is also
     /// used by the drag'n'drop manipulation and Ctrl+Shift+arrow handling.
     virtual BOOL WINAPI GetFullName(
         __in CFileData& file,


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/nethoodfs2.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/nethoodfs2.h`.
- `git diff --check -- src/plugins/nethood/nethoodfs2.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
