### PR TITLE
[translation] Fix src/plugins/uniso/dialogs.cpp comments

### DIFF
--- a/src/plugins/uniso/dialogs.cpp
+++ b/src/plugins/uniso/dialogs.cpp
@@ -71,7 +71,7 @@ CConfigurationDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
 
     case WM_COMMAND:
     {
-        // toggle the 'show boot disk as file' option
+        // enabler for 'show boot disk as file'
         if (HIWORD(wParam) == BN_CLICKED && LOWORD(wParam) == IDC_CFG_SESSIONASDIR)
         {
             BOOL enable = IsDlgButtonChecked(HWindow, IDC_CFG_SESSIONASDIR) == BST_CHECKED;


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-dea15c3b67df` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/uniso/dialogs.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-uniso-gemini31-20260505T222954Z\packets\prompt120k\packets\packet-dea15c3b67df\imported\normalized-response.json`.
