### PR TITLE
[translation] Fix src/svg.h comments

### DIFF
--- a/src/svg.h
+++ b/src/svg.h
@@ -60,7 +60,7 @@ protected:
     // creates a DIB of size 'width' and 'height', returns its handle and a pointer to its data
     void CreateDIB(int width, int height, HBITMAP* hMemBmp, void** lpMemBits);
 
-    // tints the SVG 'image' with the color determined by 'state' state
+    // tints the SVG 'image' with the color determined by 'state'
     void ColorizeSVG(NSVGimage* image, DWORD state);
 
 protected:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/svg.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-cefebd7a9b52` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/svg.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-root-copilot-gpt53-high\packets\packed-900k-128u\packets\packet-cefebd7a9b52\imported\normalized-response.json`.
