### PR TITLE
[translation] Fix src/plugins/filecomp/mainwnd.cpp comments

### DIFF
--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -962,8 +962,8 @@ bool CMainWindow::TextFilesDiffer(CTextCompareResults<CChar>* res, char* message
     TTextFileViewWindow<CChar>* leftFileView = (TTextFileViewWindow<CChar>*)FileView[fviLeft];
     TTextFileViewWindow<CChar>* rightFileView = (TTextFileViewWindow<CChar>*)FileView[fviRight];
 
-    // take ownership of the data; from now on it must be deallocated here
-    // when passed in CTextCompareResults
+    // take ownership of the data; from now on, it must be deallocated here
+    // after it is passed via CTextCompareResults
     leftFileView->SetData(res->Files[0].Text, res->Files[0].Lines, res->Files[0].LineScript);
     rightFileView->SetData(res->Files[1].Text, res->Files[1].Lines, res->Files[1].LineScript);
 

--- a/src/plugins/filecomp/mainwnd.cpp
+++ b/src/plugins/filecomp/mainwnd.cpp
@@ -1167,7 +1167,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             UINT state = GetMenuState(GetMenu(HWindow), CM_PREVDIFF, MF_BYCOMMAND);
             if (state & (MF_DISABLED | MF_GRAYED))
             {
-                if (DifferencesCount > 0) // Petr: if the view is scrolled elsewhere, Alt+Arrow should focus the difference; with only one difference this did not work at all, otherwise it worked only by switching to next/previous
+                if (DifferencesCount > 0) // Petr: when the view is scrolled away, Alt+Arrow should focus the difference (finding it manually is a pain); with only one difference, it did not work at all, otherwise it only worked by switching to previous/next
                     SelectDifference(SelectedDifference, CM_PREVDIFF);
                 return 0;
             }
@@ -1207,7 +1207,7 @@ CMainWindow::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         case CM_NEXTDIFF:
             if (DataValid)
-                SelectDifference(SelectedDifference + 1, CM_NEXTDIFF); // guard the DifferencesCount test later
+                SelectDifference(SelectedDifference + 1, CM_NEXTDIFF); // handle the DifferencesCount test later
             return 0;
 
         case CM_LASTDIFF:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/mainwnd.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-bba1ba447423` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/mainwnd.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-bba1ba447423\imported\normalized-response.json`.
