### PR TITLE
[translation] Fix packet-ff3263bd0129 comments

### DIFF
--- a/src/plugins/pak/spl/help/hh/salamander_help_shared.css
+++ b/src/plugins/pak/spl/help/hh/salamander_help_shared.css
@@ -213,7 +213,7 @@
   padding: 2px 4px;
   font-weight: bold;
   width: 10%;           /* narrow the left side of the table to a minimum */
-  padding-right :10px;  /* but leave at least 10 points so it looks decent */
+  padding-right :10px;  /* but leave at least 10px so it looks decent */
   white-space: nowrap;
 }
 

--- a/src/plugins/pak/spl/pak.rh2
+++ b/src/plugins/pak/spl/pak.rh2
@@ -7,7 +7,7 @@
 #endif //defined(APSTUDIO_INVOKED) && !defined(APSTUDIO_READONLY_SYMBOLS)
 
 #define IDC_STATIC_1 300
-#include "statics.rh2"   // IDs 300 to 339 are reserved by this include!!!
+#include "statics.rh2"   // IDs 300 to 339 are reserved by this include.
 
 #define IDB_PAK         104
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/pak/spl/help/hh/salamander_help_shared.css`, `src/plugins/pak/spl/pak.rh2`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-ff3263bd0129` with 2 validated rewrite(s).
- Comment-only guard passed for 2 changed file(s): `src/plugins/pak/spl/help/hh/salamander_help_shared.css`, `src/plugins/pak/spl/pak.rh2`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-pak-gpt54-high-20260505T200926Z\packets\prompt360k\packets\packet-ff3263bd0129\imported\normalized-response.json`.
