### PR TITLE
[translation] Fix src/common/str.cpp comments

### DIFF
--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -175,7 +175,7 @@ chk_null:
     mov     bl,[edi] // bl = *s1
     inc     edi
 
-    cmp     al,bl // first try case-sensitive comparision
+    cmp     al,bl // first try case-sensitive comparison
     je      short chk_null // match
 
     mov     al,[edx + eax] // convert *s2 char to lower case


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/common/str.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comment against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/common/str.cpp`.
- `git diff --check -- src/common/str.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
