### PR TITLE
[translation] Fix src/worker.h comments

### DIFF
--- a/src/worker.h
+++ b/src/worker.h
@@ -125,7 +125,7 @@ public:
     // may be called from any thread
     void JustConnected();
 
-    // call after some of the data are transfered; report a data chunk: 'count' bytes
+    // call after some of the data are transferred; report a data chunk: 'count' bytes
     // transferred in 'time'; 'maxPacketSize' is the largest amount expected
     // before the next BytesReceived() call
     void BytesReceived(DWORD count, DWORD time, DWORD maxPacketSize);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/worker.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/worker.h`.
- `git diff --check -- src/worker.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
