### PR TITLE
[translation] Fix src/plugins/wmobile/fs2.cpp comments

### DIFF
--- a/src/plugins/wmobile/fs2.cpp
+++ b/src/plugins/wmobile/fs2.cpp
@@ -1537,7 +1537,7 @@ CPluginFSInterface::CopyOrMoveFromFS(BOOL copy, int mode, const char* fsName, HW
                 userPart = secondPart;
                 if ((userPart - targetPath) - 1 == (int)strlen(fsName) &&
                     SalamanderGeneral->StrNICmp(targetPath, fsName, (int)(userPart - targetPath) - 1) == 0)
-                { // different FS, report only "not supported"
+                { // it is CEFS
                     diskPath = FALSE;
                     ok = TRUE;
                 }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/wmobile/fs2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-6e8e46cc5e77` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/wmobile/fs2.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-wmobile-gemini31-20260505T234121Z\packets\prompt120k\packets\packet-6e8e46cc5e77\imported\normalized-response.json`.
