### PR TITLE
[translation] Fix src/shellext/shellext.c comments

### DIFF
--- a/src/shellext/shellext.c
+++ b/src/shellext/shellext.c
@@ -263,7 +263,7 @@ HRESULT CreateShellExtClassFactory(REFIID riid, LPVOID* ppvOut)
     if (secf == NULL)
         return E_OUTOFMEMORY;
 
-    // Get interface, whichs calls AddRef
+    // Get interface, which calls AddRef
     hr = secf->lpVtbl->QueryInterface((IShellExtClassFactory*)secf, riid, ppvOut);
     if (secf->m_cRef == 0)
         SECF_Destructor(secf); // if QueryInterface failed, release the object


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/shellext/shellext.c`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/shellext/shellext.c`.
- `git diff --check -- src/shellext/shellext.c` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
