### PR TITLE
[translation] Fix src/plugins/automation/help/doxml2hh/stdafx.h comments

### DIFF
--- a/src/plugins/automation/help/doxml2hh/stdafx.h
+++ b/src/plugins/automation/help/doxml2hh/stdafx.h
@@ -26,7 +26,7 @@
 #include <algorithm>
 #include <functional>
 
-#ifndef __clang__ // we’ll work around clang-cl, which doesn’t support this MS extension; we’re using it for commnet-guard during comments translation
+#ifndef __clang__ // we’ll work around clang-cl, which doesn’t support this MS extension; we’re using it for comment-guard during comments translation
 #import <msxml6.dll>
 #import <mshtml.tlb>
 #endif


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/help/doxml2hh/stdafx.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/help/doxml2hh/stdafx.h`.
- `git diff --check -- src/plugins/automation/help/doxml2hh/stdafx.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
