### PR TITLE
[translation] Fix src/common/str.h comments

### DIFF
--- a/src/common/str.h
+++ b/src/common/str.h
@@ -212,7 +212,7 @@ inline int SWPrintFToEnd_s(WCHAR* _Dst, size_t _SizeInWords, const WCHAR* _Forma
 //
 // SPrintFToEnd_s
 //
-// The only difference from sprintf_s is that it writes after the text already
+// The only difference from swprintf_s is that it writes after the text already
 // in the buffer
 
 template <size_t _Size>


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/str.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-8ee4d08349f9` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/str.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-rest-xhigh\packets\prompt500k\packets\packet-8ee4d08349f9\imported\normalized-response.json`.
