### PR TITLE
[translation] Fix src/plugins/mmviewer/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/mmviewer/help/hh/salamander_help_shared.css
+++ b/src/plugins/mmviewer/help/hh/salamander_help_shared.css
@@ -212,7 +212,7 @@
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* shrink the left side of the table to the minimum */
+  width: 10%;           /* shrink the left side of the table to a minimum */
   padding-right :10px;  /* but leave at least 10 points so it still looks decent */
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/mmviewer/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-09a375f42193` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/mmviewer/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-mmviewer-gpt54-high-20260505T200108Z\packets\prompt360k\packets\packet-09a375f42193\imported\normalized-response.json`.
