### PR TITLE
[translation] Fix src/plugins/portables/fx.h comments

### DIFF
--- a/src/plugins/portables/fx.h
+++ b/src/plugins/portables/fx.h
@@ -185,7 +185,7 @@ namespace Fx
 
         /// Returns information about attributes that are valid for
         /// the enumerated items.
-        /// \return Combinatation of VALID_DATA_xxx flags.
+        /// \return Combination of VALID_DATA_xxx flags.
         virtual DWORD WINAPI GetValidData() const;
     };
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/portables/fx.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/portables/fx.h`.
- `git diff --check -- src/plugins/portables/fx.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
