### PR TITLE
[translation] Fix src/plugins/undelete/fs2.cpp comments

### DIFF
--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -2028,7 +2028,7 @@ void CPluginFSInterface::FragmentFile(HWND parent, const DIR_ITEM_I<char>* di, c
         goto exit;
     }
 
-    // find free cluster, use returned re-alligned starting LCN
+    // find free cluster, use returned realigned starting LCN
     for (int i = 0; freeLCN == -1 && i < BITMAP_BUFFER_SIZE - sizeof(VOLUME_BITMAP_BUFFER) - 32; i++)
     {
         if (bitmap->Buffer[i] != 0xFF)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/undelete/fs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/undelete/fs2.cpp`.
- `git diff --check -- src/plugins/undelete/fs2.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
