### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs.cpp
+++ b/src/plugins/filecomp/dialogs.cpp
@@ -133,7 +133,7 @@ LRESULT CCompareFilesDialog::DragDropEditProc(HWND hWnd, UINT uMsg, WPARAM wPara
     CCompareFilesDialog* pParent = (CCompareFilesDialog*)WindowsManager.GetWindowPtr(GetParent(hWnd));
 
     if (!pParent)
-        return NULL; // Parent dialog not found
+        return NULL; // What's wrong?
 
     if (WM_DROPFILES == uMsg)
     {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-20c4a393428f` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/dialogs.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-20c4a393428f\imported\normalized-response.json`.
