### PR TITLE
[translation] Fix src/find.cpp comments

### DIFF
--- a/src/find.cpp
+++ b/src/find.cpp
@@ -705,7 +705,7 @@ protected:
 
     // compute MD5 from the file 'file'
     // 'progress' is the numeric value shown in the status bar (optimized so we do not
-    // update the same porgress repeatedly)
+    // update the same progress repeatedly)
     // 'readSize' holds the number of bytes read so far across all files
     // 'totalSize' is the total number of bytes of all files for which the MD5 digest
     // will be determined
@@ -895,7 +895,7 @@ BOOL CDuplicateCandidates::GetMD5Digest(CGrepData* data, CFoundFilesData* file,
     }
     else
     {
-        // error occured while opening the file
+        // error occurred while opening the file
         DWORD err = GetLastError();
 
         char buf[MAX_PATH + 100];


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/find.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/find.cpp`.
- `git diff --check -- src/find.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
