### PR TITLE
[translation] Fix src/plugins/uniso/uniso.cpp comments

### DIFF
--- a/src/plugins/uniso/uniso.cpp
+++ b/src/plugins/uniso/uniso.cpp
@@ -878,7 +878,7 @@ BOOL CPluginInterfaceForViewer::CanViewFile(const char* name)
 
 CPluginDataInterface::CPluginDataInterface()
 {
-    // initialy display the 'missing CCD file' warning
+    // initially display the 'missing CCD file' warning
     DisplayMissingCCDWarning = TRUE;
 }
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/uniso/uniso.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/uniso/uniso.cpp`.
- `git diff --check -- src/plugins/uniso/uniso.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
