### PR TITLE
[translation] Fix src/plugins/ftp/ftp3.cpp comments

### DIFF
--- a/src/plugins/ftp/ftp3.cpp
+++ b/src/plugins/ftp/ftp3.cpp
@@ -325,7 +325,7 @@ void CFTPServerList::CheckProxyServersUID(CFTPProxyServerList& ftpProxyServerLis
 
 BOOL CFTPServerList::ContainsUnsecuredPassword()
 {
-    // NOTE, the same method exists for CFTPProxyServerList
+    // NOTE: the same method exists for CFTPProxyServerList
     CSalamanderPasswordManagerAbstract* passwordManager = SalamanderGeneral->GetSalamanderPasswordManager();
     int i;
     for (i = 0; i < Count; i++)
@@ -411,7 +411,7 @@ BOOL EncryptPasswordAux(BYTE** encryptedPassword, int* encryptedPasswordSize, BO
 
 BOOL CFTPServerList::EncryptPasswords(HWND hParent, BOOL encrypt)
 {
-    // NOTE, the same method exists for CFTPProxyServerList
+    // NOTE: the same method exists for CFTPProxyServerList
     BOOL ret = TRUE;
     int i;
     for (i = 0; i < Count; i++)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/ftp3.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-bf8f63c0c4c3` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/ftp3.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-bf8f63c0c4c3\imported\normalized-response.json`.
