### PR TITLE
[translation] Fix src/plugins/ftp/parser1.cpp comments

### DIFF
--- a/src/plugins/ftp/parser1.cpp
+++ b/src/plugins/ftp/parser1.cpp
@@ -1904,7 +1904,7 @@ CFTPParserParameter::GetNumberOperand(CFileData* file, CFTPListingPluginDataInte
             else
             {
                 __int64 num = dataIface->GetNumberFromColumn(*file, ColumnIndex);
-                // if (num == INT64_EMPTYNUMBER) num = 0;  // the "empty value" equals zero // cannot occur, the parser compilation fails: using the value before it is initialized
+// if (num == INT64_EMPTYNUMBER) num = 0;  // the "empty value" equals zero; this cannot occur because parser compilation fails if the value is used before it is initialized
                 *minus = num < 0;
                 return num;
             }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ftp/parser1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-1ff4914f3466` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ftp/parser1.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ftp-gpt54-high-20260505T171736Z\packets\prompt2200k-u512-c320\packets\packet-1ff4914f3466\imported\normalized-response.json`.
