### PR TITLE
[translation] Fix src/plugins/automation/guicontainer.h comments

### DIFF
--- a/src/plugins/automation/guicontainer.h
+++ b/src/plugins/automation/guicontainer.h
@@ -101,7 +101,7 @@ protected:
 
     /// Inserts temporary member.
     /// \param pszName Name of the member.
-    /// \return Returs DISPID assigned to the member.
+    /// \return Returns DISPID assigned to the member.
     DISPID InsertMember(LPCOLESTR pszName);
 
     HRESULT ContainerGetMember(
@@ -138,7 +138,7 @@ protected:
         return T::GetProgId();
     }
 
-    /// Implemented - overriden.
+    /// Implemented - overridden.
     virtual ISalamanderGuiComponentInternal* GetChildNoAddRef()
     {
         return this->m_pChild;
@@ -149,7 +149,7 @@ protected:
         this->AddComponent(pComponent);
     }
 
-    /// Overriden - inherited from CUnknownImpl.
+    /// Overridden - inherited from CUnknownImpl.
     void FinalRelease()
     {
         ISalamanderGuiComponentInternal* pChild = this->m_pChild;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guicontainer.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `3` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guicontainer.h`.
- `git diff --check -- src/plugins/automation/guicontainer.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `3` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
