### PR TITLE
[translation] Fix src/plugins/shared/spl_base.h comments

### DIFF
--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -298,8 +298,7 @@ public:
     // 'state_or'+'state_and' parameters have no meaning in that case); 'hotKey' is the item's hot key
     // obtained with the SALHOTKEY macro; 'name' may contain a hot-key hint,
     // separated by '\t'; in that case the 'hotKey' variable must be assigned the
-    // SALHOTKEY_HINT, for more details see the comment for SALHOTKEY_HINT; 'id' is the unique
-    // identifier
+    // SALHOTKEY_HINT, for more details see the comment for SALHOTKEY_HINT; 'id' is the
     // item's unique identifier within the plugin (for a separator it matters only if 'callGetState' is TRUE),
     // if 'callGetState' is TRUE, the item state is obtained by calling
     // CPluginInterfaceForMenuExtAbstract::GetMenuItemState (for separators, only the

--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -484,7 +484,7 @@ public:
     // anything
     // (do not open any windows)
     // WARNING!!! All plugin threads must be terminated (if Release returns TRUE, Salamander calls
-    // FreeLibrary is called on the plugin .SPL, so the plugin code is unmapped from memory and the threads
+    // FreeLibrary on the plugin .SPL, so the plugin code is unmapped from memory and the threads
     // have nothing left to run; usually neither a bug report nor Windows exception info is generated)
     virtual BOOL WINAPI Release(HWND parent, BOOL force) = 0;
 

--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -324,7 +324,7 @@ public:
     // if 'callGetState' is TRUE, the submenu state is obtained by calling
     // CPluginInterfaceForMenuExtAbstract::GetMenuItemState (only the
     // MENU_ITEM_STATE_ENABLED and MENU_ITEM_STATE_HIDDEN states matter; the others are ignored), otherwise
-    // the item state (enabled/disabled) is computed from 'state_or'+'state_and' - for the state calculation
+    // the item state (enabled/disabled) is computed from 'state_or'+'state_and' -
     // for the item state calculation, see CSalamanderConnectAbstract::AddMenuItem(); the
     // 'skillLevel' parameter
     // specifies for which user levels the submenu is displayed; the value contains one or more


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_base.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-1fe77e00e99b` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/spl_base.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-shared-gemini31-20260506T030620Z\packets\prompt160k\packets\packet-1fe77e00e99b\imported\normalized-response.json`.
