### PR TITLE
[translation] Fix src/plugins/filecomp/worker.h comments

### DIFF
--- a/src/plugins/filecomp/worker.h
+++ b/src/plugins/filecomp/worker.h
@@ -73,9 +73,9 @@ struct CChange
         struct
         {
             size_t Deleted;   // Length of subsequence deleted from the first sequence.
-            size_t Inserted;  // Length of subsequence inserted to the seccond sequence.
+            size_t Inserted;  // Length of subsequence inserted to the second sequence.
             size_t DeletePos; // Position in the first sequence.
-            size_t InsertPos; // Position in the seccond sequence.
+            size_t InsertPos; // Position in the second sequence.
         };
         struct
         {


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/filecomp/worker.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/filecomp/worker.h`.
- `git diff --check -- src/plugins/filecomp/worker.h` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
