### PR TITLE
[translation] Fix src/plugins/automation/guitxtbox.h comments

### DIFF
--- a/src/plugins/automation/guitxtbox.h
+++ b/src/plugins/automation/guitxtbox.h
@@ -19,7 +19,7 @@ class CSalamanderGuiTextBox : public CSalamanderGuiComponentImpl<CSalamanderGuiT
 {
 private:
 protected:
-    /// Overrriden.
+    /// Overridden.
     /// \see CSalamanderGuiComponentBase::CreateHwnd
     virtual HWND CreateHwnd(HWND hWndParent);
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/guitxtbox.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/guitxtbox.h`.
- `git diff --check -- src/plugins/automation/guitxtbox.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
