### PR TITLE
[translation] Fix src/plugins/shared/spl_arc.h comments

### DIFF
--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -129,7 +129,7 @@ public:
     // 'panel' identifies the panel in which the archive is open (PANEL_LEFT or PANEL_RIGHT);
     // returns TRUE if closing is possible; if 'force' is TRUE, it always returns TRUE; if
     // critical shutdown (for more details see CSalamanderGeneralAbstract::IsCriticalShutdown), there is
-    // there is no point in prompting the user about anything
+    // no point in prompting the user about anything
     virtual BOOL WINAPI CanCloseArchive(CSalamanderForOperationsAbstract* salamander, const char* fileName,
                                         BOOL force, int panel) = 0;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_arc.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-32d3c4a38c20` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/spl_arc.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\shared-xhigh\packets\prompt650k\packets\packet-32d3c4a38c20\imported\normalized-response.json`.
