### PR TITLE
[translation] Fix src/plugins/checksum/checksum.cpp comments

### DIFF
--- a/src/plugins/checksum/checksum.cpp
+++ b/src/plugins/checksum/checksum.cpp
@@ -36,7 +36,7 @@ SConfig Config = {
     {662, 301, 230, 80, 80, 229, 279, 430, 860}, // CalcDlgWidths
     {433, 301, 230, 80, 80},                     // VerDlgWidths
     {
-        // Register all known algorthms here
+        // Register all known algorithms here
         {HT_CRC, true, IDS_COLUMN_CRC, IDS_COPYTOCBOARD_CRC, IDS_SAVE_FILTER_CRC, IDS_VERIFY_CRC, _T(".sfv"), "CRC", CRCFactory},
         {HT_MD5, true, IDS_COLUMN_MD5, IDS_COPYTOCBOARD_MD5, IDS_SAVE_FILTER_MD5, IDS_VERIFY_MD5, _T(".md5"), "MD5", MD5Factory},
         {HT_SHA1, true, IDS_COLUMN_SHA1, IDS_COPYTOCBOARD_SHA1, IDS_SAVE_FILTER_SHA1, IDS_VERIFY_SHA1, _T(".sha1"), "SHA1", SHA1Factory},


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/checksum/checksum.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/checksum/checksum.cpp`.
- `git diff --check -- src/plugins/checksum/checksum.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
