### PR TITLE
[translation] Fix src/setup/doinst.c comments

### DIFF
--- a/src/setup/doinst.c
+++ b/src/setup/doinst.c
@@ -576,8 +576,8 @@ BOOL QueryRetry(const char* sFileName, DWORD error, int* result)
 //
 
 // copies the file from sFileName into tFileName
-// if the target file already exists, the overwrite variable is set
-// and skip; if the overwrite variable is set, it does not ask about overwriting
+// if the target file already exists, the overwrite and skip variables are
+// checked; if the overwrite variable is set, it does not ask about overwriting
 // if the skip variable is set, the file is skipped
 // on error returns FALSE - options then have no meaning
 // on successful completion returns TRUE and the options variable


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/setup/doinst.c`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-64c0cfb4d951` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/setup/doinst.c`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-setup-gemini31-20260506T012449Z\packets\prompt120k\packets\packet-64c0cfb4d951\imported\normalized-response.json`.
