### PR TITLE
[translation] Fix src/plugins/undelete/library/arraylt.h comments

### DIFF
--- a/src/plugins/undelete/library/arraylt.h
+++ b/src/plugins/undelete/library/arraylt.h
@@ -58,7 +58,7 @@ enum CErrorType
 //   contain pointers to its own data, reason:
 //     objects are moved in array (e.g. when reallocating array or when inserting
 //     item to the beginning of array) simply by using memmove, so during these
-//     moves constructors/destructors are not called; for example:
+//     move constructors/destructors are not called, example:
 //       char Path[MAX_PATH];  // full file name
 //       char *Name;           // points to 'Path' to file name (without path)
 //     SOLUTION: store only offsets instead of complete pointers


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/library/arraylt.h`.
- Keeps the change comment-only; no executable code was modified.
- Applies the approved second-pass wording across 2 approved rewrite(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- `git diff --check -- src/plugins/undelete/library/arraylt.h` completed without diff integrity failures.
- Confirmed the final diff stayed comment-only for this file.

## Telemetry
- Second-pass chunk 01, one-file PR pipeline for `src/plugins/undelete/library/arraylt.h`.
- Approved rewrites applied: 2.
