### PR TITLE
[translation] Fix src/plugins/uniso/hfs.cpp comments

### DIFF
--- a/src/plugins/uniso/hfs.cpp
+++ b/src/plugins/uniso/hfs.cpp
@@ -395,7 +395,7 @@ BOOL CHFS::ListDirectory(char* rootPath, int session,
                     pFolders[nFolders++] = fi;
                     continue;
                 }
-                // AddDir failed (path too long?)
+                // AddDir failed (path too long?) -> continue
                 free(fi);
                 Error(IDS_ERR_TOO_LONG_PATH, FALSE);
             }

--- a/src/plugins/uniso/hfs.cpp
+++ b/src/plugins/uniso/hfs.cpp
@@ -567,7 +567,7 @@ int CHFS::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
         if (!bFileComplete)
         {
             // because it was created with the read-only attribute, we must clear
-            // the read-only attribute so the file can be deleted
+            // it so the file can be deleted
             attrs &= ~FILE_ATTRIBUTE_READONLY;
             if (!SetFileAttributes(name, attrs))
                 Error(LoadStr(IDS_CANT_SET_ATTRS), GetLastError());


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/hfs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-252daf037701` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/uniso/hfs.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-uniso-gemini31-20260505T222954Z\packets\prompt120k\packets\packet-252daf037701\imported\normalized-response.json`.
