### PR TITLE
[translation] Fix src/plugins/automation/guiform.cpp comments

### DIFF
--- a/src/plugins/automation/guiform.cpp
+++ b/src/plugins/automation/guiform.cpp
@@ -64,7 +64,7 @@ CSalamanderGuiForm::~CSalamanderGuiForm()
 
     HwndNeeded();
 
-    // Resize form to accomodate all the child components.
+    // Resize form to accommodate all the child components.
     AutosizeComponent(this);
 
     cx = m_bounds.cx;
@@ -459,7 +459,7 @@ LRESULT CSalamanderGuiForm::WndProc(
             }
             else if (LOWORD(wParam) == IDCANCEL)
             {
-                // This is command synthetized by the
+                // This is a command synthesized by the
                 // dialog manager in reaction to the
                 // Esc key when there is no button.
                 if (m_nCloseCode != -1)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guiform.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guiform.cpp`.
- `git diff --check -- src/plugins/automation/guiform.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
