### PR TITLE
[translation] Fix src/plugins/dbviewer/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/dbviewer/help/hh/salamander_help_shared.css
+++ b/src/plugins/dbviewer/help/hh/salamander_help_shared.css
@@ -212,8 +212,8 @@
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* shrink the left side of the table to the minimum */
-  padding-right :10px;  /* but keep at least 10 points so it still looks good */
+  width: 10%;           /* shrink the left side of the table to a minimum */
+  padding-right :10px;  /* but keep at least 10 pixels so it still looks good */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/dbviewer/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-206aba2bf881` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/dbviewer/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-dbviewer-gpt54-high-20260505T161222Z\packets\prompt360k\packets\packet-206aba2bf881\imported\normalized-response.json`.
