### PR TITLE
[translation] Fix src/plugins/unmime/parser.cpp comments

### DIFF
--- a/src/plugins/unmime/parser.cpp
+++ b/src/plugins/unmime/parser.cpp
@@ -1355,7 +1355,7 @@ BOOL ParseMailFile(LPCTSTR pszFileName, CParserOutput* pOutput, BOOL bAppendChar
                     goback = TRUE;
                 }
                 else // Handling the previous multipart case
-                {    // the previous multipart was not properly terminated, but we are at a boundary
+                {    // was not properly terminated, but we are at a boundary
                     int i;
                     for (i = STACKTOP - 1; i >= 0; i--) // one of the previous ones.
                         if (IsBoundary(cBoundaries[i], &bEnd2))


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/unmime/parser.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-271a3672f41d` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/unmime/parser.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-unmime-gemini31-20260505T230542Z\packets\prompt120k\packets\packet-271a3672f41d\imported\normalized-response.json`.
