### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs4.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs4.cpp
+++ b/src/plugins/filecomp/dialogs4.cpp
@@ -286,7 +286,7 @@ CConfigurationDialog::CConfigurationDialog(HWND parent, CConfiguration* configur
       Page3(options, changeFlag)
 {
     CALL_STACK_MESSAGE1("CConfigurationDialog::CConfigurationDialog(, , , , )");
-    Add(&Page1); // Genereal
+    Add(&Page1); // General
     Add(&Page2); // Default Compare Options
     Add(&Page3); // Colors
 


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/dialogs4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/dialogs4.cpp`.
- `git diff --check -- src/plugins/filecomp/dialogs4.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
