### PR TITLE
[translation] Fix src/plugins/zip/extract.h comments

### DIFF
--- a/src/plugins/zip/extract.h
+++ b/src/plugins/zip/extract.h
@@ -32,7 +32,7 @@ public:
     char* SlideWindow;
     unsigned WinSize;
     //unsigned                InputPos;       //read position in zip file
-    QWORD BytesLeft;   //number of copressed bytes remainig
+    QWORD BytesLeft;   //number of compressed bytes remaining
                        //to read from zipfile
     CFile* OutputFile; //current output file
     int OutputError;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/extract.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/extract.h`.
- `git diff --check -- src/plugins/zip/extract.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
