### PR TITLE
[translation] Fix src/lang/lang.rc2 comments

### DIFF
--- a/src/lang/lang.rc2
+++ b/src/lang/lang.rc2
@@ -1,4 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
+﻿//
 //
 // lang.rc2 - resources Microsoft Visual C++ does not edit directly
 //


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/lang/lang.rc2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-7999dc407279` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/lang/lang.rc2`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-lang-gpt54-high-20260505T154009Z\packets\src-lang\packets\packet-7999dc407279\imported\normalized-response.json`.
