### PR TITLE
[translation] Fix src/plugins/undelete/library/arraylt.h comments

### DIFF
--- a/src/plugins/undelete/library/arraylt.h
+++ b/src/plugins/undelete/library/arraylt.h
@@ -58,7 +58,7 @@ enum CErrorType
 //   contain pointers to its own data, reason:
 //     objects are moved in array (e.g. when reallocating array or when inserting
 //     item to the beginning of array) simply by using memmove, so during these
-//     moves contructors/destructors are not called, example:
+//     moves constructors/destructors are not called; for example:
 //       char Path[MAX_PATH];  // full file name
 //       char *Name;           // points to 'Path' to file name (without path)
 //     SOLUTION: store only offsets instead of complete pointers
@@ -67,7 +67,7 @@ template <class DATA_TYPE>
 class TDirectArray
 {
 public:
-    CErrorType State; // etNone if array is OK, otherwise some error occured
+    CErrorType State; // etNone if array is OK, otherwise some error occurred
     int Count;        // current count of items in array
 
     TDirectArray<DATA_TYPE>(int base, int delta);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/undelete/library/arraylt.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/undelete/library/arraylt.h`.
- `git diff --check -- src/plugins/undelete/library/arraylt.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
