### PR TITLE
[translation] Fix src/plugins/zip/selfextr/dialog.cpp comments

### DIFF
--- a/src/plugins/zip/selfextr/dialog.cpp
+++ b/src/plugins/zip/selfextr/dialog.cpp
@@ -25,7 +25,7 @@ int ShortPathControlWidth;
 int ShortPathControlHeigth;
 int DlgWinWidth;
 int DlgWinHeigth;
-int DlgWinAboutHeigth; //heigth with the about showed
+int DlgWinAboutHeigth; //height with the About shown
 bool AboutShowed;
 
 //bool Started = false;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/selfextr/dialog.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/selfextr/dialog.cpp`.
- `git diff --check -- src/plugins/zip/selfextr/dialog.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
