### PR TITLE
[translation] Fix src/plugins/automation/guicomponent.cpp comments

### DIFF
--- a/src/plugins/automation/guicomponent.cpp
+++ b/src/plugins/automation/guicomponent.cpp
@@ -315,7 +315,7 @@ LRESULT STDMETHODCALLTYPE CSalamanderGuiComponentBase::OnMessage(
             reinterpret_cast<LONG_PTR>(m_pfnPrevWndProc)));
 
         // If this assertion fails, it means that the component
-        // was sublassed more than once and that the subclass
+        // was subclassed more than once and that the subclass
         // chain was corrupted.
         _ASSERTE(pfnWndProc == SubclassWndProc);
 
@@ -350,7 +350,7 @@ void STDMETHODCALLTYPE CSalamanderGuiComponentBase::RecalcBounds(
     HWND hWnd,
     HDC hDC)
 {
-    // Should be overriden in inherited class.
+    // Should be overridden in inherited class.
     _ASSERTE(0);
 }
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guicomponent.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guicomponent.cpp`.
- `git diff --check -- src/plugins/automation/guicomponent.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
