### PR TITLE
[translation] Fix src/plugins/mmviewer/ogg/ogg.h comments

### DIFF
--- a/src/plugins/mmviewer/ogg/ogg.h
+++ b/src/plugins/mmviewer/ogg/ogg.h
@@ -75,7 +75,7 @@ extern "C"
         ogg_int64_t packetno; /* sequence number for decode; the framing
                              knows where there's a hole in the data,
                              but we need coupling so that the codec
-                             (which is in a seperate abstraction
+                             (which is in a separate abstraction
                              layer) also knows about the gap */
         ogg_int64_t granulepos;
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/mmviewer/ogg/ogg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/mmviewer/ogg/ogg.h`.
- `git diff --check -- src/plugins/mmviewer/ogg/ogg.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
