### PR TITLE
[translation] Fix src/plugins/ftp/fs2.cpp comments

### DIFF
--- a/src/plugins/ftp/fs2.cpp
+++ b/src/plugins/ftp/fs2.cpp
@@ -1259,7 +1259,7 @@ BOOL CPluginFSInterface::ListCurrentPath(CSalamanderDirectoryAbstract* dir,
                 CFileData file;
                 pluginData = &SimpleListPluginDataInterface; // ATTENTION: the change may also affect obtaining the data interface in CPluginFSInterface::ChangeAttributes!
                 dir->SetValidData(VALID_DATA_NONE);
-                dir->SetFlags(SALDIRFLAG_CASESENSITIVE | SALDIRFLAG_IGNOREDUPDIRS); // probably unnecessary, but everything is treated as case-sensitive so this should be safe
+                dir->SetFlags(SALDIRFLAG_CASESENSITIVE | SALDIRFLAG_IGNOREDUPDIRS); // probably not pointless; in any case everything is treated as case-sensitive, so this should be safe
                 if (!PathListingIsBroken &&                                         // if the listing is not OK, use an empty listing instead
                     PathListingLen > 0)
                 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/fs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-890ae07e0827` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/fs2.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-ieviewer-copilot-gpt53-xhigh\packets\packed-900k-128u\packets\packet-890ae07e0827\imported\normalized-response.json`.
