### PR TITLE
[translation] Fix src/translator/datasel.cpp comments

### DIFF
--- a/src/translator/datasel.cpp
+++ b/src/translator/datasel.cpp
@@ -455,7 +455,7 @@ void CDialogData::SelCtrlsAlignTo(const CAlignToParams* params)
         if (!control->Selected)
             continue;
 
-        // when moving controls individually, keep their position
+        // when moving selected controls individually, retrieve their position
         if (!params->MoveAsGroup)
             control->GetTRect(&selR, FALSE);
 


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/translator/datasel.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-52a31d45c533` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/translator/datasel.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-translator-gemini31-20260506T014450Z\packets\prompt120k\packets\packet-52a31d45c533\imported\normalized-response.json`.
