### PR TITLE
[translation] Fix src/plugins/ftp/dialogs7.cpp comments

### DIFF
--- a/src/plugins/ftp/dialogs7.cpp
+++ b/src/plugins/ftp/dialogs7.cpp
@@ -134,8 +134,8 @@ void CSolveItemErrorDlg::Validate(CTransferInfo& ti)
     }
 }
 
-// button meaning in connection with "do the same action for all operations with the same error":
-// buttons (order of values in one row of the array):
+// button meanings for "do the same action for all operations with the same error":
+// buttons (order of values in each row of the array):
 //   use-alternate-name, resume, resume or overwrite, overwrite, skip, use-existing-dir, ignore, in-binary-mode
 // special value: -1 = not applicable
 int ButtonActionsTbl[][8] = {
@@ -454,7 +454,7 @@ CSolveItemErrorDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
         if (DlgType == sidtTgtFileAlreadyExists ||
             DlgType == sidtUploadTgtFileAlreadyExists)
-        { // we want our own focus on the Overwrite button
+        { // we want to set the focus to the Overwrite button ourselves
             SendMessage(HWindow, WM_NEXTDLGCTL, (WPARAM)GetDlgItem(HWindow, CM_SIED_OVERWRITE), TRUE);
             CCenteredDialog::DialogProc(uMsg, wParam, lParam);
             return FALSE;
@@ -492,7 +492,7 @@ CSolveItemErrorDlg::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             {
                 menuID = IDM_CANTCRFILEERRRETRY;
             }
-            HMENU main = LoadMenu(HLanguage, MAKEINTRESOURCE(menuID)); // we expose all commands in both variants ("join" would be missing in the situation when the directory exists + by default autorename is tried, which fails -> because of the error "already exists" looks like "cannot create")
+            HMENU main = LoadMenu(HLanguage, MAKEINTRESOURCE(menuID)); // expose all commands in both variants ("join" would otherwise be missing when the directory already exists and autorename is tried by default but fails, making the "already exists" error appear as "cannot create")
             if (main != NULL)
             {
                 HMENU subMenu = GetSubMenu(main, 0);
@@ -1063,11 +1063,11 @@ void COperDlgListView::Attach(HWND hListView, COperationDlg* operDlg, BOOL consO
     if (dlgFont != NULL || SystemFont != NULL)
         SendMessage(HToolTip, WM_SETFONT, (WPARAM)(dlgFont != NULL ? dlgFont : SystemFont), TRUE);
 
-    // SetWindowPos(HWND_TOPMOST) is commented out because otherwise message boxes above the operation dialog do not work
-    // completely correctly: when Alt+TAB switches to a message box, the operation dialog is not activated automatically
-    // (not brought to the front).
-    //  SetWindowPos(HToolTip, HWND_TOPMOST, 0, 0, 0, 0,
-    //               SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSIZE);
+// SetWindowPos(HWND_TOPMOST) is commented out because otherwise message boxes above the operation dialog do not work correctly:
+// when Alt+TAB switches to a message box, the operation dialog is not activated automatically
+// (not brought to the front).
+//  SetWindowPos(HToolTip, HWND_TOPMOST, 0, 0, 0, 0,
+//               SWP_NOACTIVATE | SWP_NOMOVE | SWP_NOREDRAW | SWP_NOSIZE);
 
     SendMessage(HToolTip, TTM_SETDELAYTIME, TTDT_INITIAL, 0);
     SendMessage(HToolTip, TTM_SETDELAYTIME, TTDT_RESHOW, 0);
@@ -1235,9 +1235,9 @@ COperDlgListView::WindowProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
             if (pt.x + width > monRect.right)
                 pt.x = monRect.right - width;
 
-            // SetWindowPos(HWND_TOPMOST) is commented out because otherwise message boxes above the operation dialog do not work
-            // completely correctly: when Alt+TAB switches to a message box, the operation dialog is not activated automatically
-            // (not brought to the front).
+// SetWindowPos(HWND_TOPMOST) is commented out because otherwise message boxes above the operation dialog do not work correctly:
+// when Alt+TAB switches to a message box, the operation dialog is not activated automatically
+// (not brought to the front).
             /*
         SetWindowPos(HToolTip, HWND_TOPMOST,
                      pt.x,


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/dialogs7.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 5 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-4585c697e31c` with 5 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/dialogs7.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 5.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-4585c697e31c\imported\normalized-response.json`.
