### PR TITLE
[translation] Fix src/plugins/zip/chicon.cpp comments

### DIFF
--- a/src/plugins/zip/chicon.cpp
+++ b/src/plugins/zip/chicon.cpp
@@ -78,7 +78,7 @@ BOOL ChangeSfxIconAndAddManifest(const char* sfxFile, CIcon* icons, int iconsCou
                                       MAKELANGID(LANG_NEUTRAL, SUBLANG_NEUTRAL), manifest, manifestSize))
                 {
                     if (re.EndUpdateResource(FALSE))
-                        ret = TRUE; //sucess
+                        ret = TRUE; //success
                 }
                 else
                     re.EndUpdateResource(TRUE);
@@ -106,7 +106,7 @@ BOOL HasExtension(const char* filename, const char* extension)
 //
 // return values:
 //   0  success
-//   1  error openning file
+//   1  error opening file
 //   2  module is not valid win32 application
 //   3  unable to load module containing icon data
 //   4  unable to load icon from file


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/chicon.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/chicon.cpp`.
- `git diff --check -- src/plugins/zip/chicon.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
