### PR TITLE
[translation] Fix src/plugins/ftp/operats1.cpp comments

### DIFF
--- a/src/plugins/ftp/operats1.cpp
+++ b/src/plugins/ftp/operats1.cpp
@@ -3177,7 +3177,7 @@ void CFTPQueue::GetCopyProgressInfo(CQuadWord* downloaded, int* unknownSizeCount
     if (oper->GetApproxByteSize(&size, DoneOrSkippedBlockSize))
         *downloaded += size;
     else
-        *unknownSizeCount += CopyUnknownSizeCountIfUnknownBlockSize; // block size is unknown, so add those with size in blocks to the unknown ones
+        *unknownSizeCount += CopyUnknownSizeCountIfUnknownBlockSize; // block size is unknown, so add those with sizes in blocks to the unknown count
     *totalWithoutErrors = WaitingOrProcessingOrDelayedByteSize;
     if (oper->GetApproxByteSize(&size, WaitingOrProcessingOrDelayedBlockSize))
         *totalWithoutErrors += size;
@@ -3226,7 +3226,7 @@ BOOL CFTPQueue::SearchItemWithNewError(int* itemUID, int* itemIndex)
     CALL_STACK_MESSAGE1("CFTPQueue::SearchItemWithNewError()");
     HANDLES(EnterCriticalSection(&QueueCritSect));
     BOOL res = FALSE;
-    if (LastFoundErrorOccurenceTime + 1 < LastErrorOccurenceTime + 1) // +1 is here because -1 is used as the initial values
+    if (LastFoundErrorOccurenceTime + 1 < LastErrorOccurenceTime + 1) // the +1 is here because -1 is used for the initial values
     {                                                                 // it makes sense to search
         int foundUID = -1;
         int foundIndex = -1;
@@ -3240,7 +3240,7 @@ BOOL CFTPQueue::SearchItemWithNewError(int* itemUID, int* itemIndex)
                 itemErrorOccurenceTime = item->ErrorOccurenceTime;
             if (itemErrorOccurenceTime != -1 &&                                       // the item contains an error
                 itemErrorOccurenceTime >= LastFoundErrorOccurenceTime + 1 &&          // this is a "new" error
-                (foundUID == -1 || foundErrorOccurenceTime > itemErrorOccurenceTime)) // so far the first found or the "oldest" (we resolve errors in the order they occurred)
+                (foundUID == -1 || foundErrorOccurenceTime > itemErrorOccurenceTime)) // either the first one found so far or the "oldest" (we resolve errors in the order they occurred)
             {
                 foundErrorOccurenceTime = itemErrorOccurenceTime;
                 foundUID = item->UID;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/operats1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-3aa8298489fd` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/operats1.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-3aa8298489fd\imported\normalized-response.json`.
