### PR TITLE
[translation] Fix src/editwnd.h comments

### DIFF
--- a/src/editwnd.h
+++ b/src/editwnd.h
@@ -34,7 +34,7 @@ protected:
 // ****************************************************************************
 //
 
-// text in the combo box in command line; we cach it so it will not flicker
+// text in the combo box in command line; we cache it so it will not flicker
 // because it is handled from the main thread we can operate via ItemBitmap
 
 class CInnerText : public CWindow


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/editwnd.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/editwnd.h`.
- `git diff --check -- src/editwnd.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
