### PR TITLE
[translation] Fix src/plugins/ftp/ctrlcon3.cpp comments

### DIFF
--- a/src/plugins/ftp/ctrlcon3.cpp
+++ b/src/plugins/ftp/ctrlcon3.cpp
@@ -1470,7 +1470,7 @@ void CControlConnectionSocket::GiveConnectionToWorker(CFTPWorker* newWorker, HWN
                 HANDLES(EnterCriticalSection(&SocketCritSect));
                 HANDLES(EnterCriticalSection(&newWorker->SocketCritSect));
 
-                // pass the worker information about the connection and the socket data
+// pass the connection information and socket data to the worker
                 newWorker->ControlConnectionUID = UID;
                 if (HaveWorkingPath)
                 {
@@ -1537,7 +1537,7 @@ void CControlConnectionSocket::GetConnectionFromWorker(CFTPWorker* workerWithCon
             HANDLES(EnterCriticalSection(&SocketCritSect));
             HANDLES(EnterCriticalSection(&workerWithCon->SocketCritSect));
 
-            // take over from the worker the information about the connection and the socket data
+// take over the connection information and socket data from the worker
             workerWithCon->ControlConnectionUID = -1;
             if (workerWithCon->HaveWorkingPath)
             {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/ctrlcon3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-3c84984047bd` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/ctrlcon3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-3c84984047bd\imported\normalized-response.json`.
