### PR TITLE
[translation] Fix src/plugins/shared/spl_view.h comments

### DIFF
--- a/src/plugins/shared/spl_view.h
+++ b/src/plugins/shared/spl_view.h
@@ -38,7 +38,7 @@ public:
 
     // Called when the viewer is requested to open and load file
     // 'name'; 'left'+'top'+'width'+'height'+'showCmd'+'alwaysOnTop' is the recommended window placement;
-    // window; if 'returnLock' is FALSE, 'lock'+'lockOwner' have no meaning; if 'returnLock' is
+    // if 'returnLock' is FALSE, 'lock'+'lockOwner' have no meaning; if 'returnLock' is
     // TRUE, the viewer should return system event 'lock' in the nonsignaled state; 'lock'
     // becomes signaled when viewing file 'name' ends (the file is removed from the temporary
     // directory at that moment); it should also return TRUE in 'lockOwner' if the 'lock' object is to be closed


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/spl_view.h`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 1 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-6eaa4493f7c8` with 1 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/spl_view.h`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 1.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-shared-gemini31-20260506T030620Z\packets\prompt160k\packets\packet-6eaa4493f7c8\imported\normalized-response.json`.
