### PR TITLE
[translation] Fix src/plugins/nethood/nethoodfs2.h comments

### DIFF
--- a/src/plugins/nethood/nethoodfs2.h
+++ b/src/plugins/nethood/nethoodfs2.h
@@ -222,7 +222,7 @@ public:
     /// \param buf Caller supplied buffer. The method should copy the
     ///        title to it.
     /// \param bufSize Size of the buffer, in characters.
-    /// \return If the method provides the title, it shoulld return
+    /// \return If the method provides the title, it should return
     ///         a nonzero value. If the return value is zero, Salamander
     ///         will use the GetNextDirectoryLineHotPath method
     ///         to create the title automatically.


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/nethood/nethoodfs2.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/nethood/nethoodfs2.h`.
- `git diff --check -- src/plugins/nethood/nethoodfs2.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
