### PR TITLE
[translation] Fix src/plugins/automation/salamander.idl comments

### DIFF
--- a/src/plugins/automation/salamander.idl
+++ b/src/plugins/automation/salamander.idl
@@ -653,7 +653,7 @@ interface ISalamander : IUnknown
 	HRESULT Forms(
 		[out, retval] ISalamanderGui **gui);
 
-	/// \brief Saves value accross script invocations.
+	/// \brief Saves a value across script invocations.
 	///
 	/// The \b SetPersistentVal method saves value to the persistent
 	/// storage. The value is then available next time the script


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/salamander.idl`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/salamander.idl`.
- `git diff --check -- src/plugins/automation/salamander.idl` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
