### PR TITLE
[translation] Fix src/menu1.cpp comments

### DIFF
--- a/src/menu1.cpp
+++ b/src/menu1.cpp
@@ -156,7 +156,7 @@ COldMenuHookTlsAllocator::HookThread()
         hOldHookProc = SetWindowsHookEx(WH_CALLWNDPROC, // HANDLES can't do this!
                                         MenuMessageHookProc,
                                         NULL, threadID);
-        // it stores th handle to the procedure in TLS so that CallNextHookEx can be called
+        // it stores the handle to the procedure in TLS so that CallNextHookEx can be called
         TlsSetValue(OldMenuHookTlsIndexHOldHook, (LPVOID)hOldHookProc);
         return hOldHookProc;
     }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/menu1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-09fb9f587547` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/menu1.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-09fb9f587547\imported\normalized-response.json`.