### PR TITLE
Translate Czech trace messages

### DIFF
--- a/src/plugins/filecomp/filecomp.cpp
+++ b/src/plugins/filecomp/filecomp.cpp
@@ -656,7 +656,7 @@ CFilecompThread::Body()
         wnd = dlg->Create();
         if (!wnd)
         {
-            TRACE_E("Nepodarilo se vytvorit CompareFilesDialog");
+            TRACE_E("Failed to create CompareFilesDialog");
             goto LBODYFINAL;
         }
         SetForegroundWindow(wnd);
@@ -726,7 +726,7 @@ CFilecompThread::Body()
                             win);
         if (!wnd)
         {
-            TRACE_E("Nepodarilo se vytvorit MainWindow, GetLastError() = " << GetLastError());
+            TRACE_E("Failed to create MainWindow, GetLastError() = " << GetLastError());
             break;
         }
         dialogBox = FALSE;

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -778,13 +778,13 @@ void CSetWaitCursorWindow::AttachToWindow(HWND hWnd)
     DefWndProc = (WNDPROC)GetWindowLongPtr(hWnd, GWLP_WNDPROC);
     if (DefWndProc == NULL)
     {
-        TRACE_E("Spatny handle okna. hWnd = " << hWnd);
+        TRACE_E("Invalid window handle. hWnd = " << hWnd);
         DefWndProc = DefWindowProc;
         return;
     }
     if (!SetProp(hWnd, (LPCTSTR)AtomObject2, (HANDLE)this))
     {
-        TRACE_E("Chyba pri pripojovani objektu na okno.");
+        TRACE_E("Error attaching object to window.");
         DefWndProc = DefWindowProc;
         return;
     }
@@ -793,7 +793,7 @@ void CSetWaitCursorWindow::AttachToWindow(HWND hWnd)
 
     if (DefWndProc == CSetWaitCursorWindow::CWindowProc) // that would be recursion
     {
-        TRACE_E("Tak tohle by se vubec nemelo stat.");
+        TRACE_E("This should never happen.");
         DefWndProc = DefWindowProc;
     }
 }

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -51,7 +51,7 @@ BOOL InitFS()
     WorkerMayBeClosedEvent = HANDLES(CreateEvent(NULL, TRUE, FALSE, NULL)); // manual, nonsignaled
     if (WorkerMayBeClosedEvent == NULL)
     {
-        TRACE_E("Nepodarilo se vytvorit event WorkerMayBeClosedEvent.");
+        TRACE_E("Failed to create event WorkerMayBeClosedEvent.");
         return FALSE;
     }
     HANDLES(InitializeCriticalSection(&WorkerMayBeClosedStateCS));
@@ -115,7 +115,7 @@ BOOL InitFS()
                                              SAVEBITS_CLASSNAME,
                                              NULL))
     {
-        TRACE_E("Nepodarilo se registrovat tridu SAVEBITS_CLASSNAME.");
+        TRACE_E("Failed to register class SAVEBITS_CLASSNAME.");
         return FALSE;
     }
 

--- a/src/plugins/pictview/pictview.cpp
+++ b/src/plugins/pictview/pictview.cpp
@@ -1911,7 +1911,7 @@ BOOL CPluginInterfaceForViewer::ViewFile(LPCTSTR name, int left, int top, int wi
     HANDLE contEvent = CreateEvent(NULL, FALSE, FALSE, NULL);
     if (contEvent == NULL)
     {
-        TRACE_E("Nepodarilo se vytvorit Continue event.");
+        TRACE_E("Failed to create Continue event.");
         return FALSE;
     }
 

--- a/src/plugins/pictview/render1.cpp
+++ b/src/plugins/pictview/render1.cpp
@@ -2870,11 +2870,11 @@ BOOL CRendererWindow::RenameFileInternal(LPCTSTR oldPath, LPCTSTR oldName, TCHAR
                         else
                         {
                             if (in == INVALID_HANDLE_VALUE)
-                                TRACE_E("Nepodarilo se otevrit soubor " << path);
+                                TRACE_E("Failed to open file " << path);
                             else
                                 CloseHandle(in);
                             if (out == INVALID_HANDLE_VALUE)
-                                TRACE_E("Nepodarilo se otevrit soubor " << tgtPath);
+                                TRACE_E("Failed to open file " << tgtPath);
                             else
                                 CloseHandle(out);
                         }

--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -1180,7 +1180,7 @@ int CZipCommon::CheckForExtraBytes()
     {
         if (Extract && expectedEndOfCentrDir > CentrDirOffs)
         {
-            TRACE_W("spatna velikost centralniho adresare, kompenzuji chybu");
+            TRACE_W("bad central directory size, compensating for the error");
             CentrDirSize = expectedEndOfCentrDir - CentrDirOffs;
             return 0;
         }
@@ -1355,10 +1355,10 @@ void CZipCommon::ProcessHeader(CFileHeader* fileHeader, CFileInfo* fileInfo)
                     fileInfo->StartDisk = NEXT(DWORD);
             }
             else
-                TRACE_E("zip64 extra-field je prilis maly, poskozeny zip?");
+                TRACE_E("Zip64 extra field is too small, corrupted ZIP?");
         }
         else
-            TRACE_E("nenasli jsme zip64 extra-field, poskozeny zip?");
+            TRACE_E("Zip64 extra field not found, corrupted ZIP?");
     }
 }
 

