### PR TITLE
[translation] Fix src/geticon.h comments

### DIFF
--- a/src/geticon.h
+++ b/src/geticon.h
@@ -32,7 +32,7 @@
 //      hiword, ie MAKELONG(24, 48) would extract 24 and 48 size icons.
 //      yes, this is a hack; it allows IExtractIcon::Extract
 //      to be called by external callers with custom large/small
-//      icon sizes that differ from what the shell uses internally.
+//      sizes that are not what the shell uses internally.
 //
 UINT WINAPI ExtractIcons(LPCTSTR szFileName, int nIconIndex, int cxIcon, int cyIcon,
                          HICON* phicon, UINT* piconid, UINT nIcons, UINT flags);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/geticon.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies the approved second-pass wording across 1 approved rewrite(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- `git diff --check -- src/geticon.h` completed without diff integrity failures.
- Confirmed the final diff stayed comment-only for this file.

## Telemetry
- Second-pass chunk 01, one-file PR pipeline for `src/geticon.h`.
- Approved rewrites applied: 1.
