### PR TITLE
[translation] Fix src/plugins/7zip/doc/notes.txt comments

### DIFF
--- a/src/plugins/7zip/doc/notes.txt
+++ b/src/plugins/7zip/doc/notes.txt
@@ -91,8 +91,8 @@ Notes on the 7zip implementation
   and who knows what else...
 
 
-Progress
---------
+Passwords
+---------
 
 - Calling ProgressAddText(...., TRUE) does not work (delayedPaint == TRUE) ⇒ it
   freezes. It works with FALSE.


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/doc/notes.txt`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-3f3a5525ba4f` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/7zip/doc/notes.txt`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-7zip-gpt54-high-20260505T154227Z\packets\prompt360k\packets\packet-3f3a5525ba4f\imported\normalized-response.json`.
