### PR TITLE
[translation] Fix src/plugins/7zip/lang/lang.rc2 comments

### DIFF
--- a/src/plugins/7zip/lang/lang.rc2
+++ b/src/plugins/7zip/lang/lang.rc2
@@ -25,7 +25,7 @@ BEGIN
     LTEXT           "Password:",IDC_STATIC_3,48,40,37,8
     EDITTEXT        IDC_PASSWORD,88,38,151,12,ES_PASSWORD | ES_AUTOHSCROLL
 /*
- // preparation for skip and skip all
+ // preparation for the Skip and Skip all buttons
     DEFPUSHBUTTON   "OK",IDOK,12,63,50,14
     PUSHBUTTON      "Skip",IDC_SKIP,72,63,50,14
     PUSHBUTTON      "Skip all",IDC_SKIPALL,132,63,50,14


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/7zip/lang/lang.rc2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-80190b121bfb` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/7zip/lang/lang.rc2`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-7zip-gpt54-high-20260505T154227Z\packets\prompt360k\packets\packet-80190b121bfb\imported\normalized-response.json`.
