### PR TITLE
[translation] Fix src/plugins/nethood/icons.h comments

### DIFF
--- a/src/plugins/nethood/icons.h
+++ b/src/plugins/nethood/icons.h
@@ -254,7 +254,7 @@ public:
 
     /// Returns appropriate network icon.
     /// \param nSize Size of the requested icon. This is one
-    ///        of the SALICONSIZE_xxx constants.
+///        of the SALICONSIZE_xxx constants.
     /// \param icon Identifier of the icon to retrieve. This is
     ///        value from the Icon enumeration.
     /// \return If the method succeeds the return value is handle


### PR DESCRIPTION
## Summary
Applied approved second-pass comment/help-text rewrites to `src/plugins/nethood/icons.h`.

## Model
Second-pass translation pipeline.

## Verification
- `git diff --check -- src/plugins/nethood/icons.h`
- comment-only rewrite set

## Telemetry
- approved rewrites applied: 1
- skipped: 0