### PR TITLE
[translation] Fix src/plugins2.cpp comments

### DIFF
--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -1948,7 +1948,7 @@ CPlugins::GetPluginDataFromSuffix(const char* dllSuffix)
             CPluginData* data = Data[i];
             char* s = data->DLLName;
             if ((*s != '\\' || *(s + 1) != '\\') && // not UNC
-                (*s == 0 || *(s + 1) != ':'))       // not "c:" -> realtive path to plugins
+                (*s == 0 || *(s + 1) != ':'))       // not "c:" -> relative path to plugins
             {
                 strcpy(name, data->DLLName);
                 s = fullDLLName;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins2.cpp`.
- `git diff --check -- src/plugins2.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