--- a/src/plugins/zip/dialogs2.cpp
+++ b/src/plugins/zip/dialogs2.cpp
@@ -237,13 +237,13 @@ BOOL CAdvancedSEDialog::OnInit(WPARAM wParam, LPARAM lParam)
         CurrentSfxLang = (CSfxLang*)SendDlgItemMessage(Dlg, IDC_LANGUAGE, CB_GETITEMDATA, i, 0);
         if ((LRESULT)CurrentSfxLang == CB_ERR)
         {
-            TRACE_E("nepodarilo se ziskat aktualni jazyk z comboboxu");
+            TRACE_E("Failed to get current language from combo box");
             CurrentSfxLang = NULL;
         }
     }
     else
     {
-        TRACE_E("nepodarilo se ziskat aktualni jazyk z comboboxu");
+        TRACE_E("Failed to get current language from combo box");
         CurrentSfxLang = NULL;
     }
 
@@ -487,10 +487,10 @@ BOOL CAdvancedSEDialog::OnTexts(WORD wNotifyCode, WORD wID, HWND hwndCtl)
             dlg.Proceed();
         }
         else
-            TRACE_E("nepodarilo se ziskat aktualni jazyk z comboboxu");
+            TRACE_E("Failed to get current language from combo box");
     }
     else
-        TRACE_E("nepodarilo se ziskat aktualni jazyk z comboboxu");
+        TRACE_E("Failed to get current language from combo box");
 
     return TRUE;
 }
@@ -922,7 +922,7 @@ BOOL CAdvancedSEDialog::CreateFavoritesMenu()
     FavoritiesMenu = CreatePopupMenu();
     if (!FavoritiesMenu)
     {
-        TRACE_E("Nedostali jsme FavoritiesMenu ve funkci InitMenu.");
+        TRACE_E("Failed to create FavoritiesMenu in InitMenu.");
         return FALSE;
     }
     if (Favorities.Count == 0)
@@ -1048,7 +1048,7 @@ BOOL CAdvancedSEDialog::OnImport()
                     lstrcpy(settings.SfxFile, DefLanguage->FileName);
                 else
                 {
-                    TRACE_E("CAdvancedSEDialog::OnImport(), neni naloadena DefLanguage");
+                    TRACE_E("CAdvancedSEDialog::OnImport(), DefLanguage is not loaded");
                     settings.SfxFile[0] = 0;
                 }
 
