### PR TITLE
[translation] Fix src/plugins/nethood/tree.h comments

### DIFF
--- a/src/plugins/nethood/tree.h
+++ b/src/plugins/nethood/tree.h
@@ -40,7 +40,7 @@ protected:
         /// Pointer to the next sibling in the chain.
         CNode* m_pNextSibling;
 
-        /// Pointer to the the first child in the chain.
+        /// Pointer to the first child in the chain.
         CNode* m_pFirstChild;
 
         /// Pointer to the parent node.


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/tree.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/tree.h`.
- `git diff --check -- src/plugins/nethood/tree.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
