### PR TITLE
[translation] Fix src/plugins/automation/shim.h comments

### DIFF
--- a/src/plugins/automation/shim.h
+++ b/src/plugins/automation/shim.h
@@ -55,7 +55,7 @@ public:
     virtual HRESULT InterruptScript(IActiveScript* pScript);
 
     /// Allows the shim to control, whether particular error will be displayed
-    /// or supressed.
+    /// or suppressed.
     /// \return If the error should be displayed, the return value is true.
     virtual bool DisplayErrorHook(__in EXCEPINFO* ei, __in_opt BSTR src, __in bool bDebug);
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/automation/shim.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/automation/shim.h`.
- `git diff --check -- src/plugins/automation/shim.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
