### PR TITLE
Revert incorrect translation comment swap from #1353

### DIFF
--- a/src/plugins/ftp/ftp2.cpp
+++ b/src/plugins/ftp/ftp2.cpp
@@ -316,8 +316,8 @@ BOOL CSrvTypeColumn::SaveToStr(char* buf, int bufSize, BOOL ignoreColWidths)
                SaveStrLen(DescrStr) + 1 +    // DescrStr
                3 +                           // Type
                SaveStrLen(EmptyValue) + 1 +  // EmptyValue
-               2 +                           // FixedWidth
                2 +                           // LeftAlignment
+               2 +                           // FixedWidth
                (int)strlen(strWidth);        // Width
     if (bufSize >= size + 1)
     {


### PR DESCRIPTION
Reverts squash merge ebab8c07 from #1353. The PR swapped the comments for LeftAlignment and FixedWidth in src/plugins/ftp/ftp2.cpp, but the serialization code writes LeftAlignment before FixedWidth.