### PR TITLE
[translation] Fix src/plugins/ftp/operats9.cpp comments

### DIFF
--- a/src/plugins/ftp/operats9.cpp
+++ b/src/plugins/ftp/operats9.cpp
@@ -5,7 +5,7 @@
 #include "precomp.h"
 
 #ifdef _DEBUG
-int CUploadListingsOnServer::FoundPathIndexesInCache = 0; // how many searched paths the cache has caught
+int CUploadListingsOnServer::FoundPathIndexesInCache = 0; // how many searched paths were found in the cache
 int CUploadListingsOnServer::FoundPathIndexesTotal = 0;   // total number of searched paths
 #endif
 
@@ -1817,7 +1817,7 @@ CUploadListingChange::CUploadListingChange(DWORD changeTime, CUploadListingChang
     }
 }
 
-CUploadListingChange::~CUploadListingChange() // release the data, but WARNING: must not free NextChange
+CUploadListingChange::~CUploadListingChange() // release the data, but WARNING: do not free NextChange
 {
     if (Name != NULL)
         SalamanderGeneral->Free(Name);


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/operats9.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-663cb40bf0dc` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/operats9.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-663cb40bf0dc\imported\normalized-response.json`.
