### PR TITLE
[translation] Fix src/common/winlib.cpp comments

### DIFF
--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -912,8 +912,8 @@ CWindowQueue::~CWindowQueue()
 {
     if (!Empty())
         TRACE_ET(_T("Some window is still opened in ") << QueueName << _T(" queue!")); // should not happen...
-    // there is no multithreading risk here anymore (the app is shutting down, the threads are/were terminated)
-    // deallocate at least some memory
+// there is no multithreading risk here anymore (the app is shutting down and the threads have been terminated)
+// deallocate at least some memory
     CWindowQueueItem* last;
     CWindowQueueItem* item = Head;
     while (item != NULL)
@@ -1142,7 +1142,7 @@ void CTransferInfo::EditLine(int ctrlID, double& value, TCHAR* format, BOOL sele
                 value = _tcstod(buff, &stopString); // only if the string is a number
             }
             else
-                value = 0; // on error, set zero
+                value = 0; // on error, set it to zero
             break;
         }
         }
@@ -1187,7 +1187,7 @@ void CTransferInfo::EditLine(int ctrlID, int& value, BOOL select)
             }
 
             TCHAR* endptr;
-            value = _tcstoul(buff, &endptr, 10); // replacement for atoi / _ttoi, which returns 2147483647 instead of 4000000000 because it uses signed int
+            value = _tcstoul(buff, &endptr, 10); // replacement for atoi / _ttoi, which return 2147483647 instead of 4000000000 because they use signed int
             break;
         }
         }
@@ -1257,7 +1257,7 @@ void CTransferInfo::EditLine(int ctrlID, __int64& value, BOOL select, BOOL unsig
             }
             if (*s != 0)
             {
-                value = 0; // on error, set zero
+                value = 0; // on error, set it to zero
                 break;
             }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/common/winlib.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-dd7d95362610` with 4 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/common/winlib.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 4.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\common-main-gpt54-high-20260505T132753Z\packets\prompt360k\packets\packet-dd7d95362610\imported\normalized-response.json`.
