### PR TITLE
[translation] Fix src/setup/setup.rc comments

### DIFF
--- a/src/setup/setup.rc
+++ b/src/setup/setup.rc
@@ -514,7 +514,7 @@ BEGIN
     LTEXT           "Wählen Sie, wo Sie die Programm-Verknüpfung installieren möchten:",-1,20,50,244,8
     CONTROL         "&Desktop",IDC_SPF_DESKTOP,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,29,61,50,12
     CONTROL         "&Startmenü",IDC_SPF_LINK,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,29,73,63,12
-    //CONTROL         "An &Taskleiste anheften", IDC_SPF_PINTOTASKBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,29,85,87,12 // disabled option kept for reference
+    //CONTROL         "&Pin to Taskbar", IDC_SPF_PINTOTASKBAR,"Button",BS_AUTOCHECKBOX | WS_TABSTOP,29,85,87,12 // disabled option kept for reference
     LTEXT           "Installiere Verknüpfungen für:",IDC_SPF_FOLDERS,19,111,197,8
     CONTROL         "&Aktuellen Benutzer",IDC_SPF_PERSONAL,"Button",BS_AUTORADIOBUTTON | WS_GROUP | WS_TABSTOP,29,122,89,12
     CONTROL         "A&lle Benutzer",IDC_SPF_COMMON,"Button",BS_AUTORADIOBUTTON | WS_TABSTOP,29,134,70,12


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/setup/setup.rc`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-6659a657e381` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/setup/setup.rc`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-setup-gemini31-20260506T012449Z\packets\prompt120k\packets\packet-6659a657e381\imported\normalized-response.json`.
