### PR TITLE
[translation] Fix src/salamdr3.cpp comments

### DIFF
--- a/src/salamdr3.cpp
+++ b/src/salamdr3.cpp
@@ -505,7 +505,7 @@ BOOL SalGetFullName(char* name, int* errTextID, const char* curDir, char* nextFo
                 if (curDir != NULL)
                 {
                     // for relative paths without a leading '\\', do not treat spaces as mistakes when 'allowRelPathWithSpaces' is enabled
-                    // (a directory or file name can start with a space even though Windows and other softwares,
+                    // (a directory or file name can start with a space even though Windows and other software,
                     // Salamander included, try to prevent it)
                     if (allowRelPathWithSpaces && *s != '\\')
                         s = name;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/salamdr3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/salamdr3.cpp`.
- `git diff --check -- src/salamdr3.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
