### PR TITLE
[translation] Fix src/plugins/uniso/udf.cpp comments

### DIFF
--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -1181,7 +1181,7 @@ int CUDF::UnpackFile(CSalamanderForOperationsAbstract* salamander, const char* s
                 // picb->Offset is nonzero only for small (less than a sector) files inlined within File Entry
                 if (!file.Write(sector + picb->Offset, nbytes, &written, name, NULL))
                 {
-                    // The error message was already displayed.
+// The error message was already displayed by SafeWriteFile().
                     ret = UNPACK_CANCEL;
                     bFileComplete = FALSE;
                     break;

--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -513,7 +513,7 @@ int CUDF::ReadFileEntry(Uint8* data, bool bEFE, Uint16 part, CICBTag* icbTag, CU
                 ad->Length = l_ad;
                 ad->Location = 0; // To be determined by the caller
                 ad->Partition = part;
-                return -1; // -1 tells the caller that Location is not set yet
+                return -1; // -1 tells the caller the data is inlined, but Location is not set
             }
         }
         else


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/uniso/udf.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-360c71415188` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/uniso/udf.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-uniso-gemini31-20260505T222954Z\packets\prompt120k\packets\packet-360c71415188\imported\normalized-response.json`.
