### PR TITLE
[translation] Fix src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs comments

### DIFF
--- a/src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs
+++ b/src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs
@@ -271,7 +271,7 @@ namespace sspack
 		/// </summary>
 		Unique = 0x02,
 		/// <summary>
-		/// Inidicates that the argument may be specified more than once.
+		/// Indicates that the argument may be specified more than once.
 		/// Only valid if the argument is a collection
 		/// </summary>
 		Multiple = 0x04,
@@ -419,7 +419,7 @@ namespace sspack
 	/// <summary>
 	/// Parser for command line arguments.
 	///
-	/// The parser specification is infered from the instance fields of the object
+	/// The parser specification is inferred from the instance fields of the object
 	/// specified as the destination of the parse.
 	/// Valid argument types are: int, uint, string, bool, enums
 	/// Also argument types of Array of the above types are also valid.
@@ -449,7 +449,7 @@ namespace sspack
 
 		/// <summary>
 		/// Parses Command Line Arguments. Displays usage message to Console.Out
-		/// if /?, /help or invalid arguments are encounterd.
+		/// if /?, /help or invalid arguments are encountered.
 		/// Errors are output on Console.Error.
 		/// Use ArgumentAttributes to control parsing behaviour.
 		/// </summary>
@@ -598,7 +598,7 @@ namespace sspack
 		/// <param name="text"> The text to search. </param>
 		/// <param name="value"> The character value to search for. </param>
 		/// <param name="startIndex"> The index to stat searching at. </param>
-		/// <returns> The index of the first occurence of value or -1 if it is not found. </returns>
+		/// <returns> The index of the first occurrence of value or -1 if it is not found. </returns>
 		public static int IndexOf(StringBuilder text, char value, int startIndex)
 		{
 			for (int index = startIndex; index < text.Length; index++)
@@ -616,7 +616,7 @@ namespace sspack
 		/// <param name="text"> The text to search. </param>
 		/// <param name="value"> The character to search for. </param>
 		/// <param name="startIndex"> The index to start the search at. </param>
-		/// <returns>The index of the last occurence of value in text or -1 if it is not found. </returns>
+		/// <returns>The index of the last occurrence of value in text or -1 if it is not found. </returns>
 		public static int LastIndexOf(StringBuilder text, char value, int startIndex)
 		{
 			for (int index = Math.Min(startIndex, text.Length - 1); index >= 0; index--)
@@ -811,7 +811,7 @@ namespace sspack
 		}
 
 		/// <summary>
-		/// A user firendly usage string describing the command line argument syntax.
+		/// A user friendly usage string describing the command line argument syntax.
 		/// </summary>
 		public string GetUsageString(int screenWidth)
 		{


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `6` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs`.
- `git diff --check -- src/plugins/portables/res/SpriteSheetPacker/src/sspack/ProgramArguments.cs` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `6` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
