### PR TITLE
[translation] Fix src/plugins/zip/zip2sfx/inflate.cpp comments

### DIFF
--- a/src/plugins/zip/zip2sfx/inflate.cpp
+++ b/src/plugins/zip/zip2sfx/inflate.cpp
@@ -473,7 +473,7 @@ int inflate_stored()
         return 1; // error in compressed data
     DUMPBITS(16)
 
-    ///* old copy routine; the new one should be faster
+    // old copy routine; the new one should be faster
     // read and output the uncompressed data
     while (n--)
     {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/zip/zip2sfx/inflate.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-6f035bb95494` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/zip/zip2sfx/inflate.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-zip-subtools-gemini31-20260506T004132Z\packets\prompt120k\packets\packet-6f035bb95494\imported\normalized-response.json`.
