### PR TITLE
[translation] Fix src/drivelst.cpp comments

### DIFF
--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1258,7 +1258,7 @@ int GetIndexForDrvText(CPluginFSInterfaceEncapsulation** fsList, int count,
     return currentIndex;
 }
 
-// creates a grayscale version of the icon from 'hSrcIcon'
+// creates a black-and-white version of the icon from 'hSrcIcon'
 // WARNING: slow; use with caution
 HICON ConvertIcon16x16ToGray(HICON hSrcIcon)
 {
@@ -1414,7 +1414,7 @@ void InitDropboxPath()
 #define my_DEFINE_KNOWN_FOLDER(name, l, w1, w2, b1, b2, b3, b4, b5, b6, b7, b8) \
     EXTERN_C const GUID DECLSPEC_SELECTANY name = {l, w1, w2, {b1, b2, b3, b4, b5, b6, b7, b8}}
 
-// {A52BBA46-E9E1-435f-B3D9-28DAA648C0F6}  // OneDriver folder from the system, introduced only since Windows 8.1
+// {A52BBA46-E9E1-435f-B3D9-28DAA648C0F6}  // OneDrive folder from the system, introduced only since Windows 8.1
 my_DEFINE_KNOWN_FOLDER(my_FOLDERID_SkyDrive, 0xa52bba46, 0xe9e1, 0x435f, 0xb3, 0xd9, 0x28, 0xda, 0xa6, 0x48, 0xc0, 0xf6);
 
 // the path to the local OneDrive folder - Personal (only for personal accounts, for business accounts we have OneDriveBusinessStorages)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/drivelst.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-d3f5eef457c3` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/drivelst.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-d3f5eef457c3\imported\normalized-response.json`.
