### PR TITLE
[translation] Fix src/plugins/filecomp/precomp.h comments

### DIFF
--- a/src/plugins/filecomp/precomp.h
+++ b/src/plugins/filecomp/precomp.h
@@ -43,7 +43,7 @@
 #include "winliblt.h"
 #include "auxtools.h"
 
-// get rid of some anoying warnings
+// get rid of some annoying warnings
 #pragma warning(disable : 4661)
 #pragma warning(disable : 4786)
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/precomp.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/precomp.h`.
- `git diff --check -- src/plugins/filecomp/precomp.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
