### PR TITLE
[translation] Fix src/plugins/wmobile/fs1.cpp comments

### DIFF
--- a/src/plugins/wmobile/fs1.cpp
+++ b/src/plugins/wmobile/fs1.cpp
@@ -77,7 +77,7 @@ CPluginInterfaceForFS::ChangeDriveMenuItemContextMenu(HWND parent, int panel, in
 {
     CALL_STACK_MESSAGE7("CPluginInterfaceForFS::ChangeDriveMenuItemContextMenu(, %d, %d, %d, , %s, %d, %d, , , ,)",
                         panel, x, y, pluginFSName, pluginFSNameIndex, isDetachedFS);
-    // The Windows Mobile plugin has no context Change Drive menu
+    // The Windows Mobile plugin has no Change Drive context menu
     return FALSE;
 }
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/fs1.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-c287a362b027` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/wmobile/fs1.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-wmobile-gemini31-20260505T234121Z\packets\prompt120k\packets\packet-c287a362b027\imported\normalized-response.json`.
