### PR TITLE
[translation] Fix src/salshlib.cpp comments

### DIFF
--- a/src/salshlib.cpp
+++ b/src/salshlib.cpp
@@ -570,7 +570,7 @@ BOOL CSalShExtPastedData::CanUnloadPlugin(HWND parent, CPluginInterfaceAbstract*
         {
             // find out whether the unloaded plugin has anything to do with our archive;
             // the plugin could unload itself while the archiver is used (each archiver function
-            // loads the plugin itself), but better safe than sorry, so we cancel any pedning archive listing
+            // loads the plugin itself), but better safe than sorry, so we cancel any pending archive listing
             int format = PackerFormatConfig.PackIsArchive(ArchiveFileName);
             if (format != 0) // we found a supported archive
             {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/salshlib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/salshlib.cpp`.
- `git diff --check -- src/salshlib.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
