### PR TITLE
[translation] Fix src/shellext/shexinit.c comments

### DIFF
--- a/src/shellext/shexinit.c
+++ b/src/shellext/shexinit.c
@@ -44,7 +44,7 @@ SEI_Release(THIS)
 //
 //  PARAMETERS:
 //    pIDFolder - Specifies the parent folder
-//    pDataObj  - Spefifies the set of items selected in that folder.
+//    pDataObj  - Specifies the set of items selected in that folder.
 //    hRegKey   - Specifies the type of the focused item in the selection.
 //
 //  RETURN VALUE:


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/shellext/shexinit.c`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/shellext/shexinit.c`.
- `git diff --check -- src/shellext/shexinit.c` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
