### PR TITLE
[translation] Fix src/plugins/filecomp/viewtext.h comments

### DIFF
--- a/src/plugins/filecomp/viewtext.h
+++ b/src/plugins/filecomp/viewtext.h
@@ -18,7 +18,7 @@ protected:
     typedef typename std::vector<CChar*> CLineBuffer;
     // CChar * Buffer;
     // CChar const ** Linbuf;
-    CChar* LineBuffer; // bufer for one formated line
+    CChar* LineBuffer; // buffer for one formatted line
     CChar* Text;
     CLineBuffer Lines;
     CIntIndexes LineChanges;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/viewtext.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/viewtext.h`.
- `git diff --check -- src/plugins/filecomp/viewtext.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
