### PR TITLE
[translation] Fix src/plugins/filecomp/worker2.cpp comments

### DIFF
--- a/src/plugins/filecomp/worker2.cpp
+++ b/src/plugins/filecomp/worker2.cpp
@@ -331,7 +331,7 @@ int CFilecompWorker::FindDifferencesBody(CCachedFile (&cf)[2], QWORD changeOffs,
                 }
             }
 
-            // compare data in blocks of the requested size
+// compare data in blocks of the current size
             DWORD size = (DWORD)__min(blokSize, remain);
 
             ptr0 = cf[0].ReadBuffer(offset, size, CancelFlag);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/filecomp/worker2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-0670419cb86c` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/filecomp/worker2.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-filecomp-gpt54-high-20260505T164833Z\packets\prompt360k\packets\packet-0670419cb86c\imported\normalized-response.json`.
