### PR TITLE
[translation] Fix src/plugins/nethood/cache.h comments

### DIFF
--- a/src/plugins/nethood/cache.h
+++ b/src/plugins/nethood/cache.h
@@ -658,7 +658,7 @@ private:
     /// Cache tree data structure.
     typedef TTree<CNethoodCacheNode> CNethoodCacheTree;
 
-    /// Miscelaneous constants that affects cache behavior and performance.
+    /// Miscellaneous constants that affect cache behavior and performance.
     enum
     {
         /// Delay (in milliseconds) before the re-enumeration of the
@@ -1426,7 +1426,7 @@ private:
         WPARAM wParam,
         LPARAM lParam);
 
-    /// Helper routine to supress compiler warnings.
+    /// Helper routine to suppress compiler warnings.
     static inline void SetInstanceToHwnd(
         HWND hwnd,
         CNethoodCacheManagementThread* pInstance)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/cache.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/cache.h`.
- `git diff --check -- src/plugins/nethood/cache.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
