### PR TITLE
[translation] Fix src/plugins/zip/config.h comments

### DIFF
--- a/src/plugins/zip/config.h
+++ b/src/plugins/zip/config.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-//disable not finished source, which is yet under costruction
+//disable not finished source, which is yet under construction
 //#define DITRIBUTABLE_VERSION
 
 //definitions for inflate module


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/config.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/config.h`.
- `git diff --check -- src/plugins/zip/config.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
