### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -259,7 +259,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
         iconData.SetReadingDone(0); // just for the form
         BOOL addtoIconCache;
         CFileData file;
-        // inicialization of structure members which will not be changed later
+        // initialization of structure members which will not be changed later
         file.PluginData = -1; // -1 just like that, ignored
         file.Selected = 0;
         file.SizeValid = 0;
@@ -2320,7 +2320,7 @@ CHANGE_AGAIN:
                             else
                                 st += strlen(st);
 
-                            // copy containts the "translated" path
+                            // copy contains the "translated" path
                             if (!pathEndsWithSpaceOrDot)
                                 copyAttr = find.dwFileAttributes;
                             if ((copyAttr & FILE_ATTRIBUTE_DIRECTORY) == 0)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/fileswn3.cpp`.
- `git diff --check -- src/fileswn3.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
