### PR TITLE
[translation] Fix src/plugins/undelete/fs2.cpp comments

### DIFF
--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -779,8 +779,8 @@ BOOL CPluginFSInterface::CopyFile(FILE_RECORD_I<char>* record, char* filename, c
     // extract all streams
     char* pathend = path + strlen(path);
 
-    // we want to copy file stream (no ADS streams) first
-    // otherwise file overwrite test will be broken beacuse with ADS will be also created base file
+    // we want to copy the file stream (without ADS streams) first
+    // otherwise the overwrite check would fail because ADS would also create the base file
     TDirectArray<DATA_STREAM_I<char>*> copyStreams(10, 10);
     DATA_STREAM_I<char>* stream = record->Streams;
     while (stream != NULL)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/undelete/fs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/undelete/fs2.cpp`.
- `git diff --check -- src/plugins/undelete/fs2.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
