### PR TITLE
[translation] Fix src/plugins/portables/fxfs.cpp comments

### DIFF
--- a/src/plugins/portables/fxfs.cpp
+++ b/src/plugins/portables/fxfs.cpp
@@ -419,7 +419,7 @@ namespace Fx
                 {
                     if (assignItemForFiles)
                     {
-                        // Tranfer ownership of the FSItem to the PluginData.
+                        // Transfer ownership of the FSItem to the PluginData.
                         fileData.PluginData = reinterpret_cast<DWORD_PTR>(item);
                         item->AddRef();
                     }


### PR DESCRIPTION
## Summary
- Refines approved translated comments in `src/plugins/portables/fxfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- `git diff --check -- src/plugins/portables/fxfs.cpp` completed without diff integrity failures.
- Applied 1 approved comment/help-text rewrite in the target file.
- Added inline review comments for the changed hunk.

## Telemetry
- Second-pass translation pipeline for one file in chunk 05.
- Comment-only diff; 0 executable code hunks changed.
