### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -2518,7 +2518,7 @@ BOOL CFilesWindow::ChangePathToDrvType(HWND parent, int driveType, const char* d
 void CFilesWindow::ChangeDrive(char drive)
 {
     CALL_STACK_MESSAGE2("CFilesWindow::ChangeDrive(%u)", drive);
-    //--- DefaultDire refresh
+    //--- DefaultDir refresh
     MainWindow->UpdateDefaultDir(MainWindow->GetActivePanel() != this);
     //---  possible disk selection from the dialog
     CFilesWindow* anotherPanel = (Parent->LeftPanel == this ? Parent->RightPanel : Parent->LeftPanel);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-4ccefeaecc1a` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/fileswn3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-4ccefeaecc1a\imported\normalized-response.json`.
