### PR TITLE
[translation] Fix src/plugins/zip/inflate.h comments

### DIFF
--- a/src/plugins/zip/inflate.h
+++ b/src/plugins/zip/inflate.h
@@ -53,7 +53,7 @@ typedef int (*FFlushOutput)(unsigned, CDecompressionObject*);
 
 typedef struct
 {
-    //public fields, should be intialized before calling Inflate()
+    //public fields, should be initialized before calling Inflate()
     uch* SlideWin;    //circular buffer
     unsigned WinSize; //size of sliding window,
                       //should be at least 32K


### PR DESCRIPTION
## Summary
- Refines approved translated comments in `src/plugins/zip/inflate.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk in the final diff.

## Model
Model: OpenAI GPT-5.4

## Verification
- `git diff --check -- src/plugins/zip/inflate.h` completed without diff integrity failures.
- Applied 1 approved comment/help-text rewrite in the target file.
- Added inline review comments for the changed hunk.

## Telemetry
- Second-pass translation pipeline for one file in chunk 05.
- Comment-only diff; 0 executable code hunks changed.
