### PR TITLE
[translation] Fix src/plugins/filecomp/dialogs2.cpp comments

### DIFF
--- a/src/plugins/filecomp/dialogs2.cpp
+++ b/src/plugins/filecomp/dialogs2.cpp
@@ -221,7 +221,7 @@ void CPropPageColors::ChooseColor(int item, int colorFG, int colorBK, const RECT
                              btnRect->right, btnRect->top, HWindow, &tpmPar))
     {
     case CM_CUSTOMTEXT:
-        color = colorFG; // keep going...
+        color = colorFG; // fall through
     case CM_CUSTOMBACKGROUND:
     {
         CHOOSECOLOR cc;
@@ -563,7 +563,7 @@ CPreviewWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
         RECT r1; // line number
         r1.left = 0;
         r1.right = (2 + 1) * FontWidth + BORDER_WIDTH;
-        r1.bottom = 0; // have valid data later if the drawing loop never runs
+        r1.bottom = 0; // so we have valid data later even if the drawing loop never runs
         RECT r2;       // the actual text line
         r2.left = r1.right;
         r2.right = cr.right;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/dialogs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-66045f5c0d41` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/dialogs2.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-66045f5c0d41\imported\normalized-response.json`.
