### PR TITLE
[translation] Fix src/plugins/zip/crypt.cpp comments

### DIFF
--- a/src/plugins/zip/crypt.cpp
+++ b/src/plugins/zip/crypt.cpp
@@ -49,7 +49,7 @@ __forceinline int update_keys(int c, __UINT32* keys)
     return c;
 }
 
-// Initialize the encryption keys from
+// Initialize the encryption keys and the random header according to
 // the given password.
 void init_keys(const char* password, __UINT32* keys)
 {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/crypt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-08bde330fd40` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/zip/crypt.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-zip-gemini31-20260506T000700Z\packets\prompt120k\packets\packet-08bde330fd40\imported\normalized-response.json`.
