### PR TITLE
[translation] Fix packet-b02ed5158a02 comments

### DIFF
--- a/src/plugins/ieviewer/help/hh/salamander_help_shared.css
+++ b/src/plugins/ieviewer/help/hh/salamander_help_shared.css
@@ -213,7 +213,7 @@
   padding: 2px 4px;
   font-weight: bold;
   width: 10%;           /* narrow the left side of the table to a minimum */
-  padding-right :10px;  /* but keep at least 10 points so it looks presentable */
+  padding-right :10px;  /* but keep at least 10 pixels so it still looks presentable */
   white-space: nowrap;
 }
 

--- a/src/plugins/ieviewer/versinfo.rh2
+++ b/src/plugins/ieviewer/versinfo.rh2
@@ -13,7 +13,7 @@
 #define VERSINFO_MINORA      1
 #define VERSINFO_MINORB      2
 
-#include "spl_vers.h" // pull version numbers + build
+#include "spl_vers.h" // pull in version numbers and the build number
 
 #define VERSINFO_COPYRIGHT   "Copyright © 1999-2023 Open Salamander Authors"
 #define VERSINFO_COMPANY     "Open Salamander"


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/ieviewer/help/hh/salamander_help_shared.css`, `src/plugins/ieviewer/versinfo.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-b02ed5158a02` with 2 validated rewrite(s).
- Comment-only guard passed for 2 changed file(s): `src/plugins/ieviewer/help/hh/salamander_help_shared.css`, `src/plugins/ieviewer/versinfo.rh2`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-ieviewer-gpt54-high-20260505T194922Z\packets\prompt360k\packets\packet-b02ed5158a02\imported\normalized-response.json`.
