### PR TITLE
[translation] Fix src/plugins/filecomp/cwoptim.cpp comments

### DIFF
--- a/src/plugins/filecomp/cwoptim.cpp
+++ b/src/plugins/filecomp/cwoptim.cpp
@@ -150,7 +150,7 @@ void CFilecompCoWorkerOptimized<CChar>::IdentifyLines(CFilecompCoWorkerBase<CCha
     {
         // reserve space
         compareData[i].resize(files[i].Lines.size() - 1);
-        // indentify each line
+        // identify each line
         typename CLineBuffer::iterator line = files[i].Lines.begin();
         CIndexes::iterator eqvclass = compareData[i].begin();
         for (; line < files[i].Lines.end() - 1; ++line, ++eqvclass)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/cwoptim.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/cwoptim.cpp`.
- `git diff --check -- src/plugins/filecomp/cwoptim.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
