### PR TITLE
[translation] Fix src/plugins/renamer/regiface.h comments

### DIFF
--- a/src/plugins/renamer/regiface.h
+++ b/src/plugins/renamer/regiface.h
@@ -21,7 +21,7 @@ typedef int BOOL;
 
 // ******************************************************************
 //
-// Error codes - errors can occur when compilig or matching expresion
+// Error codes - errors can occur when compiling or matching expression
 //
 
 enum CRegExpErrors
@@ -110,7 +110,7 @@ public:
     virtual BOOL RegComp(char* exp, unsigned options) = 0;
 
     // Match 'string' against previously compiled pattern. 'length'
-    // is leghth of string. Matching starts at 'offest' in subject
+    // is length of string. Matching starts at 'offset' in subject
     // string.
     // If 'separateThread' is TRUE, matching is executed in separate
     // thread, such matching is protected against stack overflow,


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/renamer/regiface.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/renamer/regiface.h`.
- `git diff --check -- src/plugins/renamer/regiface.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
