### PR TITLE
[translation] Fix src/lang/texts.rc2 comments

### DIFF
--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -220,7 +220,7 @@ STRINGTABLE
  IDS_FFMENU_HELP,           "&Help"
 
 //
-// archiv context menu
+// archive context menu
 //
 
  IDS_ARCHIVEMENU_OPEN,      "&Open\tEnter"


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/lang/texts.rc2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/lang/texts.rc2`.
- `git diff --check -- src/lang/texts.rc2` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
