### PR TITLE
[translation] Fix src/plugins/shared/htmlhelp.h comments

### DIFF
--- a/src/plugins/shared/htmlhelp.h
+++ b/src/plugins/shared/htmlhelp.h
@@ -225,7 +225,7 @@ extern "C"
         int iType;               // the type of the information type ie. Inclusive, Exclusive, or Hidden
         LPCSTR pszCatName;       // Set to the name of the Category to enumerate the info types in a category; else NULL
         LPCSTR pszITName;        // volatile pointer to the name of the info type. Allocated by call. Caller responsible for freeing
-        LPCSTR pszITDescription; // Pointer to the info type description.
+        LPCSTR pszITDescription; // volatile pointer to the info type description.
     } HH_ENUM_IT, *PHH_ENUM_IT;
 
     typedef struct tagHH_ENUM_CAT


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/htmlhelp.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-8fad3b51ce21` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/htmlhelp.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\shared-xhigh\packets\prompt650k\packets\packet-8fad3b51ce21\imported\normalized-response.json`.
