### PR TITLE
[translation] Fix src/plugins/filecomp/cwbase.h comments

### DIFF
--- a/src/plugins/filecomp/cwbase.h
+++ b/src/plugins/filecomp/cwbase.h
@@ -49,7 +49,7 @@ protected:
     const int& CancelFlag; // 0 ... keep going, otherwise finish
     CFCFileData Files[2];
 
-    // work buffers for StrictCompare are to prevent offten re-allocation when
+    // work buffers for StrictCompare prevent repeated reallocation when
     // called multiple times
     struct CStrictData
     {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/cwbase.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/cwbase.h`.
- `git diff --check -- src/plugins/filecomp/cwbase.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
