### PR TITLE
[translation] Fix src/plugins/ieviewer/ieviewer.cpp comments

### DIFF
--- a/src/plugins/ieviewer/ieviewer.cpp
+++ b/src/plugins/ieviewer/ieviewer.cpp
@@ -1528,12 +1528,12 @@ BOOL CSite::Create(HWND hParentWnd)
     if (!ObjectInitialize())
         return FALSE;
 
-    // Let it create an instance of CLSID_WebBrowser and fetch IID_IUnknown
+// Create an instance of CLSID_WebBrowser and fetch IID_IUnknown
     HRESULT hr = CoCreateInstance(my_CLSID_WebBrowser, NULL,
                                   CLSCTX_INPROC_SERVER | CLSCTX_INPROC_HANDLER,
                                   IID_IUnknown, (void**)&m_pIUnknown);
 
-    if (hr == REGDB_E_CLASSNOTREG) // correct case
+    if (hr == REGDB_E_CLASSNOTREG) // expected case
     {
         TRACE_E("A InternetExplorer class is not registered in the registration database");
         return FALSE;
@@ -1553,7 +1553,7 @@ BOOL CSite::Create(HWND hParentWnd)
         return FALSE;
     }
 
-    // try whether IID_IWebBrowser2 is also available
+// see whether IID_IWebBrowser2 is also available
     hr = m_pIUnknown->QueryInterface(IID_IWebBrowser2, (void**)&m_pIWebBrowser2);
     if (FAILED(hr))
     {
@@ -1935,8 +1935,8 @@ CIEMainWindowQueue::~CIEMainWindowQueue()
 {
     if (!Empty())
         TRACE_E("A viewer window remained open!");
-    // no multithreading risk here (the plugin is ending, threads are/were terminated)
-    // free at least some memory
+// no multithreading risk here (the plugin is ending, and the threads have been or are being terminated)
+// free at least some memory
     CIEMainWindowQueueItem* last;
     CIEMainWindowQueueItem* item = Head;
     while (item != NULL)
@@ -2008,7 +2008,7 @@ BOOL CIEMainWindowQueue::CloseAllWindows(BOOL force, int waitTime, int forceWait
     }
     CS.Leave();
 
-    // wait until/if they close
+// wait to see whether they close
     DWORD ti = GetTickCount();
     DWORD w = force ? forceWaitTime : waitTime;
     while ((w == INFINITE || w > 0) && !Empty())
@@ -2123,7 +2123,7 @@ CIEMainWindow::GetLock()
 
 // ****************************************************************************
 // static function CIEMainWindow::CIEMainWindowProc for all messages of all viewer
-// windows, distributes messages to individual viewer windows via the
+// windows; it distributes messages to individual viewer windows via the
 // CIEMainWindow::WindowProc method (a suitable place to process messages of
 // individual windows)
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ieviewer/ieviewer.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 6 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-983ade61aacb` with 6 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/ieviewer/ieviewer.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 6.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ieviewer-gpt54-high-20260505T194922Z\packets\prompt360k\packets\packet-983ade61aacb\imported\normalized-response.json`.
