### PR TITLE
[translation] Fix src/dialogs.cpp comments

### DIFF
--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -1270,7 +1270,7 @@ MENU_TEMPLATE_ITEM ProgressDialogMenu2[] =
         {
             // Prior to Windows Vista we only called GetNextWindow(), which was enough to reach the next window in the Z-order.
             // Vista introduced new hidden helper windows such as "MSCTFIME UI" and "Default IME" that sit between us and
-            // our window (main, viver, ect.). So we skip hidden windows here.
+            // our window (main, viewer, etc.). So we skip hidden windows here.
             BOOL valid;
             HWND hNext = HWindow;
             do


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/dialogs.cpp`.
- `git diff --check -- src/dialogs.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
