### PR TITLE
[translation] Fix src/plugins/uniso/udf.cpp comments

### DIFF
--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -37,7 +37,7 @@ typedef wchar_t unicode_t;
 //		  | ((Uint32)data[(p) + 2] << 16))
 #define GET_DWORD(data, p) ((Uint32)data[p] | ((Uint32)data[(p) + 1] << 8) | ((Uint32)data[(p) + 2] << 16) | ((Uint32)data[(p) + 3] << 24))
 #define GET_QWORD(data, p) ((Uint64)data[p] | ((Uint64)data[(p) + 1] << 8) | ((Uint64)data[(p) + 2] << 16) | ((Uint64)data[(p) + 3] << 24) | ((Uint64)data[(p) + 4] << 32) | ((Uint64)data[(p) + 5] << 40) | ((Uint64)data[(p) + 6] << 48) | ((Uint64)data[(p) + 7] << 56))
-/* This is wrong with regard to endianess */
+/* This is wrong with regard to endianness */
 #define GETN(data, p, n, target) memcpy(target, &data[p], n)
 
 static void


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/uniso/udf.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/uniso/udf.cpp`.
- `git diff --check -- src/plugins/uniso/udf.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
