### PR TITLE
[translation] Fix src/snooper.h comments

### DIFF
--- a/src/snooper.h
+++ b/src/snooper.h
@@ -11,7 +11,7 @@
 
     void AddDirectory(CFilesWindow* win, const char* path, BOOL registerDevNotification);                           // add a new directory for the snooper
     void ChangeDirectory(CFilesWindow* win, const char* newPath, BOOL registerDevNotification);                     // change of the specified directory
-    void DetachDirectory(CFilesWindow* win, BOOL waitForHandleClosure = FALSE, BOOL closeDevNotifification = TRUE); // no need to search anymore
+    void DetachDirectory(CFilesWindow* win, BOOL waitForHandleClosure = FALSE, BOOL closeDevNotifification = TRUE); // no need to snoop anymore
 
     BOOL InitializeThread();
     void TerminateThread();


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/snooper.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-cf49ba7df27e` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/snooper.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-cf49ba7df27e\imported\normalized-response.json`.
