### PR TITLE
[translation] Fix src/fileswn3.cpp comments

### DIFF
--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -784,7 +784,7 @@ BOOL CFilesWindow::ReadDirectory(HWND parent, BOOL isRefresh)
                                     *ifaces++ = foundThumbLoaderPlugins[i2]->GetPluginInterfaceForThumbLoader();
                                 }
                                 *ifaces = NULL;      // the end of list of plugin interfaces
-                                iconData.SetFlag(4); // so far no unread thumbnail
+                                iconData.SetFlag(4); // thumbnail not loaded yet
 
                                 // we must allocate space for the thumbnail here; it cannot be done in the thread
                                 iconData.SetIndex(IconCache->AllocThumbnail());


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/fileswn3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-0f816375f2aa` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/fileswn3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-0f816375f2aa\imported\normalized-response.json`.
