### PR TITLE
[translation] Fix src/plugins/demoplug/thumbldr.cpp comments

### DIFF
--- a/src/plugins/demoplug/thumbldr.cpp
+++ b/src/plugins/demoplug/thumbldr.cpp
@@ -224,7 +224,7 @@ CPluginInterfaceForThumbLoader::LoadThumbnail(const char* filename,
                                               BOOL fastThumbnail)
 {
     BOOL stopFurtherLoaders = TRUE; // don't try next parsers
-    // we must call thumbMaker->SetError() when error occures and stopFurtherLoaders is TRUE
+    // we must call thumbMaker->SetError() when error occurs and stopFurtherLoaders is TRUE
 
     // open the file
     HANDLE hFile = HANDLES_Q(CreateFile(filename, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE,


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/demoplug/thumbldr.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/demoplug/thumbldr.cpp`.
- `git diff --check -- src/plugins/demoplug/thumbldr.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
