### PR TITLE
[translation] Fix src/plugins/dbviewer/dbflib/dbflib.h comments

### DIFF
--- a/src/plugins/dbviewer/dbflib/dbflib.h
+++ b/src/plugins/dbviewer/dbflib/dbflib.h
@@ -3,7 +3,7 @@
 
 #pragma once
 
-/* Define some usefull types */
+/* Define some useful types */
 #ifndef U8
 #define U8 unsigned char
 #endif


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/dbviewer/dbflib/dbflib.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/dbviewer/dbflib/dbflib.h`.
- `git diff --check -- src/plugins/dbviewer/dbflib/dbflib.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
