### PR TITLE
[translation] Fix src/drivelst.cpp comments

### DIFF
--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -358,7 +358,7 @@ BOOL IsAdminShareExtraLogonFailureErr(DWORD err, const char* root)
         root++;
         while (*++root != 0 && *root != '\\' && CharIsAllowedInServerName(*root))
             ;             // skip the server name and do a simple check (incomplete; for example, it also rejects dots in IPv4 and IPv6) whether this is really an invalid name (in that case, we will not ask for a username and password)
-        if (*root == '.') // we will take care of IPv4 adresses (let's ignore IPv6)
+        if (*root == '.') // we will take care of IPv4 addresses (let's ignore IPv6)
         {
             const char* r = root;
             while (*++r != 0 && *r != '\\')
@@ -1518,7 +1518,7 @@ void InitOneDrivePath()
     {
         DWORD i = 0;
         while (1)
-        { // enumarate all extensions one by one
+        { // enumerate all extensions one by one
             char keyName[300];
             DWORD keyNameLen = _countof(keyName);
             if (RegEnumKeyEx(hKey, i, keyName, &keyNameLen, NULL, NULL, NULL, NULL) == ERROR_SUCCESS)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/drivelst.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/drivelst.cpp`.
- `git diff --check -- src/drivelst.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
