### PR TITLE
[translation] Fix src/plugins/pictview/exif/config.h comments

### DIFF
--- a/src/plugins/pictview/exif/config.h
+++ b/src/plugins/pictview/exif/config.h
@@ -89,7 +89,7 @@
 
 #define ssize_t int
 
-// static inline not supported by MSVC and not usefull here -> define it out
+// static inline not supported by MSVC and not useful here -> define it out
 #define inline
 
 #ifndef M_PI


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/exif/config.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/exif/config.h`.
- `git diff --check -- src/plugins/pictview/exif/config.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
