### PR TITLE
[translation] Fix src/common/messages.cpp comments

### DIFF
--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -264,7 +264,7 @@ C__MessagesW::C__MessagesW() : MessagesStrStream(&MessagesStringBuf)
     // For now we use only output streams, and only with strings (without conversion) and numbers. So sending a number to the stringstream should be enough. If we start using streams more heavily in the future and the debug heap reports leaks again, we will have to add more input/output here.
     std::wstringstream s;
     s << 1;
-#endif // MULTITHREADED_MESSAGES_ENABLE
+#endif // _DEBUG
 }
 
 struct C__MessageBoxDataW


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/messages.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-49eb33301b23` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/messages.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-main-gpt54-high-20260505T132753Z\packets\prompt360k\packets\packet-49eb33301b23\imported\normalized-response.json`.
