### PR TITLE
[translation] Fix src/plugins/uniso/iso9660.cpp comments

### DIFF
--- a/src/plugins/uniso/iso9660.cpp
+++ b/src/plugins/uniso/iso9660.cpp
@@ -85,7 +85,7 @@ BOOL CISO9660::Open(BOOL quiet)
                 memcpy(&PVD, sector, SECTOR_SIZE);
                 break;
 
-            case 0x02: // suplementary/enhanced volume descriptor
+            case 0x02: // supplementary/enhanced volume descriptor
                 memcpy(&SVD, sector, SECTOR_SIZE);
 
                 // Joliet has FileStructureVersion = 1


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/uniso/iso9660.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/uniso/iso9660.cpp`.
- `git diff --check -- src/plugins/uniso/iso9660.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
