### PR TITLE
[translation] Fix src/plugins/zip/common.h comments

### DIFF
--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -33,14 +33,14 @@ public:
     CZIPFileData(QWORD qwPackedSize, int nItem, BOOL bUnix) : PackedSize(qwPackedSize), ItemNumber(nItem), Unix(bUnix) {}
 
     QWORD PackedSize;
-    int ItemNumber; // # of item in Cetral Directory, not offset
+    int ItemNumber; // item index in Central Directory, not offset
     BOOL Unix;
 };
 
 struct CExtInfo
 {
     LPTSTR Name;
-    int ItemNumber; // # of item in Cetral Directory, not offset
+    int ItemNumber; // item index in Central Directory, not offset
     bool IsDir;
 
     CExtInfo(LPCTSTR pName, bool isDir, int nItem);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/common.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/common.h`.
- `git diff --check -- src/plugins/zip/common.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
