### PR TITLE
[translation] Fix src/plugins/zip/iosfxset.h comments

### DIFF
--- a/src/plugins/zip/iosfxset.h
+++ b/src/plugins/zip/iosfxset.h
@@ -12,7 +12,7 @@ extern const char* SFX_TDREGVAL;
 
 int ImportSFXSettings(const char* textData, CSfxSettings* settings, const char* zip2sfxDir);
 
-// return valueas
+// return values
 //
 // lower word is one of the following values:
 //
@@ -22,6 +22,6 @@ int ImportSFXSettings(const char* textData, CSfxSettings* settings, const char* 
 // 3 unknown keyword in $()
 // 4 bad key
 //
-// higher word contains index of where the syntax error occured in the target dir string
+// higher word contains the index where the syntax error occurred in the target dir string
 DWORD ParseTargetDir(const char* path, unsigned* targetDir, const char** subDir,
                      const char** dirSpecLeft, const char** dirSpecRight, HKEY* Key);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/iosfxset.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment occurrences in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/iosfxset.h`.
- `git diff --check -- src/plugins/zip/iosfxset.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment occurrences, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
