### PR TITLE
[translation] Fix src/common/messages.h comments

### DIFF
--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -287,7 +287,7 @@ extern C__MessagesW __MessagesW;
 #define DMESSAGE_TQ(str, buttons) MESSAGE_TQ(str, (buttons))
 #define DMESSAGE_TQW(str, buttons) MESSAGE_TQW(str, (buttons))
 
-// MESSAGE_TE requires MESSAGES_DEBUG to be defined
+// MESSAGE_E requires MESSAGES_DEBUG to be defined
 #define DMESSAGE_TE(str, buttons) MESSAGE_TE(str, (buttons))
 #define DMESSAGE_TEW(str, buttons) MESSAGE_TEW(str, (buttons))
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/messages.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-083aae388a12` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/messages.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-rest-xhigh\packets\prompt500k\packets\packet-083aae388a12\imported\normalized-response.json`.
