### PR TITLE
[translation] Fix src/zip.h comments

### DIFF
--- a/src/zip.h
+++ b/src/zip.h
@@ -258,7 +258,7 @@ protected:
                                     const char* archivePath);
 };
 
-// checks the free space at path 'path' and, if it is >= totalSize, asks the user whether to continue
+// checks the free space at path 'path' and, if it is not >= totalSize, asks the user whether to continue
 BOOL TestFreeSpace(HWND parent, const char* path, const CQuadWord& totalSize, const char* messageTitle);
 
 //


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/zip.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-59b4490b8377` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/zip.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-59b4490b8377\imported\normalized-response.json`.
