### PR TITLE
[translation] Fix src/plugins/automation/sample-scripts/Unpack Multiple Archives.js comments

### DIFF
--- a/src/plugins/automation/sample-scripts/Unpack Multiple Archives.js
+++ b/src/plugins/automation/sample-scripts/Unpack Multiple Archives.js
@@ -76,7 +76,7 @@ var archivesMask = "*";                        // only archives with name matchi
 //   Unpack selected archives (and archives in selected directories) using open source 7-Zip archiver. 
 //   This script can be easily adapted for other unpackers. Features: recursive directory walking, file 
 //   masks matching, calling external application (7-Zip archiver), error states handling, output log 
-//   with opearation summary.
+//   with operation summary.
 //
 // Installation and Requirements:
 //   Open Salamander: https://www.altap.cz/


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/sample-scripts/Unpack Multiple Archives.js`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/sample-scripts/Unpack Multiple Archives.js`.
- `git diff --check -- src/plugins/automation/sample-scripts/Unpack Multiple Archives.js` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
