### PR TITLE
[translation] Fix src/plugins/7zip/7zip.h comments

### DIFF
--- a/src/plugins/7zip/7zip.h
+++ b/src/plugins/7zip/7zip.h
@@ -125,7 +125,7 @@ protected:
     C7zClient* Client;
     UString Password;
 
-    friend class CPluginInterfaceForArchiver; // For acessing Password
+    friend class CPluginInterfaceForArchiver; // For accessing Password
 
 public:
     CPluginDataInterface(C7zClient* client);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/7zip/7zip.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/7zip/7zip.h`.
- `git diff --check -- src/plugins/7zip/7zip.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.