### PR TITLE
[translation] Fix src/plugins/unarj/unarjspl.cpp comments

### DIFF
--- a/src/plugins/unarj/unarjspl.cpp
+++ b/src/plugins/unarj/unarjspl.cpp
@@ -760,7 +760,7 @@ int CPluginInterfaceForArchiver::ProcessDataProc(const void* buffer, DWORD size)
                 Abort = TRUE;
                 return 0;
             }
-            return 1; // sucess
+            return 1; // success
         }
         lstrcpy(buf, LoadStr(IDS_UNABLEWRITE));
         FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS, NULL,


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/unarj/unarjspl.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/unarj/unarjspl.cpp`.
- `git diff --check -- src/plugins/unarj/unarjspl.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
