### PR TITLE
[translation] Fix src/plugins/shared/spl_bzip2.h comments

### DIFF
--- a/src/plugins/shared/spl_bzip2.h
+++ b/src/plugins/shared/spl_bzip2.h
@@ -23,7 +23,7 @@
 /***********************************************************************
  * Simplified interface to the BZIP2 library provided by Salamander.
  * To understand the action types and return values, it is recommended
- * to read ther documentation at www.bzip.org.
+ * to read the documentation at www.bzip.org.
  ***********************************************************************/
 
 /* Values for action argument of Compress() */


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/shared/spl_bzip2.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/shared/spl_bzip2.h`.
- `git diff --check -- src/plugins/shared/spl_bzip2.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 1 changed comment hunk, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
