### PR TITLE
[translation] Fix src/common/winlib.cpp comments

### DIFF
--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -1107,7 +1107,7 @@ void CTransferInfo::EditLine(int ctrlID, double& value, TCHAR* format, BOOL sele
             BOOL decPoints = FALSE;
             BOOL expPart = FALSE;
             if (*s == _T('-') || *s == _T('+'))
-                s++;        // skip the digit
+                s++;        // skip the sign
             while (*s != 0) // convert comma to period
             {
                 if (!expPart && !decPoints && (*s == _T(',') || *s == _T('.')))
@@ -1173,7 +1173,7 @@ void CTransferInfo::EditLine(int ctrlID, int& value, BOOL select)
 
             TCHAR* s = buff;
             if (*s == _T('-') || *s == _T('+'))
-                s++;        // skip the digit
+                s++;        // skip the sign
             while (*s != 0) // validate the number
             {
                 if (*s < _T('0') || *s > _T('9'))
@@ -1227,7 +1227,7 @@ void CTransferInfo::EditLine(int ctrlID, __int64& value, BOOL select, BOOL unsig
             TCHAR* s = buff;
             BOOL minus = !unsignedNum && *s == _T('-');
             if (!unsignedNum && *s == _T('-') || *s == _T('+'))
-                s++; // skip the digit
+                s++; // skip the sign
             unsigned __int64 num = 0;
             BOOL overflow = FALSE;
             while (*s != 0) // validate the number


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-ecc17908f368` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/winlib.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `/mnt/d/source/ostranslationreview/.local/provider-eval/common-current-xhigh/packets/common/packets/packet-ecc17908f368/imported/normalized-response.json`.
