### PR TITLE
[translation] Fix src/plugins/pictview/render1.cpp comments

### DIFF
--- a/src/plugins/pictview/render1.cpp
+++ b/src/plugins/pictview/render1.cpp
@@ -2024,7 +2024,7 @@ LRESULT CRendererWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         if ((XStretchedRange > 65535) && ((LOWORD(wParam) == SB_THUMBPOSITION) || (LOWORD(wParam) == SB_THUMBTRACK)))
         {
-            // We need 32-bit accurary
+            // We need 32-bit accuracy
             SCROLLINFO si;
 
             si.fMask = SIF_TRACKPOS;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/pictview/render1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Applies the approved wording corrections across 1 changed comment hunk(s) in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- Second-pass translation publish pipeline applied only approved comment/help-text rewrites for `src/plugins/pictview/render1.cpp`.
- `git diff --check -- src/plugins/pictview/render1.cpp` completed without diff integrity failures.
- 1 approved rewrite(s) were committed and annotated inline.

## Telemetry
- Cumulative for this one-file publish: 1 isolated worktree, 1 commit, 1 pushed branch, and 1 inline review comment(s).
- Branch: `pp06-10-render1-e179233`.
- Diff scope remained comment-only for the published file.
