### PR TITLE
[translation] Fix src/plugins/regedt/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/regedt/help/hh/salamander_help_shared.css
+++ b/src/plugins/regedt/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
+/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
-/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page
@@ -323,4 +323,3 @@
   padding-left: 4px;
   text-align: left;
 }
-

--- a/src/plugins/regedt/help/hh/salamander_help_shared.css
+++ b/src/plugins/regedt/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
+/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page
@@ -213,7 +213,7 @@
   vertical-align: top;
   padding: 2px 4px;
   font-weight: bold;
-  width: 10%;           /* narrow the left side of the table to the minimum */
+  width: 10%;           /* narrow the left side of the table to a minimum */
   padding-right :10px;  /* but keep at least 10 points there so it still looks decent */
   white-space: nowrap;
 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/regedt/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: copilot_sdk

## Verification
- OSTranslationReview publish flow applied packet `packet-4d949ccc8f4e` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/regedt/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-regedt-gpt54-high-20260505T211407Z\packets\prompt360k\packets\packet-4d949ccc8f4e\imported\normalized-response.json`.
