### PR TITLE
[translation] Fix src/plugins/nethood/cache.cpp comments

### DIFF
--- a/src/plugins/nethood/cache.cpp
+++ b/src/plugins/nethood/cache.cpp
@@ -708,7 +708,7 @@ UINT CNethoodCache::GetPathStatus(
     int cTokens;
     int iToken = 0;
 
-    // Consumer cannot be specified without also returning ther node.
+    // Consumer cannot be specified without also returning the node.
     assert(node || !pEventConsumer);
 
     if (node)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/cache.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/cache.cpp`.
- `git diff --check -- src/plugins/nethood/cache.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
