### PR TITLE
[translation] Fix src/plugins/splitcbn/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/splitcbn/help/hh/salamander_help_shared.css
+++ b/src/plugins/splitcbn/help/hh/salamander_help_shared.css
@@ -213,7 +213,7 @@
   padding: 2px 4px;
   font-weight: bold;
   width: 10%;           /* shrink the left side of the table to a minimum */
-  padding-right :10px;  /* but leave at least 10 points so it still looks decent */
+  padding-right :10px;  /* but leave at least 10 pixels so it still looks decent */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/splitcbn/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-cae7c59b5b56` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/splitcbn/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-splitcbn-gemini31-20260505T215426Z\packets\prompt120k\packets\packet-cae7c59b5b56\imported\normalized-response.json`.
