### PR TITLE
[translation] Fix src/fileswn4.cpp comments

### DIFF
--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -1892,7 +1892,7 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
             if (drawFocusFrame)
                 r.bottom--;
         }
-        // DRAWFLAG_MASK: hack, under XP some stuff is added in font of the text in the mask while drawing short texts; not an issue if text is not drawn
+        // DRAWFLAG_MASK: hack, under XP some stuff is added in front of the text in the mask while drawing short texts; not an issue if text is not drawn
         ExtTextOut(hDC, textX, textY, ETO_OPAQUE, &r, out0, (drawFlags & DRAWFLAG_MASK) ? 0 : out0Len, NULL);
 
         // display the second line
@@ -1907,7 +1907,7 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
                 if (drawFocusFrame)
                     r.bottom--;
             }
-            // DRAWFLAG_MASK: hack, under XP some stuff is added in font of the text in the mask while drawing short texts; not an issue if text is not drawn
+            // DRAWFLAG_MASK: hack, under XP some stuff is added in front of the text in the mask while drawing short texts; not an issue if text is not drawn
             ExtTextOut(hDC, textX, textY, ETO_OPAQUE, &r, out1, (drawFlags & DRAWFLAG_MASK) ? 0 : out1Len, NULL);
         }
         // display the third line and clear the background of the area below it
@@ -1918,7 +1918,7 @@ void CFilesWindow::DrawTileItem(HDC hTgtDC, int itemIndex, RECT* itemRect, DWORD
             if (drawFocusFrame)
                 r.bottom--;
             textY += FontCharHeight;
-            // DRAWFLAG_MASK: hack, under XP some stuff is added in font of the text in the mask while drawing short texts; not an issue if text is not drawn
+            // DRAWFLAG_MASK: hack, under XP some stuff is added in front of the text in the mask while drawing short texts; not an issue if text is not drawn
             ExtTextOut(hDC, textX, textY, ETO_OPAQUE, &r, out2, (drawFlags & DRAWFLAG_MASK) ? 0 : out2Len, NULL);
         }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-8b78b2683053` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/fileswn4.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-8b78b2683053\imported\normalized-response.json`.
