### PR TITLE
[translation] Fix src/mainwnd3.cpp comments

### DIFF
--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -3119,7 +3119,7 @@ MENU_TEMPLATE_ITEM AddToSystemMenu[] =
             RightPanel->GotoRoot();
             return 0;
         }
-            // enabling/diabling the left panel status line
+            // enabling/disabling the left panel status line
         case CM_LEFTSTATUS:
         {
             LeftPanel->ToggleStatusLine();


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/mainwnd3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/mainwnd3.cpp`.
- `git diff --check -- src/mainwnd3.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
