### PR TITLE
[translation] Fix src/plugins/undelete/library/ntfs.h comments

### DIFF
--- a/src/plugins/undelete/library/ntfs.h
+++ b/src/plugins/undelete/library/ntfs.h
@@ -1422,7 +1422,7 @@ BOOL CMFTSnapshot<CHAR>::GetLostClustersMap(CClusterBitmap* clusterBitmap, CLUST
     clusterMap->Free();
     QWORD clusterCount = clusterBitmap->GetClusterCount();
 
-    // pass 0: get size of arrays we shoud allocate, allocet them
+    // pass 0: get size of arrays we should allocate, allocate them
     // pass 1: fill these arrays
     for (int pass = 0; pass < 2; pass++)
     {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/undelete/library/ntfs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/undelete/library/ntfs.h`.
- `git diff --check -- src/plugins/undelete/library/ntfs.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
