### PR TITLE
[translation] Fix src/plugins/dbviewer/dbviewer.rh2 comments

### DIFF
--- a/src/plugins/dbviewer/dbviewer.rh2
+++ b/src/plugins/dbviewer/dbviewer.rh2
@@ -68,7 +68,7 @@
 #define CM_FILE_FIRST              10040
 #define CM_FILE_LAST               10041
 
-// for Coversion submenu
+// for Conversion submenu
 #define CM_CODING_FIRST            10050
 #define CM_CODING_LAST             10250
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/dbviewer/dbviewer.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/dbviewer/dbviewer.rh2`.
- `git diff --check -- src/plugins/dbviewer/dbviewer.rh2` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
