### PR TITLE
[translation] Fix tools/salbreak/salbreak.cpp comments

### DIFF
--- a/tools/salbreak/salbreak.cpp
+++ b/tools/salbreak/salbreak.cpp
@@ -24,7 +24,7 @@ HINSTANCE hInst;                     // current instance
 TCHAR szTitle[MAX_LOADSTRING];       // The title bar text
 TCHAR szWindowClass[MAX_LOADSTRING]; // The title bar text
 
-// Foward declarations of functions included in this code module:
+// Forward declarations of functions included in this code module:
 ATOM MyRegisterClass(HINSTANCE hInstance);
 BOOL InitInstance(HINSTANCE, int);
 LRESULT CALLBACK WndProc(HWND, UINT, WPARAM, LPARAM);
@@ -203,7 +203,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
     return 0;
 }
 
-// Mesage handler for about box.
+// Message handler for about box.
 LRESULT CALLBACK About(HWND hDlg, UINT message, WPARAM wParam, LPARAM lParam)
 {
     switch (message)


### PR DESCRIPTION
## Summary
- Refines comment wording in `tools/salbreak/salbreak.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `tools/salbreak/salbreak.cpp`.
- `git diff --check -- tools/salbreak/salbreak.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 2 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
