### PR TITLE
[translation] Fix src/plugins/ftp/ftp.rh2 comments

### DIFF
--- a/src/plugins/ftp/ftp.rh2
+++ b/src/plugins/ftp/ftp.rh2
@@ -528,7 +528,7 @@
 #define IDS_QUICKRENAMEFILEERRSUF1 10233
 // suffix for IDS_QUICKRENAMEFILEERR: Error: Target file is locked by another operation."
 #define IDS_QUICKRENAMEFILEERRSUF2 10234
-// proxy script error: Error has occured while processing proxy server script.\n\nError: %s
+// proxy script error: Error has occurred while processing proxy server script.\n\nError: %s
 #define IDS_ERRINPROXYSCRIPT    10235
 // Proxy server address is empty.
 #define IDS_PROXYSRVADREMPTY    10236
@@ -551,7 +551,7 @@
 #define IDS_ENTERACCTTEXT           10246
 // Enter User name dialog: info: Connecting to "%s".
 #define IDS_CONNECTINGTOAS1         10247
-// Enter Password/Acount dialog: info: Connecting to "%s" as "%s".
+// Enter Password/Account dialog: info: Connecting to "%s" as "%s".
 #define IDS_CONNECTINGTOAS2         10248
 
 // word "hidden" instead of real password or account in log-file or welcome message
@@ -679,7 +679,7 @@
 #define IDS_LOGMSGUPLOADISNOTCOMPL2   10371
 // download failed only due to missing server reply to RETR command - file is probably OK, so it worths to Resume it: Forcing Resume for file ""%s"" (file content was successfully received but server did not confirm successful sending of this file).\r\n
 #define IDS_LOGMSGDWNLOADFORCRESUM    10372
-// upload: autorename tryies to upload file to newly generated name: Renaming file for upload to ""%s""...\r\n
+// upload: autorename tries to upload file to newly generated name: Renaming file for upload to ""%s""...\r\n
 #define IDS_LOGMSGUPLOADRENFILE       10373
 // Downloading file ""%s"" to ""%s""...\r\n
 #define IDS_LOGMSGDOWNLOADFILE2       10374
@@ -710,7 +710,7 @@
 #define IDS_LOGMSGDATACONTERMINATED   10392
 // preliminar attempt to open passive data con. has failed, reconnecting (after sending of FTP transfer command): Reconnecting data connection...\r\n
 #define IDS_LOGMSGDATACONRECON        10393
-// some error has occured in data connection: Data connection error: %s\r\n
+// some error has occurred in data connection: Data connection error: %s\r\n
 #define IDS_LOGMSGDATCONERROR         10394
 // unexpected server reply (some extra reply received before sending of next command): Unexpected reply:
 #define IDS_LOGMSGUNEXPREPLY          10395
@@ -1179,7 +1179,7 @@
 #define IDS_FINISHINGKEEPALIVECMD     10711
 // when keep alive command is processing and user press ESC: Do you want to cancel command sent to keep the connection alive? Connection to FTP server will be terminated.
 #define IDS_KEEPALIVECMDESC           10712
-// message to log: when keep alive command is processing and FTP client want to send another command and when timeout occures: Sending of command to keep the connection alive has timed out.\r\n
+// message to log: when keep alive command is processing and FTP client wants to send another command and when timeout occurs: Sending of command to keep the connection alive has timed out.\r\n
 #define IDS_LOGMSGKEEPALIVECMDTIMEOUT 10713
 // message to log: NLST/LIST keep-alive command: error when trying to prepare active data connection (unable to listen on socket): Unable to prepare active data connection.\r\n
 #define IDS_LOGMSGOPENACTDATACONERROR 10714
@@ -1454,7 +1454,7 @@
 #define IDS_OPERDLGCOACT_CONNECTING   10891
 // Unable to connect, waiting %d seconds to retry (attempt no. %d of %d): %s
 #define IDS_OPERDLGCOACT_WAITRECON    10892
-// no more attemps to reconnect (%s is description of error of last attempt to open connection): Unable to connect: %s
+// no more attempts to reconnect (%s is description of error of last attempt to open connection): Unable to connect: %s
 #define IDS_OPERDLGCOACT_CONERROR     10893
 // when downloading file, estimated time left: time left:
 #define IDS_OPERDLGCOACT_TIMELEFT     10894
@@ -1812,7 +1812,7 @@
 #define IDS_PRXSCRERR_HOSTVARSONLY    11224
 // invalid port definition in server address (follows "Connect to:"): You can set port only as number or as $(ProxyPort) or $(Port) variable.
 #define IDS_PRXSCRERR_INVPORT         11225
-// note: do not translate "USER" (it's FTP command): You cannot use ""3xx:"" condition for the first command, some preceeding command (typically ""USER"") is neccessary.
+// note: do not translate "USER" (it's FTP command): You cannot use ""3xx:"" condition for the first command, some preceding command (typically ""USER"") is necessary.
 #define IDS_PRXSCRERR_3XXONFIRSTLINE  11226
 // Proxy script must contain at least one command.
 #define IDS_PRXSCRERR_NONECMDS        11227
@@ -1850,7 +1850,7 @@
 // when connecting and server demands more commands than is supplied in proxy script (text for Solve Error dialog in operation dialog): Proxy script is probably incomplete. See server reply to last script command for details: %s
 #define IDS_INCOMPLETEPRXSCR3         11257
 
-// proxy server error codes (when proxy server tryies to connect to FTP server):
+// proxy server error codes (when proxy server tries to connect to FTP server):
 // Connection was rejected or failed.
 #define IDS_PROXYERRREJORFAIL         11265
 // Unable to connect to identd on client (you probably need to install identd service).
@@ -1878,7 +1878,7 @@
 #define IDS_PROXYERRUNABLETOCON2      11281
 // Proxy server rejects anonymous users, please add your username and password to proxy server definition.
 #define IDS_PROXYERRNOAUTHUNSUP       11282
-// Proxy server does not support username+password authentification, please try anonymous access (clear username and password in proxy server definition).
+// Proxy server does not support username+password authentication, please try anonymous access (clear username and password in proxy server definition).
 #define IDS_PROXYERRUSERPASSAUTHUNSUP 11283
 // Proxy server rejects your username and password.
 #define IDS_PROXYERRUSERPASSFAIL      11284


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/ftp/ftp.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `9` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/ftp/ftp.rh2`.
- `git diff --check -- src/plugins/ftp/ftp.rh2` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `9` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
