### PR TITLE
[translation] Fix src/plugins/shared/winliblt.cpp comments

### DIFF
--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -1100,7 +1100,7 @@ void CTransferInfo::EditLine(int ctrlID, double& value, char* format, BOOL selec
             BOOL decPoints = FALSE;
             BOOL expPart = FALSE;
             if (*s == '-' || *s == '+')
-                s++;        // skip a digit
+                s++;        // skip the sign
             while (*s != 0) // convert comma to period
             {
                 if (!expPart && !decPoints && (*s == ',' || *s == '.'))
@@ -1162,7 +1162,7 @@ void CTransferInfo::EditLine(int ctrlID, int& value, BOOL select)
 
             char* s = buff;
             if (*s == '-' || *s == '+')
-                s++;        // skip a digit
+                s++;        // skip the sign
             while (*s != 0) // validate the number
             {
                 if (*s < '0' || *s > '9')


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/shared/winliblt.cpp`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-e88966302358` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/shared/winliblt.cpp`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\plugins-shared-gemini31-20260506T030620Z\packets\prompt160k\packets\packet-e88966302358\imported\normalized-response.json`.
