### PR TITLE
[translation] Fix src/plugins/zip/typecons.h comments

### DIFF
--- a/src/plugins/zip/typecons.h
+++ b/src/plugins/zip/typecons.h
@@ -5,7 +5,7 @@
 
 #include "selfextr/comdefs.h"
 
-//types defintions
+//types definitions
 
 //basic types
 typedef unsigned __int8 __UINT8;
@@ -141,7 +141,7 @@ typedef struct
     // [variable size] zip64 extensible data sector
 } CZip64EOCentrDirRecord;
 
-typedef struct // May immediatelly follow (actually be included in) CZip64EOCentrDirRecord
+typedef struct // May immediately follow (actually be included in) CZip64EOCentrDirRecord
 {
     __UINT16 Method;     // compression method
     __UINT64 CompSize;   // compressed size


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/zip/typecons.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/zip/typecons.h`.
- `git diff --check -- src/plugins/zip/typecons.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
