### PR TITLE
[translation] Fix src/execute.cpp comments

### DIFF
--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -723,7 +723,7 @@ const char* WINAPI ExecuteExpNamePart(HWND msgParent, void* param)
     }
     strcpy(data->Buffer, s + 1);
     char* ss = strrchr(data->Buffer, '.');
-    //  if (ss != NULL && ss != data->Buffer)   // extension is present ('.' not at the begining of the name, e.g. ".cvspass")
+    //  if (ss != NULL && ss != data->Buffer)   // extension is present ('.' not at the beginning of the name, e.g. ".cvspass")
     if (ss != NULL) // An extension is present (".cvspass" is considered an extension in Windows)
         *ss = 0;
     return data->Buffer;
@@ -742,7 +742,7 @@ const char* WINAPI ExecuteExpExtPart(HWND msgParent, void* param)
     }
     strcpy(data->Buffer, s + 1);
     s = strrchr(data->Buffer, '.');
-    //  if (s != NULL && s != data->Buffer)   // extension is present ('.' not at the begining of the name, e.g. ".cvspass")
+    //  if (s != NULL && s != data->Buffer)   // extension is present ('.' not at the beginning of the name, e.g. ".cvspass")
     if (s != NULL) // An extension is present here (".cvspass" is considered an extension in Windows)
         return s + 1;
     return "";


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/execute.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/execute.cpp`.
- `git diff --check -- src/execute.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
