### PR TITLE
[translation] Fix src/plugins/ftp/operats3.cpp comments

### DIFF
--- a/src/plugins/ftp/operats3.cpp
+++ b/src/plugins/ftp/operats3.cpp
@@ -1852,7 +1852,7 @@ void CFTPWorker::ReceiveNetEvent(LPARAM lParam, int index)
                                 {
                                     BytesToWriteOffset = 0;
                                     BytesToWriteCount = 0;
-                                    break; // report the error
+                                    break; // return the error
                                 }
                             }
                         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/operats3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-c7a6689264a1` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/operats3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-ieviewer-copilot-gpt53-xhigh\packets\packed-900k-128u\packets\packet-c7a6689264a1\imported\normalized-response.json`.
