### PR TITLE
[translation] Fix src/translator/wndframe.cpp comments

### DIFF
--- a/src/translator/wndframe.cpp
+++ b/src/translator/wndframe.cpp
@@ -362,7 +362,7 @@ BOOL CFrameWindow::OpenProject(const char* importSubPath)
                 QuietTranslate && (OutWindow.GetInfoLines() == 1 || completelyUntranslated)) // nothing to translate (the only info line is the header) or no text translated at all—report via exit code
             {
                 DestroyWindow(HWindow);
-                ExitProcess(QuietTranslate && completelyUntranslated ? 0 : 1); // terminate immediately to avoid showing the main window; exit code 1 means validation succeeded
+                ExitProcess(QuietTranslate && completelyUntranslated ? 0 : 1); // terminate immediately to avoid showing the main window and other unwanted things; exit code 1 means validation succeeded
             }
         }
 
@@ -374,7 +374,7 @@ BOOL CFrameWindow::OpenProject(const char* importSubPath)
             if (!dirty || Data.Save() && Data.SaveProject())
             {
                 DestroyWindow(HWindow);
-                ExitProcess(dirty ? 0 : 1); // terminate immediately; exit code 0 = changes saved, 1 = no changes detected
+                ExitProcess(dirty ? 0 : 1); // terminate immediately to avoid showing the main window and other unwanted things; exit code 0 = changes saved, 1 = no changes detected
             }
         }
 
@@ -405,7 +405,7 @@ BOOL CFrameWindow::OpenProject(const char* importSubPath)
                 if (Data.Save() && Data.SaveProject())
                 {
                     DestroyWindow(HWindow);
-                    ExitProcess(1); // terminate immediately to avoid flashing the main window; exit code 1 indicates success
+                    ExitProcess(1); // terminate immediately to avoid flashing the main window and other unwanted things; exit code 1 indicates success
                 }
             }
         }
@@ -459,7 +459,7 @@ BOOL CFrameWindow::OpenProject(const char* importSubPath)
                     if (Data.Save() && Data.SaveProject())
                     {
                         DestroyWindow(HWindow);
-                        ExitProcess(1); // exit immediately to avoid showing the main window; exit code 1 means validation succeeded
+                        ExitProcess(1); // exit immediately to avoid showing the main window and other unwanted things; exit code 1 means validation succeeded
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/translator/wndframe.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 4 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-d21a1cb12145` with 4 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/translator/wndframe.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 4.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-translator-gemini31-20260506T014450Z\packets\prompt120k\packets\packet-d21a1cb12145\imported\normalized-response.json`.
