### PR TITLE
[translation] Fix src/plugins/automation/abortpalette.cpp comments

### DIFF
--- a/src/plugins/automation/abortpalette.cpp
+++ b/src/plugins/automation/abortpalette.cpp
@@ -280,7 +280,7 @@ unsigned CScriptAbortPaletteThread::Body()
     // Let everyone know that the palette window is now ready.
     SetEvent(m_hWindowCreatedEvt);
 
-    // Remove unneccessary items from the system menu.
+    // Remove unnecessary items from the system menu.
     HMENU hSysMenu = GetSystemMenu(hwndPalette, FALSE);
     if (hSysMenu != NULL)
     {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/abortpalette.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/abortpalette.cpp`.
- `git diff --check -- src/plugins/automation/abortpalette.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
