### PR TITLE
[translation] Fix src/plugins/pictview/pictview.rh2 comments

### DIFF
--- a/src/plugins/pictview/pictview.rh2
+++ b/src/plugins/pictview/pictview.rh2
@@ -432,7 +432,7 @@
 #define IDS_TWCC_BADDEST           2240 /* Unknown destination Application/Source in DSM_Entry */
 #define IDS_TWCC_CAPUNSUPPORTED    2241 /* Capability not supported by source            */
 #define IDS_TWCC_CAPBADOPERATION   2242 /* Operation not supported by capability         */
-#define IDS_TWCC_CAPSEQERROR       2243 /* Capability has dependancy on other capability */
+#define IDS_TWCC_CAPSEQERROR       2243 /* Capability has dependency on other capability */
 #define IDS_TWCC_DENIED            2244 /* File System operation is denied (file is protected) */
 #define IDS_TWCC_FILEEXISTS        2245 /* Operation failed because file already exists. */
 #define IDS_TWCC_FILENOTFOUND      2246 /* File not found */


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/pictview.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/pictview.rh2`.
- `git diff --check -- src/plugins/pictview/pictview.rh2` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
