### PR TITLE
[translation] Fix src/plugins/uniso/rawfs.cpp comments

### DIFF
--- a/src/plugins/uniso/rawfs.cpp
+++ b/src/plugins/uniso/rawfs.cpp
@@ -164,7 +164,7 @@ int CRawFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char*
             ULONG written;
             if (!file.Write(sector, nbytes, &written, name, NULL))
             {
-                // The error message has already been displayed.
+                // The error message has already been displayed by SafeWriteFile().
                 ret = UNPACK_CANCEL;
                 bFileComplete = FALSE;
                 break;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/rawfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-e5ac72b429be` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/uniso/rawfs.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `/mnt/d/source/ostranslationreview/.local/provider-eval/plugins-uniso-copilot-gpt53-xhigh/packets/packed-900k-128u/packets/packet-e5ac72b429be/imported/normalized-response.json`.
