### PR TITLE
[translation] Fix src/plugins/pictview/wiawrap.cpp comments

### DIFF
--- a/src/plugins/pictview/wiawrap.cpp
+++ b/src/plugins/pictview/wiawrap.cpp
@@ -1490,7 +1490,7 @@ STDMETHODIMP CDataCallback::BandedDataCallback(
                 FixBitmapHeight(pBuffer + 1, m_nDataSize, TRUE);
 
                 // For WiaImgFmt_MEMORYBMP transfers, the WIA service does not
-                // include a BITMAPFILEHEADER preceeding the bitmap data.
+                // include a BITMAPFILEHEADER preceding the bitmap data.
                 // In this case, fill in the BITMAPFILEHEADER structure.
 
                 if (m_nHeaderSize != 0)


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/wiawrap.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/wiawrap.cpp`.
- `git diff --check -- src/plugins/pictview/wiawrap.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
