### PR TITLE
[translation] Fix src/plugins/ftp/menu.cpp comments

### DIFF
--- a/src/plugins/ftp/menu.cpp
+++ b/src/plugins/ftp/menu.cpp
@@ -4,7 +4,7 @@
 
 #include "precomp.h"
 
-int GlobalShowLogUID = -1;      // UID of the log FTPCMD_SHOWLOGS should display (-1 == none)
+int GlobalShowLogUID = -1;      // UID of the log that FTPCMD_SHOWLOGS should display (-1 == none)
 int GlobalDisconnectPanel = -1; // panel for which disconnect is called (-1 == active panel - source)
 
 //
@@ -136,7 +136,7 @@ BOOL CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstrac
     }
 
     case FTPCMD_CLOSECONNOTIF: // posted helper command ('salamander' and 'eventMask' are empty)
-    {                          // checks whether the user has already learned about the closing of the "control connection"
+    {                          // checks whether the user has already learned that the "control connection" was closed
         ClosedCtrlConChecker.Check(parent);
         return FALSE; // ignored
     }
@@ -237,7 +237,7 @@ BOOL CPluginInterfaceForMenuExt::ExecuteMenuItem(CSalamanderForOperationsAbstrac
                     break;
                 }
             }
-            workerWithCon->ForceClose(); // force-close the socket (nothing should be waiting on close socket; CloseSocket() would be enough, but we play it safe - SocketClosed is set to TRUE immediately after adding to ReturningConnections)
+            workerWithCon->ForceClose(); // force-close the socket (nothing should be waiting for the socket to close; CloseSocket() would be enough, but we play it safe - SocketClosed is set to TRUE immediately after adding to ReturningConnections)
             if (workerWithCon->CanDeleteFromRetCons())
                 DeleteSocket(workerWithCon);
         }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/menu.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-e5f91517d20f` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/menu.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-e5f91517d20f\imported\normalized-response.json`.
