### PR TITLE
[translation] Fix src/plugins/zip/add.cpp comments

### DIFF
--- a/src/plugins/zip/add.cpp
+++ b/src/plugins/zip/add.cpp
@@ -1630,7 +1630,7 @@ int CZipPack::PackFiles()
                 if (Options.Action & PA_MULTIVOL)
                 {
                     TempFile->FilePointer = file.LocHeaderOffs;
-                    // Pleasee the comment for encrypted archives 35 lines above, it applies also here
+                    // See the comment for encrypted archives 35 lines above; it applies here as well
                     if (Config.Level <= 2)
                     {
                         next->Flag |= FAST;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/add.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment occurrence in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/add.cpp`.
- `git diff --check -- src/plugins/zip/add.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment occurrence, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
