### PR TITLE
[translation] Fix src/plugins/portables/fxfs.cpp comments

### DIFF
--- a/src/plugins/portables/fxfs.cpp
+++ b/src/plugins/portables/fxfs.cpp
@@ -403,7 +403,7 @@ namespace Fx
                 {
                     if (assignItemForDirs)
                     {
-                        // Tranfer ownership of the FSItem to the PluginData.
+                        // Transfer ownership of the FSItem to the PluginData.
                         fileData.PluginData = reinterpret_cast<DWORD_PTR>(item);
                         item->AddRef();
                     }
@@ -857,7 +857,7 @@ namespace Fx
             {
                 if (childEnumerator == nullptr && exitLoop)
                 {
-                    // We are exitting, return the last enumerator we have.
+                    // We are exiting, return the last enumerator we have.
                     childEnumerator = parentEnumerator;
                 }
                 else


### PR DESCRIPTION
## Summary
- Refines comment wording in `src/plugins/portables/fxfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across `2` changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Reviewed the affected comments against baseline commit `a28afcb958578dd219311a7b500320b162de812b` and the local file context.
- Confirmed the final diff only changes comments in `src/plugins/portables/fxfs.cpp`.
- `git diff --check -- src/plugins/portables/fxfs.cpp` completed without diff integrity failures.

## Telemetry
- 1 file reviewed, `2` changed comment hunks, and 0 non-comment edits.
- Grounding inputs: baseline source plus in-file surrounding context.
