### PR TITLE
[translation] Fix src/shiconov.cpp comments

### DIFF
--- a/src/shiconov.cpp
+++ b/src/shiconov.cpp
@@ -155,7 +155,7 @@ BOOL GetGoogleDrivePath(char* gdPath, int gdPathMax, CSQLite3DynLoadBase** sqlit
                 }
             }
             if (sqlite3_Dyn_InOut != NULL)
-                *sqlite3_Dyn_InOut = sqlite3_Dyn; // return the loaded sqlite.dll for futher use (it may have been loaded before this function was called)
+                *sqlite3_Dyn_InOut = sqlite3_Dyn; // return the loaded sqlite.dll for further use (it may have been loaded before this function was called)
             else
                 delete sqlite3_Dyn; // release sqlite.dll, nobody is waiting for it
         }


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/shiconov.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/shiconov.cpp`.
- `git diff --check -- src/shiconov.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
