### PR TITLE
[translation] Fix src/salmon/dialogs.cpp comments

### DIFF
--- a/src/salmon/dialogs.cpp
+++ b/src/salmon/dialogs.cpp
@@ -358,7 +358,7 @@ CMainDialog::DialogProc(UINT uMsg, WPARAM wParam, LPARAM lParam)
     {
         // the monitored process grants us permission to call SetForegroundWindow.
         // The crucial detail is to invoke it only once our message loop is already running;
-        // otherwise Windows behaves poorly (until we call SetForegroundWindow from OpenMainDialog).
+        // otherwise Windows behaves poorly (when we called SetForegroundWindow from OpenMainDialog).
         // When the monitored application was launched from the Start Menu and crashed, we stayed in the background,
         // the ProtMon window remained inactive, and it did not receive focus until the monitored application
         // closed its window.


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salmon/dialogs.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-3d5614b6354b` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/salmon/dialogs.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-salmon-gemini31-20260506T010733Z\packets\prompt120k\packets\packet-3d5614b6354b\imported\normalized-response.json`.
