### PR TITLE
[translation] Fix src/plugins/unlha/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/unlha/help/hh/salamander_help_shared.css
+++ b/src/plugins/unlha/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
+/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
-/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page
@@ -323,4 +323,3 @@
   padding-left: 4px;
   text-align: left;
 }
-

--- a/src/plugins/unlha/help/hh/salamander_help_shared.css
+++ b/src/plugins/unlha/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
+/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page
@@ -214,7 +214,7 @@
   padding: 2px 4px;
   font-weight: bold;
   width: 10%;           /* narrow the left side of the table to the minimum */
-  padding-right :10px;  /* but keep at least 10 points there so it still looks decent */
+  padding-right :10px;  /* but keep at least 10 pixels there so it still looks decent */
   white-space: nowrap;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unlha/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 3 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-58f4db72cc5e` with 3 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/unlha/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 3.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-unlha-gemini31-20260505T225953Z\packets\prompt120k\packets\packet-58f4db72cc5e\imported\normalized-response.json`.
