### PR TITLE
[translation] Fix src/packac.cpp comments

### DIFF
--- a/src/packac.cpp
+++ b/src/packac.cpp
@@ -1659,7 +1659,7 @@ BOOL CPackACFound::Set(const char* fullName, const CQuadWord& size, FILETIME las
 // CPackACDrives
 //
 
-// dialog procedure for the disk selection dialog
+// dialog procedure for the disk selection dialog used for searching
 INT_PTR
 CPackACDrives::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/packac.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-0c0e5e820998` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/packac.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-0c0e5e820998\imported\normalized-response.json`.
