### PR TITLE
[translation] Fix src/salmon/salmon.cpp comments

### DIFF
--- a/src/salmon/salmon.cpp
+++ b/src/salmon/salmon.cpp
@@ -1037,7 +1037,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, int cmdShow
             // the parent process has terminated, so we exit as well
 
             // if we find any dumps, process them - Salamander could have crashed during init while loading
-            // shell extensions and did not manage to open the main window and call CheckForBugs
+            // shell extensions and did not manage to open the main window and call ChechForBugs
             // or Salamander crashed before the exception handler was installed and the minidump was captured by WER,
             // which we have redirected to our bug report directory (Vista+)
             // Salamander could also have crashed in a way that bypassed the exception handler (typically caused by faulty shell extensions)
@@ -1053,7 +1053,7 @@ WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR cmdLine, int cmdShow
             if (LoadHLanguageVerbose(slgName)) // we need to display the GUI, we must load the SLG
             {
                 // if we manage to lock the mutex, release it later; we do not want
-                // additional processes started afterwards to pop up their windows during ours
+                // additional processes started afterwards to pop up their windows during our window
                 BOOL leave = MainDialogMutex.Enter();
                 OpenMainDialog(TRUE);
                 if (leave)


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/salmon/salmon.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-033a209dfa69` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/salmon/salmon.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-salmon-gemini31-20260506T010733Z\packets\prompt120k\packets\packet-033a209dfa69\imported\normalized-response.json`.
