### PR TITLE
[translation] Fix src/translator/trldata.h comments

### DIFF
--- a/src/translator/trldata.h
+++ b/src/translator/trldata.h
@@ -291,7 +291,7 @@ enum CTransformationEnum
     eloSelect,              // [] Modify the current selection.
     eloMove,                // [deltaX, deltaY] Move the control by the given offsets.
     eloResize,              // [edge, delta] Resize the control; 'edge' selects the side, 'delta' is the amount in dialog units.
-    eloResizeDlg,           // [horizontal, delta] Resize the dialog; when 'horizontal' is TRUE adjust the width, otherwise the height.
+    eloResizeDlg,           // [horizontal, delta] Resize the dialog; when 'horizontal' is TRUE adjust the width, otherwise the height; 'delta' is the amount in dialog units.
     eloResizeControls,      // [resize] Resize command adjusts control width or height according to 'resize'.
     eloSizeToContent,       // [] Size to Content command.
     eloSetSize,             // [width, height] Set explicit control size; -1 keeps the current dimension.


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/translator/trldata.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-fb4fc89ca718` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/translator/trldata.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-translator-gemini31-20260506T014450Z\packets\prompt120k\packets\packet-fb4fc89ca718\imported\normalized-response.json`.
