### PR TITLE
[translation] Fix src/plugins/unrar/unrar.cpp comments

### DIFF
--- a/src/plugins/unrar/unrar.cpp
+++ b/src/plugins/unrar/unrar.cpp
@@ -1058,7 +1058,7 @@ BOOL CPluginInterfaceForArchiver::ReadHeader(CFileHeader* header)
     {
     case 0:
     {
-        // Not every char representable in ANSI page can be reprsented in OEM page used by RAR files
+        // Not every char representable in ANSI page can be represented in OEM page used by RAR files
         // e.g. the Ellipsis character 0x2026
         if (headerData.FileNameW[0])
         {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/unrar/unrar.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/unrar/unrar.cpp`.
- `git diff --check -- src/plugins/unrar/unrar.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
