### PR TITLE
[translation] Fix src/translator/datadlg.cpp comments

### DIFF
--- a/src/translator/datadlg.cpp
+++ b/src/translator/datadlg.cpp
@@ -1741,7 +1741,6 @@ BOOL CDialogData::GetFooterSeparatorAndButtons(TDirectArray<DWORD>* footer)
 
     // measure the distances between buttons; in some dialogs the bottom row of buttons
     // is split into two parts (one left aligned, one right aligned) - we do not tidy that automatically
-    // we do not tidy it automatically
     BOOL spacingIsOK = TRUE;
     if (indexes.Count > 2)
     {


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/translator/datadlg.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-8221b4e2201c` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/translator/datadlg.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-translator-gemini31-20260506T014450Z\packets\prompt120k\packets\packet-8221b4e2201c\imported\normalized-response.json`.
