### PR TITLE
[translation] Fix src/plugins/automation/progressaut.cpp comments

### DIFF
--- a/src/plugins/automation/progressaut.cpp
+++ b/src/plugins/automation/progressaut.cpp
@@ -132,7 +132,7 @@ CSalamanderProgressAutomation::~CSalamanderProgressAutomation()
     }
 
     // ProgressAddSize return non-zero if the operation should continue
-    // our logic is quite oposite - we return true, if the dialogg has been
+    // our logic is quite opposite - we return true, if the dialog has been
     // cancelled and the operation should be aborted
     *cancelled = m_pOperation->ProgressAddSize(0, TRUE) ? VARIANT_FALSE : VARIANT_TRUE;
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/progressaut.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/progressaut.cpp`.
- `git diff --check -- src/plugins/automation/progressaut.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
