### PR TITLE
[translation] Fix src/plugins/filecomp/viewwnd.cpp comments

### DIFF
--- a/src/plugins/filecomp/viewwnd.cpp
+++ b/src/plugins/filecomp/viewwnd.cpp
@@ -607,7 +607,7 @@ BOOL CTextFileViewWindowBase::RebuildScript(
             // context before
             size_t line;
             if (Script[0][*change].IsBlank())
-            { // find first real line preceeding change
+            { // find first real line preceding change
                 size_t si = *change;
                 while (Script[0][si].IsBlank() && si > 0)
                     --si;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/viewwnd.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/viewwnd.cpp`.
- `git diff --check -- src/plugins/filecomp/viewwnd.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
