### PR TITLE
[translation] Fix src/plugins/undelete/undelete.h comments

### DIFF
--- a/src/plugins/undelete/undelete.h
+++ b/src/plugins/undelete/undelete.h
@@ -344,8 +344,8 @@ public:
     virtual void WINAPI ShowSecurityInfo(HWND parent) {}
 
     BOOL GetTempDirOutsideRoot(HWND parent, char* buffer, char** ret);
-#if defined(_DEBUG) && _WIN32_WINNT >= 0x0501 // some debug feauters works from Windows XP (NTFS 5.0)
-    // NOTE: following functions are just quitch, dirty, and minimal tests (no error handling, etc)
+#if defined(_DEBUG) && _WIN32_WINNT >= 0x0501 // some debug features work on Windows XP and later (NTFS 5.0)
+    // NOTE: the following functions are quick, dirty, minimal tests (no error handling, etc.)
     // included only in debug build
     void DumpSpecifiedFiles(FILE* file, FILE_RECORD_I<char>* dir, char* path, int pathSize);
     void DumpDirItemInfo(FILE* file, const DIR_ITEM_I<char>* di);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/undelete/undelete.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/undelete/undelete.h`.
- `git diff --check -- src/plugins/undelete/undelete.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
