### PR TITLE
[translation] Fix src/plugins/zip/zip2sfx/zip2sfx2.cpp comments

### DIFF
--- a/src/plugins/zip/zip2sfx/zip2sfx2.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx2.cpp
@@ -117,7 +117,7 @@ BOOL WriteSFXHeader()
     offs += (sdr - sdl) + 1;
     if (td == SE_REGVALUE)
     {
-        offs += sizeof(LONG); // prepend the HKEY value; even the 64-bit build stores only a 32-bit key for known roots (e.g. HKEY_CURRENT_USER)
+        offs += sizeof(LONG); // prepend the HKEY value; even the 64-bit build stores only a 32-bit key; known roots (e.g. HKEY_CURRENT_USER) are defined as 32-bit IDs
         const char* bs = StrNChr(sdl, sdr - sdl, '\\');
         if (!bs)
             offs += 1; // add a separator character between the subkey and value


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/zip2sfx/zip2sfx2.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-49ffbb11c962` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/zip/zip2sfx/zip2sfx2.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-zip-subtools-gemini31-20260506T004132Z\packets\prompt120k\packets\packet-49ffbb11c962\imported\normalized-response.json`.
