### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -1834,7 +1834,7 @@ BOOL AddWin64RedirectedDirAux(const char* path, const char* subDir, const char* 
                 if (found)
                 {
                     if (deleteIndex != -1)
-                        dirs->Delete(deleteIndex); // there's is a directory here, we will delete it, redirected-dir has priority (redirector ignores this directory)
+                        dirs->Delete(deleteIndex); // there is a directory here, we will delete it; redirected-dir has priority (redirector ignores this directory)
                     lstrcpyn(fileData->cFileName, redirectedDirLastComp, MAX_PATH);
                     fileData->cAlternateFileName[0] = 0;
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-effdb8fb2805` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/fileswn3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-effdb8fb2805\imported\normalized-response.json`.
