### PR TITLE
[translation] Fix src/plugins/pictview/pvtwain.cpp comments

### DIFF
--- a/src/plugins/pictview/pvtwain.cpp
+++ b/src/plugins/pictview/pvtwain.cpp
@@ -135,7 +135,7 @@ CTwain::CallTwainProc(TW_IDENTITY* origin,
     {
         TW_STATUS twStatus;
         (*DSMEntry)(origin, dest, DG_CONTROL, DAT_STATUS, MSG_GET, &twStatus);
-        int resID = IDS_TWCC_BUMMER; // uknown error
+        int resID = IDS_TWCC_BUMMER; // unknown error
         switch (twStatus.ConditionCode)
         {
         case TWCC_LOWMEMORY:


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/pvtwain.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `1` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/pvtwain.cpp`.
- `git diff --check -- src/plugins/pictview/pvtwain.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `1` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
