### PR TITLE
[translation] Fix src/plugins/uniso/nrg.cpp comments

### DIFF
--- a/src/plugins/uniso/nrg.cpp
+++ b/src/plugins/uniso/nrg.cpp
@@ -29,7 +29,7 @@ struct DAOX
     BYTE LastTrack;
 };
 
-// swaping macros
+// swapping macros
 
 #define SWAPWORD(d) \
     (((d) & 0x00FF) << 8) | \


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/uniso/nrg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/uniso/nrg.cpp`.
- `git diff --check -- src/plugins/uniso/nrg.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
