### PR TITLE
[translation] Fix src/plugins/automation/guicomponent.h comments

### DIFF
--- a/src/plugins/automation/guicomponent.h
+++ b/src/plugins/automation/guicomponent.h
@@ -27,7 +27,7 @@ private:
     /// Dispatch ID of the member.
     DISPID m_dispid;
 
-    /// Original window procedure before installation of the sublass hook.
+    /// Original window procedure before installation of the subclass hook.
     WNDPROC m_pfnPrevWndProc;
 
     /// Our subclass window procedure.
@@ -61,7 +61,7 @@ protected:
 
     virtual HWND CreateHwnd(HWND hWndParent)
     {
-        // Must be overriden.
+        // Must be overridden.
         _ASSERTE(0);
         return NULL;
     }


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guicomponent.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guicomponent.h`.
- `git diff --check -- src/plugins/automation/guicomponent.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
