### PR TITLE
[translation] Fix src/plugins/zip/common.cpp comments

### DIFF
--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -325,8 +325,8 @@ int CZipCommon::Read(CFile* file, void* buffer, unsigned bytesToRead,
 {
     CALL_STACK_MESSAGE_NONE // performance-critical method
                             //  CALL_STACK_MESSAGE3("CZipCommon::Read(, , 0x%X, , ) file: %s", bytesToRead, file->FileName);
-        unsigned long read; //number of butes read by ReadFile()
-    unsigned long toRead;   //number of butes read by ReadFile()
+        unsigned long read; // number of bytes read by ReadFile()
+    unsigned long toRead;   // number of bytes requested from ReadFile()
     int result;             //temp variable
     int errorID;            // error message identifier
     int lastError;          //value returned by GetLastError()
@@ -511,7 +511,7 @@ int CZipCommon::Flush(CFile* file, const void* buffer, unsigned bytesToWrite,
                       bool* skipAll)
 {
     CALL_STACK_MESSAGE3("CZipCommon::Flush(, , 0x%X, ) file: %s", bytesToWrite, file->FileName);
-    unsigned long bytesWritten; //number of butes read by ReadFile()
+    unsigned long bytesWritten; // number of bytes written by WriteFile()
     int result;                 //temp variable
     int errorID = 0;            //error string identifier
 
@@ -1083,7 +1083,7 @@ int CZipCommon::FindZip64EOCentrDirLocator()
         // and refuse to modify it; so far we have encountered only one file
         // like this, and deleting files inside the archive caused
         // the archive data to become corrupted
-        // TODO: save manison.zip in a repository of weird ZIPs and add a correct reference here
+        // TODO: save mansion.zip in a repository of weird ZIPs and add a correct reference here
         //EOCentrDir.DiskNum = __UINT16(zip64Record.DiskNum);
     }
     if (EOCentrDir.StartDisk == 0xFFFF)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/common.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/common.cpp`.
- `git diff --check -- src/plugins/zip/common.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 3 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
