### PR TITLE
[translation] Fix src/plugins/pictview/exif/exif.c comments

### DIFF
--- a/src/plugins/pictview/exif/exif.c
+++ b/src/plugins/pictview/exif/exif.c
@@ -263,7 +263,7 @@ BOOL WINAPI EXIFReplaceThumbnail(char* fileName, char* newFile, unsigned char* p
                     pSect->content.generic.size = (6 + size);
                     pSect->content.generic.data = malloc(6 + size);
                     *(DWORD*)pSect->content.generic.data = 'XXFJ';
-                    // NULL temrination of JFXX, version number
+                    // NULL termination of JFXX, version number
                     ((WORD*)pSect->content.generic.data)[2] = 0x1000;
                     memcpy((char*)pSect->content.generic.data + 6, pData, size);
                     ret = jpeg_data_save_file(pJpeg, newFile);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/exif/exif.c`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/exif/exif.c`.
- `git diff --check -- src/plugins/pictview/exif/exif.c` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
