### PR TITLE
[translation] Fix src/plugins/uncab/uncab.cpp comments

### DIFF
--- a/src/plugins/uncab/uncab.cpp
+++ b/src/plugins/uncab/uncab.cpp
@@ -1221,7 +1221,7 @@ CPluginInterfaceForArchiver::Open(char* pszFile, int oflag, int pmode)
                 SafeSeek(ret, 0, FILE_BEGIN);
             }
 
-            return (INT_PTR)ret; //sucess
+            return (INT_PTR)ret; //success
         }
         char buf[1024];
         lstrcpy(buf, LoadStr(IDS_UNABLECREATE));
@@ -1394,7 +1394,7 @@ UINT CPluginInterfaceForArchiver::Write(INT_PTR hf, void* pv, UINT cb)
                 Abort = TRUE;
                 return -1;
             }
-            return written; // sucess
+            return written; // success
         }
 
         lstrcpy(buf, LoadStr(IDS_UNABLEWRITE));


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/uncab/uncab.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/uncab/uncab.cpp`.
- `git diff --check -- src/plugins/uncab/uncab.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
