### PR TITLE
[translation] Fix src/common/heap.h comments

### DIFF
--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -12,7 +12,7 @@
 
 // Register modules that may report memory leaks. If leaks are detected, all
 // registered modules are reloaded "as image" (without running initialization)
-// before the leak report is printed. That preserves .cpp module names instead
+// before the leak report is printed, because they are already unloaded then. That preserves .cpp module names instead
 // of "#File Error#" messages and avoids noisy MSVC-generated exceptions.
 // Safe to call from any thread.
 void AddModuleWithPossibleMemoryLeaks(const TCHAR* fileName);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/heap.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-f1d9461a019b` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/heap.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-rest-xhigh\packets\prompt500k\packets\packet-f1d9461a019b\imported\normalized-response.json`.
