### PR TITLE
[translation] Fix src/salinflt.cpp comments

### DIFF
--- a/src/salinflt.cpp
+++ b/src/salinflt.cpp
@@ -10,7 +10,7 @@
    version 1.1, Feb 2007
    
    based on file inflate.c distributed with infozip,
-   writen by  Mark Adler
+   written by  Mark Adler
    version c16b, 29 March 1998 */
 
 /*
@@ -78,7 +78,7 @@
       end-of-block.  Note however that the static length tree defines
       288 codes just to fill out the Huffman codes.  Codes 286 and 287
       cannot be used though, since there is no length base or extra bits
-      defined for them.  Similarily, there are up to 30 distance codes.
+      defined for them.  Similarly, there are up to 30 distance codes.
       However, static trees define 32 codes (all 5 bits) to fill out the
       Huffman codes, but the last two had better not show up in the data.
    7. Unzip can check dynamic Huffman blocks for complete code sets.


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/salinflt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/salinflt.cpp`.
- `git diff --check -- src/salinflt.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
