### PR TITLE
[translation] Fix src/common/trace.h comments

### DIFF
--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -110,7 +110,7 @@ public:
     }
 
 protected:
-    // store the element in the buffer, growing it if neccessary
+    // store the element in the buffer, growing it if necessary
     virtual int_type overflow(int_type element = traits_type::eof())
     {
         // if EOF, just return success
@@ -139,7 +139,7 @@ protected:
             if (ptr == 0)
                 return traits_type::eof();
 
-            // copy data and dealocate old buffer, if neccessary
+            // copy data and deallocate old buffer, if necessary
             if (pbase())
             {
                 traits_type::_Copy_s(ptr, newsize, pbase(), oldsize);
@@ -215,7 +215,7 @@ public:
     }
 
 protected:
-    // store the element in the buffer, growing it if neccessary
+    // store the element in the buffer, growing it if necessary
     virtual int_type overflow(int_type element = traits_type::eof())
     {
         // if EOF, just return success
@@ -244,7 +244,7 @@ protected:
             if (ptr == 0)
                 return traits_type::eof();
 
-            // copy data and dealocate old buffer, if neccessary
+            // copy data and deallocate old buffer, if necessary
             if (pbase())
             {
                 traits_type::_Copy_s(ptr, newsize, pbase(), oldsize);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/common/trace.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/common/trace.h`.
- Branch-target comment guard passed for `src/common/trace.h`.
- `git diff --check -- src/common/trace.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 4 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
