### PR TITLE
[translation] Fix src/plugins/zip/add_del.h comments

### DIFF
--- a/src/plugins/zip/add_del.h
+++ b/src/plugins/zip/add_del.h
@@ -9,7 +9,7 @@
 #define AF_DEL 1       //don't add file, but delete it if moving files to zip \
                        //does matter only on directories
 #define AF_NOADD 2     //don't add file and don't delete it if moving files to zip
-#define AF_OVERWRITE 3 //for unix files when ovewriting, same as AF_ADD
+#define AF_OVERWRITE 3 //for unix files when overwriting, same as AF_ADD
 
 struct CAddInfo
 {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/add_del.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/add_del.h`.
- `git diff --check -- src/plugins/zip/add_del.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
