### PR TITLE
[translation] Fix src/plugins/pictview/saveas.cpp comments

### DIFF
--- a/src/plugins/pictview/saveas.cpp
+++ b/src/plugins/pictview/saveas.cpp
@@ -509,7 +509,7 @@ UINT_PTR CALLBACK SaveAsDlgProc(HWND hDlg, UINT uMsg, WPARAM wParam, LPARAM lPar
         psai->Compression = GetItemData(hDlg, IDC_SAVE_COMPRESSION);
         psai->Flags = 0;
         psai->Flip = psai->Flags |= GetItemData(hDlg, IDC_SAVE_FLIP);
-        // Note: must remain ^= to anihilate double flip flags
+        // Note: must remain ^= to annihilate double flip flags
         psai->Flags ^= psai->Rotation = GetItemData(hDlg, IDC_SAVE_ROTATION);
         psai->Colors = GetItemData(hDlg, IDC_SAVE_BIT_DEPTH);
         if (IsDlgButtonChecked(hDlg, IDC_SAVE_INVERT))


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/saveas.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/saveas.cpp`.
- `git diff --check -- src/plugins/pictview/saveas.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
