### PR TITLE
[translation] Fix src/plugins/portables/fx.rh comments

### DIFF
--- a/src/plugins/portables/fx.rh
+++ b/src/plugins/portables/fx.rh
@@ -14,7 +14,7 @@
 #define __PORTABLES_FX_RH
 
 /**
-	This symbol indentifies bitmap stripe that contains plugin icons.
+	This symbol identifies bitmap stripe that contains plugin icons.
 	The resource must be PNG bitmap 16 pixels in height, width in multiple
 	of 16 pixels. Framework uses first icon as the plugin icon.
 	The resource type must be RCDATA.


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/portables/fx.rh`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/portables/fx.rh`.
- `git diff --check -- src/plugins/portables/fx.rh` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
