### PR TITLE
[translation] Fix src/plugins/shared/spl_fs.h comments

### DIFF
--- a/src/plugins/shared/spl_fs.h
+++ b/src/plugins/shared/spl_fs.h
@@ -312,20 +312,20 @@ public:
     // 'path' is an in/out buffer containing the path (the buffer size is 'pathBufSize')
     virtual void WINAPI CompleteDirectoryLineHotPath(char* path, int pathBufSize) = 0;
 
-    // loads files and directories from the current path and stores them in the 'dir' object (for path NULL or
-    // "", files and directories on other paths are ignored; if a directory named
-    // ".." is added, it is drawn as the "up-dir" symbol; file and directory names are fully
-    // determined by the plugin, Salamander only displays them); Salamander obtains the contents of
-    // plugin-added columns through the 'pluginData' interface (if the plugin does not add columns
-    // and has no custom icons, it returns 'pluginData'==NULL); in 'iconsType' it returns the requested method
-    // of obtaining file and directory icons for the panel; pitFromPlugin degrades to pitSimple if
-    // 'pluginData' is NULL (without 'pluginData', pitFromPlugin cannot be provided); if 'forceRefresh' is
-    // TRUE, this is a hard refresh (Ctrl+R) and the plugin should load files and directories without using
-    // the cache; returns TRUE if loading succeeds; if it returns FALSE, an error occurred and ChangePath
-    // will be called on the current path; ChangePath is expected to select an accessible subpath
-    // or return FALSE; after a successful call to ChangePath, ListCurrentPath will be called again;
-    // if it returns FALSE, the return value 'pluginData' is ignored (the data in 'dir' must be
-    // released using 'dir.Clear(pluginData)', otherwise only the Salamander part of the data is released);
+    // Only if GetSupportedServices() returns FS_SERVICE_GETPATHFORMAINWNDTITLE:
+    // obtains the text to be displayed in the main window title if current path display
+    // in the main window title is enabled (see Configuration/Appearance/Display current
+    // path...); 'fsName' is the current FS name; if 'mode' is 1, it is the
+    // "Directory Name Only" mode (only the name of the current directory should be displayed - the last
+    // component of the path); if 'mode' is 2, it is the "Shortened Path" mode (a
+    // shortened form of the path should be displayed - root (including path separator) + "..." + path
+    // separator + the last path component); 'buf' is a buffer of size 'bufSize' for the
+    // resulting text; returns TRUE if it returns the requested text; returns FALSE if the
+    // text should be created based on separator point data obtained via the
+    // GetNextDirectoryLineHotPath() method.
+    // NOTE: if GetSupportedServices() does not return FS_SERVICE_GETPATHFORMAINWNDTITLE,
+    //       the full path on the FS is displayed in the main window title in all title display
+    //       modes (even in "Directory Name Only" and "Shortened Path").
     virtual BOOL WINAPI GetPathForMainWindowTitle(const char* fsName, int mode, char* buf, int bufSize) = 0;
 
     // Only if GetSupportedServices() returns FS_SERVICE_SHOWINFO:


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_fs.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-9968689d602a` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/spl_fs.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-shared-gemini31-20260506T030620Z\packets\prompt160k\packets\packet-9968689d602a\imported\normalized-response.json`.
