### PR TITLE
[translation] Fix src/plugins/filecomp/controls.cpp comments

### DIFF
--- a/src/plugins/filecomp/controls.cpp
+++ b/src/plugins/filecomp/controls.cpp
@@ -83,7 +83,7 @@ CFileHeaderWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         r.left++;
         r.right--;
 
-        // DT_PATH_ELLIPSIS does not work on some strings, which prints clipped text
+        // DT_PATH_ELLIPSIS does not work for some strings, so clipped text gets printed
         // PathCompactPath() needs a copy in a local buffer, but it does not clip the text
         char buff[2 * MAX_PATH];
         strncpy_s(buff, _countof(buff), Text, _TRUNCATE);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/controls.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-64d954ceafbb` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/controls.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-64d954ceafbb\imported\normalized-response.json`.
