### PR TITLE
[translation] Fix packet-6e973c64cbd7 comments

### DIFF
--- a/src/plugins/demoplug/demoplug.rh2
+++ b/src/plugins/demoplug/demoplug.rh2
@@ -60,7 +60,7 @@
 #define CML_VIEWER_VIEW          1540
 #define CML_VIEWER_FILTER        1545
 
-#define CM_FILTER_FIRST          1550 // reserved interval
+#define CM_FILTER_FIRST          1550 // reserved range
 #define CM_FILTER_LAST           1559
 
 #define IDS_MENU_FILES           2000

--- a/src/plugins/demoplug/help/hh/salamander_help_shared.css
+++ b/src/plugins/demoplug/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
+/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
-/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page

--- a/src/plugins/demoplug/help/hh/salamander_help_shared.css
+++ b/src/plugins/demoplug/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
+/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page
@@ -213,8 +213,8 @@
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* narrow the left side of the table to the minimum */
-  padding-right :10px;  /* but keep at least 10 points there so it still looks decent */
+  width: 10%;           /* narrow the left side of the table to a minimum */
+  padding-right :10px;  /* but keep at least 10 points so it still looks decent */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/demoplug/demoplug.rh2`, `src/plugins/demoplug/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-6e973c64cbd7` with 5 validated rewrite(s).
- Comment-only guard passed for 2 changed file(s): `src/plugins/demoplug/demoplug.rh2`, `src/plugins/demoplug/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 5.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-demoplug-gpt54-high-20260505T162129Z\packets\prompt360k\packets\packet-6e973c64cbd7\imported\normalized-response.json`.
