### PR TITLE
[translation] Fix src/inflate.h comments

### DIFF
--- a/src/inflate.h
+++ b/src/inflate.h
@@ -41,7 +41,7 @@ struct CDecompressionObject
     char* OutputMemPtr;  // current position in the buffer for unpacked data
     DWORD OutputMemSize; // size of buffer for unpacked data
 
-    //public fields, should be intialized before calling Inflate()
+    //public fields, should be initialized before calling Inflate()
     uch* SlideWin;    //circular buffer
     unsigned WinSize; //size of sliding window, should be at least 32K
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/inflate.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/inflate.h`.
- `git diff --check -- src/inflate.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
