### PR TITLE
[translation] Fix src/plugins/winscp/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/winscp/help/hh/salamander_help_shared.css
+++ b/src/plugins/winscp/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
+/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/winscp/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-d1bc0c19b73e` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/winscp/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-winscp-gemini31-20260505T233342Z\packets\prompt120k\packets\packet-d1bc0c19b73e\imported\normalized-response.json`.
