### PR TITLE
[translation] Fix src/plugins/pictview/PVMessageEnvelope.cpp comments

### DIFF
--- a/src/plugins/pictview/PVMessageEnvelope.cpp
+++ b/src/plugins/pictview/PVMessageEnvelope.cpp
@@ -19,7 +19,7 @@ public:
 
     LPPVHandle PVHandle;
     LPPVImageSequence PVImageSequence;
-    // The following 4 items are used when transfering file via shared memory
+    // The following 4 items are used when transferring file via shared memory
     HANDLE hFileMap;
     LPBYTE pBuffer; // Buffer with file content
     LPBYTE pCur;    // Current position inside pBuffer
@@ -792,7 +792,7 @@ bool PVMessage_SimplifyImageSequence::HandleRequest()
     int nFrameSize = ((pHdr->ScreenWidth * 3 + 3) & ~3) * pHdr->ScreenHeight;
     DWORD hFMap;
 
-    // Get the number of frames and create shared memory object accomodating all pixels of all frames
+    // Get the number of frames and create shared memory object accommodating all pixels of all frames
     nFrames = 0;
     while (pSeq)
     {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/PVMessageEnvelope.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/PVMessageEnvelope.cpp`.
- `git diff --check -- src/plugins/pictview/PVMessageEnvelope.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