@@ -1350,7 +1350,7 @@ BOOL CAdvancedSEDialog::OnResetValues()
     if (!DefLanguage)
     {
         //MessageBox(Dlg, LoadStr(IDS_NODEFSFX), LoadStr(IDS_ERROR), MB_OK | MB_ICONEXCLAMATION);
-        TRACE_E("Neni naloudena DefLanguage pro sfx advanced dialog a je volano reset values.");
+        TRACE_E("DefLanguage is not loaded for the SFX advanced dialog, and reset values was called.");
     }
     else
     {
@@ -1577,7 +1577,7 @@ BOOL CAdvancedSEDialog::OnFavoriteOption(WORD itemID)
     mi.fMask = MIIM_DATA;
     if (!GetMenuItemInfo(FavoritiesMenu, itemID, FALSE, &mi))
     {
-        TRACE_E("Nejde ziskat item data vubrane polozky z menu favorities.");
+        TRACE_E("Failed to get item data for the selected Favorities menu item.");
         return TRUE;
     }
     CFavoriteSfx* fav = (CFavoriteSfx*)mi.dwItemData;

--- a/src/plugins/zip/extract.cpp
+++ b/src/plugins/zip/extract.cpp
@@ -492,7 +492,7 @@ void Refill(CDecompressionObject* decompress)
 
     if (CZIPUNPACK(decompress)->BytesLeft == 0)
     {
-        TRACE_E("Pozadavek na doplneni vstupniho bufferu za hranici zkomprimovanych dat");
+        TRACE_E("Request to refill the input buffer beyond the compressed data boundary");
         decompress->Input->Error = IDS_EOF;
         return;
     }
@@ -1317,7 +1317,7 @@ int CZipUnpack::ExtractSingleFile(char* targetDir, int targetDirLen,
                                 {
                                     if (aesExtraField.VendorID != AES_NONVENDOR_ID ||
                                         ((AES_VERSION_1 != aesExtraField.Version) && (AES_VERSION_2 != aesExtraField.Version)))
-                                        TRACE_E("POZOR: soubor '" << FileNameDisp << "' je zakryptovan neznamou verzi AES, mozne komplikace");
+                                        TRACE_E("WARNING: file '" << FileNameDisp << "' is encrypted with an unknown AES version, possible complications");
 
                                     char pwd[MAX_PASSWORD];
                                     unsigned char salt[SAL_AES_MAX_SALT_LENGTH];

--- a/src/plugins/zip/main.cpp
+++ b/src/plugins/zip/main.cpp
@@ -442,7 +442,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
     {
         siz = PackSfxSettings(&LastUsedSfxSet.Settings, buffer, allocated);
         if (siz == -1)
-            TRACE_E("chyba v PackSfxSettings.");
+            TRACE_E("Error in PackSfxSettings.");
         else
         {
             if (registry->SetValue(regKey, CONFIG_SFXLAST, REG_BINARY, buffer, siz))
@@ -467,7 +467,7 @@ void CPluginInterface::SaveConfiguration(HWND parent, HKEY regKey, CSalamanderRe
             siz = PackSfxSettings(&fav->Settings, buffer, allocated);
             if (siz == -1)
             {
-                TRACE_E("chyba v PackSfxSettings.");
+                TRACE_E("Error in PackSfxSettings.");
                 break;
             }
             sprintf(key, CONFIG_SFXFAVDATA, i + 1);

--- a/src/translator/config.cpp
+++ b/src/translator/config.cpp
@@ -89,7 +89,7 @@ BOOL CreateKey(HKEY hKey, const char* name, HKEY& createdKey)
     else
     {
         MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                   "Chyba pri ukladani klice", MB_OK | MB_ICONEXCLAMATION);
+                   "Error saving key", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -107,7 +107,7 @@ BOOL SetValue(HKEY hKey, const char* name, DWORD type,
     else
     {
         MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                   "Chyba pri ukladani klice", MB_OK | MB_ICONEXCLAMATION);
+                   "Error saving key", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -127,7 +127,7 @@ BOOL SetValueW(HKEY hKey, const char* name, DWORD type,
     else
     {
         MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                   "Chyba pri ukladani klice", MB_OK | MB_ICONEXCLAMATION);
+                   "Error saving key", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -143,7 +143,7 @@ BOOL OpenKey(HKEY hKey, const char* name, HKEY& openedKey)
     {
         if (res != ERROR_FILE_NOT_FOUND)
             MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -159,15 +159,15 @@ BOOL GetValue(HKEY hKey, const char* name, DWORD type, void* buffer, DWORD buffe
             return TRUE;
         else
         {
-            MessageBox(FrameWindow.HWindow, "Neocekavany typ hodnoty",
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(FrameWindow.HWindow, "Unexpected value type",
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
             return FALSE;
         }
     else
     {
         if (res != ERROR_FILE_NOT_FOUND)
             MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -185,15 +185,15 @@ BOOL GetValueW(HKEY hKey, const char* name, DWORD type, void* buffer, DWORD buff
             return TRUE;
         else
         {
-            MessageBox(FrameWindow.HWindow, "Neocekavany typ hodnoty",
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(FrameWindow.HWindow, "Unexpected value type",
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
             return FALSE;
         }
     else
     {
         if (res != ERROR_FILE_NOT_FOUND)
             MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -209,15 +209,15 @@ BOOL GetSize(HKEY hKey, const char* name, DWORD type, DWORD& bufferSize)
             return TRUE;
         else
         {
-            MessageBox(FrameWindow.HWindow, "Neocekavany typ hodnoty",
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(FrameWindow.HWindow, "Unexpected value type",
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
             return FALSE;
         }
     else
     {
         if (res != ERROR_FILE_NOT_FOUND)
             MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -235,15 +235,15 @@ BOOL GetSizeW(HKEY hKey, const char* name, DWORD type, DWORD& bufferSize)
             return TRUE;
         else
         {
-            MessageBox(FrameWindow.HWindow, "Neocekavany typ hodnoty",
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+            MessageBox(FrameWindow.HWindow, "Unexpected value type",
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
             return FALSE;
         }
     else
     {
         if (res != ERROR_FILE_NOT_FOUND)
             MessageBox(FrameWindow.HWindow, GetErrorText(res),
-                       "Chyba pri nacitani konfigurace", MB_OK | MB_ICONEXCLAMATION);
+                       "Error loading configuration", MB_OK | MB_ICONEXCLAMATION);
         return FALSE;
     }
 }
@@ -271,7 +271,7 @@ BOOL ClearKey(HKEY key)
     while (RegEnumValue(key, 0, name, &size, NULL, NULL, NULL, NULL) == ERROR_SUCCESS)
         if (RegDeleteValue(key, name) != ERROR_SUCCESS)
         {
-            TRACE_E("Nepodarilo se smazat hodnoty klice z registry.");
+            TRACE_E("Failed to delete key values from the registry.");
             break;
         }
         else

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -603,7 +603,7 @@ int CSalamanderGeneral::DialogError(HWND parent, DWORD flags, const char* fileNa
 {
     if (fileName == NULL || error == NULL)
     {
-        TRACE_E("Invalid parametr (fileName == NULL || error == NULL) in CSalamanderGeneral::DialogError!");
+        TRACE_E("Invalid parameter (fileName == NULL || error == NULL) in CSalamanderGeneral::DialogError!");
         if (fileName == NULL)
             fileName = "";
         if (error == NULL)
@@ -665,7 +665,7 @@ int CSalamanderGeneral::DialogOverwrite(HWND parent, DWORD flags, const char* fi
 {
     if (fileName1 == NULL || fileData1 == NULL || fileName2 == NULL || fileData2 == NULL)
     {
-        TRACE_E("Invalid parametr (fileName1 == NULL || fileData1 == NULL || fileName2 == NULL || fileData2 == NULL) in CSalamanderGeneral::DialogOverwrite!");
+        TRACE_E("Invalid parameter (fileName1 == NULL || fileData1 == NULL || fileName2 == NULL || fileData2 == NULL) in CSalamanderGeneral::DialogOverwrite!");
         if (fileName1 == NULL)
             fileName1 = "";
         if (fileData1 == NULL)
@@ -741,7 +741,7 @@ int CSalamanderGeneral::DialogQuestion(HWND parent, DWORD flags, const char* fil
 {
     if (fileName == NULL || question == NULL)
     {
-        TRACE_E("Invalid parametr (fileName == NULL || question == NULL) in CSalamanderGeneral::DialogQuestion!");
+        TRACE_E("Invalid parameter (fileName == NULL || question == NULL) in CSalamanderGeneral::DialogQuestion!");
         if (fileName == NULL)
             fileName = "";
         if (question == NULL)
@@ -3226,7 +3226,7 @@ void CSalamanderGeneral::RemoveOneFileFromCache(const char* uniqueFileName)
     CALL_STACK_MESSAGE2("CSalamanderGeneral::RemoveOneFileFromCache(%s)", uniqueFileName);
     if (uniqueFileName == NULL)
     {
-        TRACE_E("Invalid parametr (NULL) in CSalamanderGeneral::RemoveOneFileFromCache!");
+        TRACE_E("Invalid parameter (NULL) in CSalamanderGeneral::RemoveOneFileFromCache!");
         return;
     }
     DiskCache.FlushOneFile(uniqueFileName);
@@ -3237,7 +3237,7 @@ void CSalamanderGeneral::RemoveFilesFromCache(const char* fileNamesRoot)
     CALL_STACK_MESSAGE2("CSalamanderGeneral::RemoveFilesFromCache(%s)", fileNamesRoot);
     if (fileNamesRoot == NULL)
     {
-        TRACE_E("Invalid parametr (NULL) in CSalamanderGeneral::RemoveFilesFromCache!");
+        TRACE_E("Invalid parameter (NULL) in CSalamanderGeneral::RemoveFilesFromCache!");
         return;
     }
     DiskCache.FlushCache(fileNamesRoot);
@@ -3260,7 +3260,7 @@ BOOL CSalamanderGeneral::GetConversionTable(HWND parent, char* table, const char
     CALL_STACK_MESSAGE2("CSalamanderGeneral::GetConversionTable(, , %s)", conversion);
     if (table == NULL)
     {
-        TRACE_E("Invalid parametr (table==NULL) in CSalamanderGeneral::GetConversionTable!");
+        TRACE_E("Invalid parameter (table==NULL) in CSalamanderGeneral::GetConversionTable!");
         return FALSE;
     }
     parent = (parent == NULL ? MainWindow->HWindow : parent);


### PR DESCRIPTION
## Summary
- translate remaining Czech TRACE_E/TRACE_W diagnostics in FTP, ZIP, FileComp, PictView, and core ZIP helpers
- fix the `Invalid parametr` typo in trace messages
- translate related Translator configuration error text found by the same non-comment scan

## Validation
- `git diff --check`
- targeted `rg` scan for the replaced Czech diagnostic phrases in the touched files
