### PR TITLE
[translation] Fix packet-85892218ead2 comments

### DIFF
--- a/src/plugins/diskmap/DiskMap/Resources/DiskMap.rh2
+++ b/src/plugins/diskmap/DiskMap/Resources/DiskMap.rh2
@@ -12,7 +12,7 @@
 
 // statics
 #define IDC_STATIC_1 3000
-#include "statics.rh2"   // 3000 to 3039 are occupied by this!!!
+#include "statics.rh2"   // 3000 to 3039 are reserved by this include.
 
 
 //Dialog:

--- a/src/plugins/diskmap/DiskMapPlugin/versinfo.rh2
+++ b/src/plugins/diskmap/DiskMapPlugin/versinfo.rh2
@@ -13,7 +13,7 @@
 #define VERSINFO_MINORA      1
 #define VERSINFO_MINORB      2
 
-#include "spl_vers.h" // pull version numbers + build
+#include "spl_vers.h" // pull in version numbers and the build number
 
 //#define VERSINFO_COPYRIGHT   "Copyright © 2009-2023 Ondřej Zarevúcky"
 #define VERSINFO_COPYRIGHT   "Copyright © 2009-2023 Ondrej Zarevucky"

--- a/src/plugins/diskmap/help/hh/salamander_help_shared.css
+++ b/src/plugins/diskmap/help/hh/salamander_help_shared.css
@@ -213,7 +213,7 @@
   padding: 2px 4px;
   font-weight: bold;
   width: 10%;           /* narrow the table's left side to a minimum */
-  padding-right :10px;  /* but leave at least 10 points so it looks acceptable */
+  padding-right :10px;  /* but leave at least 10 pixels so it looks acceptable */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/diskmap/DiskMap/Resources/DiskMap.rh2`, `src/plugins/diskmap/DiskMapPlugin/versinfo.rh2`, `src/plugins/diskmap/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-85892218ead2` with 3 validated rewrite(s).
- Comment-only guard passed for 3 changed file(s): `src/plugins/diskmap/DiskMap/Resources/DiskMap.rh2`, `src/plugins/diskmap/DiskMapPlugin/versinfo.rh2`, `src/plugins/diskmap/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-diskmap-gpt54-high-20260505T163513Z\packets\prompt360k\packets\packet-85892218ead2\imported\normalized-response.json`.
