### PR TITLE
Fix translated comment wording

### DIFF
--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -2936,7 +2936,7 @@ BOOL CDrivesList::OnContextMenu(BOOL posByMouse, int itemIndex, int panel, const
 
     // commented out so that we can disconnect a network drive that is not accessible at the moment (longer waiting is tolerated)
     //  if (Drives->At(selectedIndex).DriveType == drvtRemote &&
-    //      Drives->At(selectedIndex).Accessible &&   // we will allow to disconnect unaccessible network drives, we verify the others
+    //      Drives->At(selectedIndex).Accessible &&   // we will allow to disconnect inaccessible network drives, we verify the others
     //      MainWindow->GetActivePanel()->CheckPath(TRUE, path) != ERROR_SUCCESS) return FALSE;
 
     //  MainWindow->ReleaseMenuNew();  // windows weren't built for more context menus

--- a/src/inflate.cpp
+++ b/src/inflate.cpp
@@ -33,7 +33,7 @@
    There are (currently) three kinds of inflate blocks: stored, fixed, and
    dynamic.  The compressor outputs a chunk of data at a time and decides
    which method to use on a chunk-by-chunk basis.  A chunk might typically
-   be 32K to 64K, uncompressed.  If the chunk is uncompressible, then the
+   be 32K to 64K, uncompressed.  If the chunk is incompressible, then the
    "stored" method is used.  In this case, the bytes are simply stored as
    is, eight bits per byte, with none of the above coding.  The bytes are
    preceded by a count, since there is no longer an EOB code.

--- a/src/plugins/automation/guiform.cpp
+++ b/src/plugins/automation/guiform.cpp
@@ -469,7 +469,7 @@ LRESULT CSalamanderGuiForm::WndProc(
             }
             else if (LOWORD(wParam) == IDOK)
             {
-                // This is command synthetized by the
+                // This command is synthesized by the
                 // dialog manager in reaction to the
                 // Enter key when there is no button.
             }
@@ -515,7 +515,7 @@ void CSalamanderGuiForm::InternalAddComponent(
     _ASSERTE(bounds.cy >= 0);
 
     // Calculate automatic position of the component.
-    // Put component bellow the previous by default and put
+    // Put the component below the previous one by default and put
     // some spacing between them.
     int yspacing = 0;
     if (pPrevComponent != NULL)

--- a/src/plugins/filecomp/dlg_com.h
+++ b/src/plugins/filecomp/dlg_com.h
@@ -22,7 +22,7 @@ enum
     WN_CBINIT_FINISHED,      // the combo box was initialized successfully
     WN_CALCULATING_DETAILS,  // detailed differences are being computed
     WN_COMPARE_FINISHED,     // comparison finishes
-    WN_GET_CHANGESCOMBO,     // queries HWND of the Change combobox
+    WN_GET_CHANGESCOMBO,     // queries HWND of the Change combo box
     WN_SET_PROGRESS,         // sets progress MAKELPARAM(percent, changesCnt)
     WN_ADD_CHANGE            // registers a change in binary comparison
 };

--- a/src/plugins/ftp/ftp.rh2
+++ b/src/plugins/ftp/ftp.rh2
@@ -62,7 +62,7 @@
 #define IDM_RESUMETESTFAILEDONRETRY 1117
 // menu on button Use Binary Mode in ASCII Transfer Mode is Set for File with Binary Content dialog (see Solve Error button in operation dialog)
 #define IDM_ASCIITRFORBINFILE  1118
-// menu on Add button in FTP Configuration > General (Proxy Server combobox)
+// menu on Add button in FTP Configuration > General (Proxy Server combo box)
 #define IDM_ADDPROXYSERVER     1119
 // menu in Proxy Server dialog, in Script editbox
 #define IDM_PRXSRVSCRIPTMENU   1120

--- a/src/plugins/ftp/help/hh/ftp/dlgboxes_chattrs.htm
+++ b/src/plugins/ftp/help/hh/ftp/dlgboxes_chattrs.htm
@@ -38,7 +38,7 @@ some rights (e.g. only read for the owner) in this way.
 
 <dt><i>Include subdirectories</i></dt>
 <dd>When checked, it will process also files and directories in selected subdirectories.
-Otherwise it will process only selected subdirectories (without content).
+Otherwise, it will process only selected subdirectories (without content).
 </dd>
 
 <dt><i>Change attributes of files</i></dt>

--- a/src/plugins/nethood/cache.h
+++ b/src/plugins/nethood/cache.h
@@ -1357,7 +1357,7 @@ private:
     ///         the system defined error code.
     DWORD EnumNetworkShortcuts();
 
-    /// Enumerates volumes attached trough Terminal Service client.
+    /// Enumerates volumes attached through Terminal Service client.
     DWORD EnumTSClientVolumes();
 
     /// Reads shortcut target and inserts it as a child of the node

--- a/src/plugins/nethood/icons.h
+++ b/src/plugins/nethood/icons.h
@@ -106,7 +106,7 @@ private:
     // from the IconPro application and the 'Icons in Win32' article
     // (http://msdn.microsoft.com/en-us/library/ms997538.aspx).
     // These first two structs represent how the icon information is stored
-    // when it is bound into a EXE or DLL file. Structure members are WORD
+    // when it is bound into an EXE or DLL file. Structure members are WORD
     // aligned and the last member of the structure is the ID instead of
     // the imageoffset.
 #pragma pack(push)

--- a/src/plugins/peviewer/pefile.cpp
+++ b/src/plugins/peviewer/pefile.cpp
@@ -112,7 +112,7 @@ BOOL CPEFile::ImageDirectoryOffset(DWORD dwIMAGE_DIRECTORY,
 
     if (!b64Bit)
     {
-        /* must be 0 thru (NumberOfRvaAndSizes-1) */
+        /* must be 0 through (NumberOfRvaAndSizes-1) */
         if (dwIMAGE_DIRECTORY >= poh->NumberOfRvaAndSizes)
             return FALSE;
 
@@ -123,7 +123,7 @@ BOOL CPEFile::ImageDirectoryOffset(DWORD dwIMAGE_DIRECTORY,
     {
         PIMAGE_OPTIONAL_HEADER64 poh64 = (PIMAGE_OPTIONAL_HEADER64)poh;
 
-        /* must be 0 thru (NumberOfRvaAndSizes-1) */
+        /* must be 0 through (NumberOfRvaAndSizes-1) */
         if (dwIMAGE_DIRECTORY >= poh64->NumberOfRvaAndSizes)
             return FALSE;
 

--- a/src/plugins/regedt/finddlg.cpp
+++ b/src/plugins/regedt/finddlg.cpp
@@ -1017,7 +1017,7 @@ CComboboxEdit::GetSel(DWORD *start, DWORD *end)
 void
 CComboboxEdit::ReplaceText(const char *text)
 {
-  // we have to revive the selection because the dumb combobox forgot it
+  // we have to revive the selection because the dumb combo box forgot it
   SendMessage(HWindow, EM_SETSEL, SelStart, SelEnd);
   SendMessage(HWindow, EM_REPLACESEL, TRUE, (LPARAM)text);
 }

--- a/src/plugins/renamer/dialogs.cpp
+++ b/src/plugins/renamer/dialogs.cpp
@@ -459,7 +459,7 @@ void CComboboxEdit::SetSel(DWORD start, DWORD end)
 void CComboboxEdit::ReplaceText(const char* text)
 {
     CALL_STACK_MESSAGE_NONE
-    // we must refresh the selection because the dumb combobox forgot it
+    // we must refresh the selection because the dumb combo box forgot it
     SendMessage(HWindow, EM_SETSEL, SelStart, SelEnd);
     SendMessage(HWindow, EM_REPLACESEL, TRUE, (LPARAM)text);
 }

--- a/src/plugins/renamer/dialogs.h
+++ b/src/plugins/renamer/dialogs.h
@@ -57,7 +57,7 @@ void TransferCombo(CTransferInfo& ti, int id, int* comboContent, int& value);
 //
 // CComboboxEdit
 //
-// Because the combobox is cleared, the classic method (CB_GETEDITSEL) cannot determine
+// Because the combo box is cleared, the classic method (CB_GETEDITSEL) cannot determine
 // what the selection was after focus is lost. This control solves it.
 //
 

--- a/src/plugins/shared/lukas/counter.h
+++ b/src/plugins/shared/lukas/counter.h
@@ -6,7 +6,7 @@
 
 // ****************************************************************************
 //
-// CCounter -- hight precision counter for performance metering
+// CCounter -- high precision counter for performance metering
 
 class CCounter
 {

--- a/src/plugins/unarj/unarj.h
+++ b/src/plugins/unarj/unarj.h
@@ -74,7 +74,7 @@ typedef unsigned long ulong;   /* 32 bits or more */
 /* Structure of archive main header (low order byte first):
 /*
 /*  2  header id (comment and local file) = 0x60, 0xEA
-/*  2  basic header size (from 'first_hdr_size' thru 'comment' below)
+/*  2  basic header size (from 'first_hdr_size' through 'comment' below)
 /*	     = first_hdr_size + strlen(filename) + 1 + strlen(comment) + 1
 /*	     = 0 if end of archive
 /*
@@ -114,7 +114,7 @@ typedef unsigned long ulong;   /* 32 bits or more */
 /* Structure of archive file header (low order byte first):
 /*
 /*  2  header id (comment and local file) = 0x60, 0xEA
-/*  2  basic header size (from 'first_hdr_size' thru 'comment' below)
+/*  2  basic header size (from 'first_hdr_size' through 'comment' below)
 /*	     = first_hdr_size + strlen(filename) + 1 + strlen(comment) + 1
 /*	     = 0 if end of archive
 /*

--- a/src/plugins/undelete/library/os.h
+++ b/src/plugins/undelete/library/os.h
@@ -508,10 +508,10 @@ typedef struct _DOSDPB
 
 //  GetDriveFormFactor returns the drive form factor.
 //
-//  It returns 350 if the drive is a 3.5" floppy drive.
-//  It returns 525 if the drive is a 5.25" floppy drive.
-//  It returns 800 if the drive is a 8" floppy drive.
-//  It returns   0 on error.
+//  Returns 350 if the drive is a 3.5" floppy drive.
+//  Returns 525 if the drive is a 5.25" floppy drive.
+//  Returns 800 if the drive is an 8" floppy drive.
+//  Returns   0 on error.
 //
 //  drive is C:\, D:\, \\?\Volume{GUID} (win2k and above only) etc.
 

--- a/src/plugins/zip/chicon.h
+++ b/src/plugins/zip/chicon.h
@@ -7,7 +7,7 @@
 // Structs
 
 // These first two structs represent how the icon information is stored
-// when it is bound into a EXE or DLL file. Structure members are WORD
+// when it is bound into an EXE or DLL file. Structure members are WORD
 // aligned and the last member of the structure is the ID instead of
 // the imageoffset.
 #pragma pack(push)

--- a/src/plugins/zip/explode.cpp
+++ b/src/plugins/zip/explode.cpp
@@ -153,7 +153,7 @@ int Explode(CDecompressionObject* decompress);
    buffer of inflate is used, and it works just as well to always have
    a 32K circular buffer, so the index is anded with 0x7fff.  This is
    done to allow the window to also be used as the output buffer. */
-/* This must be supplied in an external module useable like "uch slide[8192];"
+/* This must be supplied in an external module usable like "uch slide[8192];"
    or "uch *slide;", where the latter would be malloc'ed.  In unzip, slide[]
    is actually a 32K area for use by inflate, which uses a 32K sliding window.
  */

--- a/src/plugins/zip/inflate.cpp
+++ b/src/plugins/zip/inflate.cpp
@@ -41,7 +41,7 @@
    There are (currently) three kinds of inflate blocks: stored, fixed, and
    dynamic.  The compressor outputs a chunk of data at a time and decides
    which method to use on a chunk-by-chunk basis.  A chunk might typically
-   be 32K to 64K, uncompressed.  If the chunk is uncompressible, then the
+   be 32K to 64K, uncompressed.  If the chunk is incompressible, then the
    "stored" method is used.  In this case, the bytes are simply stored as
    is, eight bits per byte, with none of the above coding.  The bytes are
    preceded by a count, since there is no longer an EOB code.

--- a/src/plugins/zip/selfextr/inflate.cpp
+++ b/src/plugins/zip/selfextr/inflate.cpp
@@ -50,7 +50,7 @@ unsigned char* InEnd;
    There are (currently) three kinds of inflate blocks: stored, fixed, and
    dynamic.  The compressor outputs a chunk of data at a time and decides
    which method to use on a chunk-by-chunk basis.  A chunk might typically
-   be 32K to 64K, uncompressed.  If the chunk is uncompressible, then the
+   be 32K to 64K, uncompressed.  If the chunk is incompressible, then the
    "stored" method is used.  In this case, the bytes are simply stored as
    is, eight bits per byte, with none of the above coding.  The bytes are
    preceded by a count, since there is no longer an EOB code.

--- a/src/plugins/zip/zip2sfx/inflate.cpp
+++ b/src/plugins/zip/zip2sfx/inflate.cpp
@@ -55,7 +55,7 @@ unsigned char* InEnd;
    There are (currently) three kinds of inflate blocks: stored, fixed, and
    dynamic.  The compressor outputs a chunk of data at a time and decides
    which method to use on a chunk-by-chunk basis.  A chunk might typically
-   be 32K to 64K, uncompressed.  If the chunk is uncompressible, then the
+   be 32K to 64K, uncompressed.  If the chunk is incompressible, then the
    "stored" method is used.  In this case, the bytes are simply stored as
    is, eight bits per byte, with none of the above coding.  The bytes are
    preceded by a count, since there is no longer an EOB code.

--- a/src/salinflt.cpp
+++ b/src/salinflt.cpp
@@ -33,7 +33,7 @@
    There are (currently) three kinds of inflate blocks: stored, fixed, and
    dynamic.  The compressor outputs a chunk of data at a time and decides
    which method to use on a chunk-by-chunk basis.  A chunk might typically
-   be 32K to 64K, uncompressed.  If the chunk is uncompressible, then the
+   be 32K to 64K, uncompressed.  If the chunk is incompressible, then the
    "stored" method is used.  In this case, the bytes are simply stored as
    is, eight bits per byte, with none of the above coding.  The bytes are
    preceded by a count, since there is no longer an EOB code.

--- a/src/shellext/shellext.h
+++ b/src/shellext/shellext.h
@@ -302,7 +302,7 @@ void SE_Destructor(ShellExt* se);
 #define _ILNext(pidl)           _ILSkip(pidl, (pidl)->mkid.cb) 
 
 //#ifdef _DEBUG 
-// Dugging aids for making sure we dont use free pidls 
+// Debugging aids for making sure we don't use freed PIDLs
 //#define VALIDATE_PIDL(pidl) Assert((pidl)->mkid.cb != 0xC5C5) 
 //#else 
 #define VALIDATE_PIDL(pidl) 

--- a/src/translator/datarh.h
+++ b/src/translator/datarh.h
@@ -77,7 +77,7 @@ public:
 protected:
     void CleanIncompleteItems();
 
-    // analyse the line and add it to the array if it is a define
+    // analyse the line and add it to the array if it is a #define
     BOOL ProcessLine(const char* line, const char* lineEnd, int row);
 
     // convert 'param' to a numeric ID; when the value is still unknown because


### PR DESCRIPTION
Summary:
- polish minor wording issues in translated English comments
- normalize small terms such as combo box, through, and EXE article usage
- keep the changes comment-only, without runtime string or diagnostic literal edits

Validation:
- python tools/comments/english_audit.py . --no-diagnostic-strings --no-style-consistency --min-severity low --format text --exit-zero
- git diff --cached --check
- python tools/comments/code_guard.py against the normalized baseline for touched .cpp/.h files