### PR TITLE
[translation] Fix src/plugins/pictview/render1.cpp comments

### DIFF
--- a/src/plugins/pictview/render1.cpp
+++ b/src/plugins/pictview/render1.cpp
@@ -1832,7 +1832,7 @@ LRESULT CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         return 0;
     }
 
-    if (uMsg == WM_MOUSEHWHEEL) // horizontall scroll, supported from Windows Vista
+    if (uMsg == WM_MOUSEHWHEEL) // horizontal scroll, supported from Windows Vista
     {
         short zDelta = (short)HIWORD(wParam);
         DWORD scrollChars = SalamanderGeneral->GetMouseWheelScrollChars(); // can be also WHEEL_PAGESCROLL (0xffffffff) for page scroll
@@ -1961,7 +1961,7 @@ LRESULT CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             KillTimer(HWindow, IMGSEQ_TIMER_ID);
         }
         DragAcceptFiles(HWindow, FALSE);
-        if (Loading) //Ooops. Soneone is closing our window, but we are still decompresing!
+        if (Loading) //Ooops. Someone is closing our window, but we are still decompressing!
         {
             Canceled = TRUE;
             break; // j.r. verify this path
@@ -1999,7 +1999,7 @@ LRESULT CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if ((YStretchedRange > 65535) && ((LOWORD(wParam) == SB_THUMBPOSITION) || (LOWORD(wParam) == SB_THUMBTRACK)))
         {
-            // We need 32-bit accurary
+            // We need 32-bit accuracy
             SCROLLINFO si;
 
             si.fMask = SIF_TRACKPOS;


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/pictview/render1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `3` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/pictview/render1.cpp`.
- `git diff --check -- src/plugins/pictview/render1.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `3` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
