### PR TITLE
[translation] Fix src/plugins/filecomp/filecomp.cpp comments

### DIFF
--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -522,8 +522,8 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
 
             if (!fd2)
             {
-                // one item is selected and we take the other either from focus
-                // or from the selection in the target panel
+// one item is selected, and we take the other either from the focused item
+// or from the selection in the target panel
                 index = 0;
                 fd2 = SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir);
                 if (!tgtPanelIsDisk || !fd2 || SG->GetPanelSelectedItem(PANEL_TARGET, &index, &isDir))
@@ -561,7 +561,7 @@ BOOL CPluginInterfaceForMenu::ExecuteMenuItem(CSalamanderForOperationsAbstract* 
         SG->SalPathAppend(file1, fd1->Name, MAX_PATH);
 
         if (fd2 &&
-            !isDir && fd2 != fd1) // in case we take the file from the focus
+            !isDir && fd2 != fd1) // in case we take the file from the focused item
         {
             // store the name of the second file
             SG->GetPanelPath(PANEL_SOURCE, file2, MAX_PATH, NULL, NULL);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/filecomp.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-31a845541dd7` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/filecomp.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-31a845541dd7\imported\normalized-response.json`.
