### PR TITLE
[translation] Fix src/plugins/automation/persistence.h comments

### DIFF
--- a/src/plugins/automation/persistence.h
+++ b/src/plugins/automation/persistence.h
@@ -75,7 +75,7 @@ private:
         PERSISTENT_ENTRY(const PERSISTENT_ENTRY& e)
         {
             // Transfer ownership of the values to this entry.
-            // Reduces overhead of excesive allocating/copying
+            // Reduces overhead of excessive allocating/copying
             // between temporary instances.
 
             this->name = e.name;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/persistence.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/persistence.h`.
- `git diff --check -- src/plugins/automation/persistence.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
