### PR TITLE
[translation] Fix src/plugins/automation/guidefs.h comments

### DIFF
--- a/src/plugins/automation/guidefs.h
+++ b/src/plugins/automation/guidefs.h
@@ -8,7 +8,7 @@
 	Copyright (c) 2010-2023 Open Salamander Authors
 	
 	guidefs.h
-	Miscelaneous definitions for the GUI.
+	Miscellaneous definitions for the GUI.
 */
 
 #pragma once


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guidefs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guidefs.h`.
- `git diff --check -- src/plugins/automation/guidefs.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
