### PR TITLE
[translation] Fix src/plugins/nethood/icons.h comments

### DIFF
--- a/src/plugins/nethood/icons.h
+++ b/src/plugins/nethood/icons.h
@@ -254,7 +254,7 @@ public:
 
     /// Returns appropriate network icon.
     /// \param nSize Size of the requested icon. This is one
-    ///        of the SALICONSIZE_xxx constans.
+    ///        of the SALICONSIZE_xxx constants.
     /// \param icon Identifier of the icon to retrieve. This is
     ///        value from the Icon enumeration.
     /// \return If the method succeeds the return value is handle


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/icons.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/icons.h`.
- `git diff --check -- src/plugins/nethood/icons.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
