### PR TITLE
[translation] Fix src/plugins/undelete/help/hh/salamander_help_shared.css comments

### DIFF
--- a/src/plugins/undelete/help/hh/salamander_help_shared.css
+++ b/src/plugins/undelete/help/hh/salamander_help_shared.css
@@ -1,5 +1,5 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
+/* Shared part used for both CHM and WEB */
 /* Shared part used for both CHM and WEB */
 
 #help_page


### PR DESCRIPTION
## Summary
- Refines translated comments in `src/plugins/undelete/help/hh/salamander_help_shared.css`.
- Keeps the change comment-only; no executable code was modified.
- Tightens the approved wording across 2 changed comment hunk(s) in the final diff.

## Model
Model: gemini

## Verification
- OSTranslationReview publish flow applied packet `packet-e1a2a1f32db2` with 2 validated rewrite(s).
- Comment-only guard passed for 1 changed file(s): `src/plugins/undelete/help/hh/salamander_help_shared.css`.
- `git diff --check` completed before commit in non-dry-run mode.
- Inline review comments prepared: 2.

## Telemetry
- PR publication is script-based and made 0 LLM requests.
- Normalized response: `D:\Source\OSTranslationReview\.local\provider-eval\src-audit-gaps-gemini31-20260506T043021Z\packets\prompt120k\packets\packet-e1a2a1f32db2\imported\normalized-response.json`.
