### PR TITLE
[translation] Fix src/plugins/ftp/operats7.cpp comments

### DIFF
--- a/src/plugins/ftp/operats7.cpp
+++ b/src/plugins/ftp/operats7.cpp
@@ -1534,8 +1534,8 @@ void CFTPWorker::HandleEventInWorkingState2(CFTPWorkerEvent event, BOOL& sendQui
                                                         CFTPQueueItemDir* parentItem = (CFTPQueueItemDir*)(ftpQueueItems->At(ftpQueueItems->Count - 1)); // it must necessarily be a descendant of CFTPQueueItemDir (each "parent" item has the counts Skipped+Failed+NotDone)
                                                         parentItem->SetStateAndNotDoneSkippedFailed(childItemsNotDone, childItemsSkipped,
                                                                                                     childItemsFailed, childItemsUINeeded);
-                                                        // Now all new items are represented only by the "parent" item -> count the new
-                                                        // NotDone + Skipped + Failed + UINeeded apply only to this item
+// Now all new items are represented only by the "parent" item -> count
+// the new NotDone + Skipped + Failed + UINeeded only for this item
                                                         childItemsNotDone = 1;
                                                         childItemsFailed = 0;
                                                         childItemsSkipped = 0;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/operats7.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-e28d21e863d8` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/operats7.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-e28d21e863d8\imported\normalized-response.json`.
