### PR TITLE
[translation] Fix src/plugins/unarj/unarj.cpp comments

### DIFF
--- a/src/plugins/unarj/unarj.cpp
+++ b/src/plugins/unarj/unarj.cpp
@@ -609,7 +609,7 @@ void __fastcall FillInputBuffer()
     while (1)
     {
         if (ReadFile(ArcFile, InputBuffer, toRead, &read, NULL) && toRead == read)
-            break; //sucess
+            break; //success
         if (!ErrorProc(AE_ACCESS, EF_RETRY))
             throw 0;
         SafeSeek(ArcFilePos);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/unarj/unarj.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/unarj/unarj.cpp`.
- `git diff --check -- src/plugins/unarj/unarj.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
