### PR TITLE
[translation] Fix src/plugins/zip/common.h comments

### DIFF
--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -65,7 +65,7 @@ struct CConfiguration
     bool NoEmptyDirs;                  //don't add empty directories to zip
     bool BackupZip;                    //create temporary backup of zip before
                                        //any modification of it
-    bool ShowExOptions;                //display exteded pack options dialog
+    bool ShowExOptions;                //display extended pack options dialog
     bool TimeToNewestFile;             //set zip file time to the newest file time
     char VolSizeCache[5][MAX_VOL_STR]; //volume sizes
     unsigned VolSizeUnits[5];          //MB if nozero


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/common.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/common.h`.
- `git diff --check -- src/plugins/zip/common.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
