### PR TITLE
[translation] Fix src/tserver/openedit.cpp comments

### DIFF
--- a/src/tserver/openedit.cpp
+++ b/src/tserver/openedit.cpp
@@ -5,7 +5,7 @@
 
 // import EnvDTE based on its LIBID, dte80a.tlh will be created in build directory and included into project
 #pragma warning(disable : 4278)
-#ifndef __clang__ // we’ll work around clang-cl, which doesn’t support this MS extension; we’re using it for commnet-guard during comments translation
+#ifndef __clang__ // we’ll work around clang-cl, which doesn’t support this MS extension; we’re using it for comment-guard during comments translation
 #import "libid:80cc9f66-e7d8-4ddd-85b6-d9e6cd0e93e2" raw_interfaces_only named_guids
 #endif
 #pragma warning(default : 4278)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/tserver/openedit.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/tserver/openedit.cpp`.
- `git diff --check -- src/tserver/openedit.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
