### PR TITLE
[translation] Fix src/plugins/zip/inflate.h comments

### DIFF
--- a/src/plugins/zip/inflate.h
+++ b/src/plugins/zip/inflate.h
@@ -24,14 +24,14 @@ typedef void (*FRefillInBuffer)(CDecompressionObject*);
 
 typedef struct
 {
-    //public fields, should be intialized before calling Inflate()
+    //public fields, should be initialized before calling Inflate()
     uch* NextByte;      //pointer to next byte in the input buffer
     unsigned BytesLeft; //number of bytes left in buffer
                         //i.e. number of valid bytes pointed
                         //by NextByte
     void* UserData;     //pointer to a user data
     int Error;          //error state (0 = no error), could be set
-                        //by arbitrary funcion at every time
+                        //by arbitrary function at every time
                         //checked in NextByte() function (inflate.cpp)
 
     //internal fields
@@ -49,7 +49,7 @@ typedef struct
 
 typedef int (*FFlushOutput)(unsigned, CDecompressionObject*);
 //first parameter is number of bytes to be flushed
-//return zero if succesfull, non zero value if failed
+//return zero if successful, non zero value if failed
 
 typedef struct
 {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/inflate.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `3` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/inflate.h`.
- `git diff --check -- src/plugins/zip/inflate.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `3` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
