### PR TITLE
[translation] Fix src/common/dib.cpp comments

### DIFF
--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -23,7 +23,7 @@
 #include "dib.h"
 
 // Workaround for a runtime check failure in the debug build: the original version of the macro casts rgb to WORD,
-//  so it reports data loss in the RED component.
+// so the runtime check reports data loss in the RED component.
 #undef GetGValue
 #define GetGValue(rgb) ((BYTE)(((rgb) >> 8) & 0xFF))
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/dib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-d06c043ab58d` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/dib.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-main-gpt54-high-20260505T132753Z\packets\prompt360k\packets\packet-d06c043ab58d\imported\normalized-response.json`.
