### PR TITLE
[translation] Fix src/plugins/filecomp/filecache.cpp comments

### DIFF
--- a/src/plugins/filecomp/filecache.cpp
+++ b/src/plugins/filecomp/filecache.cpp
@@ -49,7 +49,7 @@ int CCachedFile::SetFile(HANDLE file)
     {
         return 1;
     }
-    // Allocate slightly more to accomodate aligned seeking in ReadBuffer
+    // Allocate slightly more to accommodate aligned seeking in ReadBuffer
     Buffer = (LPBYTE)malloc(BUFFER_SIZE + SECTOR_SIZE);
     if (!Buffer)
     {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/filecache.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/filecache.cpp`.
- `git diff --check -- src/plugins/filecomp/filecache.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
