### PR TITLE
[translation] Fix src/plugins/automation/guilabel.h comments

### DIFF
--- a/src/plugins/automation/guilabel.h
+++ b/src/plugins/automation/guilabel.h
@@ -18,7 +18,7 @@
 class CSalamanderGuiLabel : public CSalamanderGuiComponentImpl<CSalamanderGuiLabel, ISalamanderGuiComponent>
 {
 protected:
-    /// Overridden.
+/// Overridden.
     /// \see CSalamanderGuiComponentBase::CreateHwnd
     virtual HWND CreateHwnd(HWND hWndParent);
 


### PR DESCRIPTION
## Summary
Applied approved second-pass comment/help-text rewrites to `src/plugins/automation/guilabel.h`.

## Model
Second-pass translation pipeline.

## Verification
- `git diff --check -- src/plugins/automation/guilabel.h`
- comment-only rewrite set

## Telemetry
- approved rewrites applied: 1
- skipped: 0