### PR TITLE
[translation] Fix src/bugreprt.cpp comments

### DIFF
--- a/src/bugreprt.cpp
+++ b/src/bugreprt.cpp
@@ -2189,7 +2189,7 @@ void CCallStack::PrintBugReport(EXCEPTION_POINTERS* Exception, DWORD ThreadID, D
                                 __try
                                 {
                                     // *(ebp) is the frame pointer of the calling function
-                                    // *(ebp + 4) is the return adress (the place in the calling function where
+                                    // *(ebp + 4) is the return address (the place in the calling function where
                                     //            execution will resume after we return from this function)
                                     DWORD* ebp = (DWORD*)ctx.Ebp;
 
@@ -2452,7 +2452,7 @@ void CCallStack::PrintBugReport(EXCEPTION_POINTERS* Exception, DWORD ThreadID, D
                         int drv = drive - 'A' + 1;
                         DWORD medium = GetDriveFormFactor(drv);
                         if (medium == 350 || medium == 525 || medium == 800 || medium == 1)
-                            getMoreInfo = FALSE; // avoid unnecesary floppy disk operations during MyGetVolumeInformation()
+                            getMoreInfo = FALSE; // avoid unnecessary floppy disk operations during MyGetVolumeInformation()
                     }
 
                     if (getMoreInfo)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/bugreprt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/bugreprt.cpp`.
- `git diff --check -- src/bugreprt.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
