### PR TITLE
[translation] Fix src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs comments

### DIFF
--- a/src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs
+++ b/src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs
@@ -151,7 +151,7 @@ namespace sspack
 			placement = anchors[anchorIndex];
 
 			// Move the rectangle either to the left or to the top until it collides with
-			// a neightbouring rectangle. This is done to combat the effect of lining up
+			// a neighbouring rectangle. This is done to combat the effect of lining up
 			// rectangles with gaps to the left or top of them because the anchor that
 			// would allow placement there has been blocked by another rectangle
 			OptimizePlacement(ref placement, rectangleWidth, rectangleHeight);


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs`.
- `git diff --check -- src/plugins/portables/res/SpriteSheetPacker/src/sspack/Packing/ArevaloRectanglePacker.cs` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
