### PR TITLE
[translation] Fix src/plugins/ftp/fs1.cpp comments

### DIFF
--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -154,8 +154,8 @@ void ReleaseFS()
 
     // terminate operation workers (they should already be finished, this is just in case of an error)
     FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(),
-                                  -1 /* all workers */,
-                                  -1 /* all operations */);
+                                  -1 /* all operations */,
+                                  -1 /* all workers */);
 
     if (!UnregisterClass(SAVEBITS_CLASSNAME, DLLInstance))
         TRACE_E("UnregisterClass(SAVEBITS_CLASSNAME) has failed");

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -215,7 +215,7 @@ void ReleaseFS()
         SalamanderGeneral->DestroySafeWaitWindow();
     }
 
-// kill auxiliary threads that did not finish cleanly
+    // kill auxiliary threads that did not finish cleanly
     AuxThreadQueue.KillAll(TRUE, 0, 0);
 
     if (FTPIcon != NULL)

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -39,7 +39,7 @@ void WINAPI HTMLHelpCallback(HWND hWindow, UINT helpID)
 
 BOOL InitFS()
 {
-#ifdef _DEBUG // must be 4 bytes because it is stored in LastWrite into the upper and lower DWORD
+#ifdef _DEBUG // must be 4 bytes because it is stored in LastWrite in the upper and lower DWORDs
     if (sizeof(CFTPTime) != 4 || sizeof(CFTPDate) != 4)
         TRACE_E("FATAL ERROR: sizeof(CFTPTime) or sizeof(CFTPDate) is not 4 bytes!");
 #endif
@@ -154,8 +154,8 @@ void ReleaseFS()
 
     // terminate operation workers (they should already be finished, this is just in case of an error)
     FTPOperationsList.StopWorkers(SalamanderGeneral->GetMsgBoxParent(),
-                                  -1 /* all operations */,
-                                  -1 /* all workers */);
+                                  -1 /* all workers */,
+                                  -1 /* all operations */);
 
     if (!UnregisterClass(SAVEBITS_CLASSNAME, DLLInstance))
         TRACE_E("UnregisterClass(SAVEBITS_CLASSNAME) has failed");
@@ -215,7 +215,7 @@ void ReleaseFS()
         SalamanderGeneral->DestroySafeWaitWindow();
     }
 
-    // kill auxiliary threads that did not finish "legally"
+// kill auxiliary threads that did not finish cleanly
     AuxThreadQueue.KillAll(TRUE, 0, 0);
 
     if (FTPIcon != NULL)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/fs1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-013cbb1ace84` with 4 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/fs1.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 4.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-013cbb1ace84\imported\normalized-response.json`.
