### PR TITLE
[translation] Fix src/plugins/shared/spl_gen.h comments

### DIFF
--- a/src/plugins/shared/spl_gen.h
+++ b/src/plugins/shared/spl_gen.h
@@ -1216,7 +1216,7 @@ public:
     // Compares n bytes of the two blocks of memory stored at buf1 and buf2.
     // Characters are converted to lowercase before comparing (not permanently;
     // using LowerCase array which was filled using CharLower Win32 API call),
-    // so case is ignored in comparation.
+    // so case is ignored in comparison.
     //
     // Parameters
     //   buf1, buf2: memory buffers to compare
@@ -2112,7 +2112,7 @@ public:
     //      primary display monitor, some of the point's coordinates may be negative values.
     //
     // Return Values
-    //   If the default window position lies on the primary monitor or some error occured,
+    //   If the default window position lies on the primary monitor or some error occurred,
     //   the return value is FALSE and you should use CreateWindow with CW_USEDEFAULT in
     //   the 'x' parameter.
     //
@@ -2988,7 +2988,7 @@ public:
     // LockMainWindow
     //   Locks main window to pretend it is disabled. Main windows is still able to receive focus
     //   in the locked state. Set 'lock' to TRUE to lock main window and to FALSE to revert it back
-    //   to normal state. 'hToolWnd' is reserverd parameter, set it to NULL. 'lockReason' is (optional,
+    //   to normal state. 'hToolWnd' is a reserved parameter, set it to NULL. 'lockReason' is (optional,
     //   can be NULL) describes the reason for main window locked state. It will be displayed during
     //   attempt to close locked main window; content of string is copied to internal structure
     //   so buffer can be deallocated after return from LockMainWindow().


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/shared/spl_gen.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunks in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/shared/spl_gen.h`.
- `git diff --check -- src/plugins/shared/spl_gen.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, 3 changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
