### PR TITLE
[translation] Fix src/salopen/salopen.cpp comments

### DIFF
--- a/src/salopen/salopen.cpp
+++ b/src/salopen/salopen.cpp
@@ -568,7 +568,7 @@ LONG __stdcall MyUnhandledExceptionFilter(EXCEPTION_POINTERS* ExceptionInfo)
 {
     //  DWORD written;
     //  WriteFile(GetStdHandle(STD_OUTPUT_HANDLE),
-    //            "SALOPEN: An exception has occured!\n",
+    //            "SALOPEN: An exception has occurred!\n",
     //            34, &written, NULL);
     //  ExitProcess(666);
     TerminateProcess(GetCurrentProcess(), 666); // more forceful exit; this still makes one call


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/salopen/salopen.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/salopen/salopen.cpp`.
- `git diff --check -- src/salopen/salopen.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
