### PR TITLE
[translation] Fix src/plugins/zip/common.cpp comments

### DIFF
--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -44,7 +44,7 @@ const CConfiguration DefConfig =
         EM_ZIP20,                     // Encryption Method
         false,                        // Do not add empty directories to the ZIP archive.
         true,                         //create temporary backup of zip
-        true,                         //display exteded pack options dialog
+        true,                         //display extended pack options dialog
         false,                        //set zip file time to the newest file time
         {"1423", {0}, {0}, {0}, {0}}, //volume sizes
         {0, 0, 0, 0, 0},              //volume size units


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/common.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/common.cpp`.
- `git diff --check -- src/plugins/zip/common.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
