### PR TITLE
[translation] Fix src/plugins/ftp/dialogs4.cpp comments

### DIFF
--- a/src/plugins/ftp/dialogs4.cpp
+++ b/src/plugins/ftp/dialogs4.cpp
@@ -219,8 +219,8 @@ void CEditSrvTypeColumnDlg::Transfer(CTransferInfo& ti)
                 }
                 if (add && GetColumnTypeName(buf, 100, (CSrvTypeColumnTypes)i))
                 {
-                    SendMessage(combo, CB_ADDSTRING, 0, (LPARAM)buf); // add the string and
-                    SendMessage(combo, CB_SETITEMDATA, count++, i);   // associate which column type it is
+                    SendMessage(combo, CB_ADDSTRING, 0, (LPARAM)buf); // add the string
+                    SendMessage(combo, CB_SETITEMDATA, count++, i);   // associate the corresponding column type with it
                     if (Edit && (int)(ColumnsData->At(*EditedColumn)->Type) == i)
                     {
                         focus = count - 1; // when editing we focus our type


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/dialogs4.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-30372fab542a` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/dialogs4.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-30372fab542a\imported\normalized-response.json`.
