### PR TITLE
Remove comment translation markers

### DIFF
--- a/src/bitmap.cpp
+++ b/src/bitmap.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/bitmap.h
+++ b/src/bitmap.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/bugreprt.cpp
+++ b/src/bugreprt.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/cache.cpp
+++ b/src/cache.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/cache.h
+++ b/src/cache.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/callstk.cpp
+++ b/src/callstk.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/callstk.h
+++ b/src/callstk.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/cfgdlg.h
+++ b/src/cfgdlg.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/codetbl.cpp
+++ b/src/codetbl.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/codetbl.h
+++ b/src/codetbl.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/color.cpp
+++ b/src/color.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "color.h"

--- a/src/color.h
+++ b/src/color.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/allochan.cpp
+++ b/src/common/allochan.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/allochan.h
+++ b/src/common/allochan.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/array.cpp
+++ b/src/common/array.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/array.h
+++ b/src/common/array.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/crc32.cpp
+++ b/src/common/crc32.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/crc32.h
+++ b/src/common/crc32.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/dep/sqlite/readme.txt
+++ b/src/common/dep/sqlite/readme.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 SQLite sources are available at http://www.sqlite.org/download.html
 Use sqlite-amalgamation-*.zip.

--- a/src/common/dib.cpp
+++ b/src/common/dib.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/dib.h
+++ b/src/common/dib.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/handles.cpp
+++ b/src/common/handles.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/handles.h
+++ b/src/common/handles.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/heap.cpp
+++ b/src/common/heap.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/heap.h
+++ b/src/common/heap.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/lstrfix.h
+++ b/src/common/lstrfix.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/messages.cpp
+++ b/src/common/messages.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/messages.h
+++ b/src/common/messages.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/moore.cpp
+++ b/src/common/moore.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/moore.h
+++ b/src/common/moore.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 // ****************************************************************************
 // Boyer-Moore substring search algorithm

--- a/src/common/ms_init.cpp
+++ b/src/common/ms_init.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/multimon.cpp
+++ b/src/common/multimon.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/regexp.cpp
+++ b/src/common/regexp.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 /*
  * regcomp and regexec -- regsub and regerror are elsewhere

--- a/src/common/regexp.h
+++ b/src/common/regexp.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/sheets.cpp
+++ b/src/common/sheets.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/sheets.h
+++ b/src/common/sheets.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/str.cpp
+++ b/src/common/str.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/str.h
+++ b/src/common/str.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/strutils.cpp
+++ b/src/common/strutils.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/strutils.h
+++ b/src/common/strutils.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/trace.cpp
+++ b/src/common/trace.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/trace.h
+++ b/src/common/trace.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/common/winlib.cpp
+++ b/src/common/winlib.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/common/winlib.h
+++ b/src/common/winlib.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/consts.h
+++ b/src/consts.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/dialogs.cpp
+++ b/src/dialogs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogs.h
+++ b/src/dialogs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/dialogs2.cpp
+++ b/src/dialogs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogs3.cpp
+++ b/src/dialogs3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogs4.cpp
+++ b/src/dialogs4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogs5.cpp
+++ b/src/dialogs5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogs6.cpp
+++ b/src/dialogs6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogse.cpp
+++ b/src/dialogse.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/dialogsp.cpp
+++ b/src/dialogsp.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/drivelst.cpp
+++ b/src/drivelst.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/drivelst.h
+++ b/src/drivelst.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/editwnd.cpp
+++ b/src/editwnd.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/editwnd.h
+++ b/src/editwnd.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/edtlbwnd.cpp
+++ b/src/edtlbwnd.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/edtlbwnd.h
+++ b/src/edtlbwnd.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/execute.cpp
+++ b/src/execute.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/execute.h
+++ b/src/execute.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/filesbox.h
+++ b/src/filesbox.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/filesbx1.cpp
+++ b/src/filesbx1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/filesbx2.cpp
+++ b/src/filesbx2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/filesmap.cpp
+++ b/src/filesmap.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn0.cpp
+++ b/src/fileswn0.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn1.cpp
+++ b/src/fileswn1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn2.cpp
+++ b/src/fileswn2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn3.cpp
+++ b/src/fileswn3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn4.cpp
+++ b/src/fileswn4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn5.cpp
+++ b/src/fileswn5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn6.cpp
+++ b/src/fileswn6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn7.cpp
+++ b/src/fileswn7.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn8.cpp
+++ b/src/fileswn8.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswn9.cpp
+++ b/src/fileswn9.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswna.cpp
+++ b/src/fileswna.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswnb.cpp
+++ b/src/fileswnb.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/fileswnd.h
+++ b/src/fileswnd.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/filter.cpp
+++ b/src/filter.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/filter.h
+++ b/src/filter.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/find.cpp
+++ b/src/find.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/find.h
+++ b/src/find.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/finddlg1.cpp
+++ b/src/finddlg1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/finddlg2.cpp
+++ b/src/finddlg2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/geticon.cpp
+++ b/src/geticon.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "commoncontrols.h"

--- a/src/gui.cpp
+++ b/src/gui.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/gui.h
+++ b/src/gui.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/icncache.cpp
+++ b/src/icncache.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/icncache.h
+++ b/src/icncache.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/iconlist.cpp
+++ b/src/iconlist.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/iconlist.h
+++ b/src/iconlist.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/inflate.cpp
+++ b/src/inflate.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/inflate.h
+++ b/src/inflate.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/jumplist.cpp
+++ b/src/jumplist.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <ShObjIdl.h>

--- a/src/keyboard.cpp
+++ b/src/keyboard.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/lang/texts.rc2
+++ b/src/lang/texts.rc2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-#include "..\texts.rh2"
+﻿#include "..\texts.rh2"
 
 STRINGTABLE
 {

--- a/src/logo.cpp
+++ b/src/logo.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "mainwnd.h"

--- a/src/logo.h
+++ b/src/logo.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/mainwnd.h
+++ b/src/mainwnd.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/mainwnd1.cpp
+++ b/src/mainwnd1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mainwnd2.cpp
+++ b/src/mainwnd2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mainwnd3.cpp
+++ b/src/mainwnd3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mainwnd4.cpp
+++ b/src/mainwnd4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mainwnd5.cpp
+++ b/src/mainwnd5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mapi.cpp
+++ b/src/mapi.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/mapi.h
+++ b/src/mapi.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/masks.cpp
+++ b/src/masks.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/masks.h
+++ b/src/masks.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/md5.cpp
+++ b/src/md5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h" // include serves only for compilability in Salamander
 

--- a/src/md5.h
+++ b/src/md5.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/menu.h
+++ b/src/menu.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/menu1.cpp
+++ b/src/menu1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/menu2.cpp
+++ b/src/menu2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/menu3.cpp
+++ b/src/menu3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/menu4.cpp
+++ b/src/menu4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/menubar.cpp
+++ b/src/menubar.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/ms_init.cpp
+++ b/src/ms_init.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/msgbox.cpp
+++ b/src/msgbox.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/olespy.cpp
+++ b/src/olespy.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/olespy.h
+++ b/src/olespy.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/pack.h
+++ b/src/pack.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/pack1.cpp
+++ b/src/pack1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/pack2.cpp
+++ b/src/pack2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/pack3.cpp
+++ b/src/pack3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/packac.cpp
+++ b/src/packac.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/packers.cpp
+++ b/src/packers.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins.h
+++ b/src/plugins.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/7zip/7zip.cpp
+++ b/src/plugins/7zip/7zip.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/7zip/7zthreads.cpp
+++ b/src/plugins/7zip/7zthreads.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/7zip/FStreams.cpp
+++ b/src/plugins/7zip/FStreams.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/7zip/dialogs.cpp
+++ b/src/plugins/7zip/dialogs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/7zip/extract.cpp
+++ b/src/plugins/7zip/extract.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/7zip/update.h
+++ b/src/plugins/7zip/update.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/automation/generated/readme.txt
+++ b/src/plugins/automation/generated/readme.txt
@@ -1,3 +1,2 @@
-CommentsTranslationProject: TRANSLATED
 
 This directory contains only automatically generated files.

--- a/src/plugins/automation/help/hh/salamander_help_shared.css
+++ b/src/plugins/automation/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/automation/versinfo.rh2
+++ b/src/plugins/automation/versinfo.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-/*
+﻿/*
 	Automation Plugin for Open Salamander
 	
 	Copyright (c) 2009-2023 Milan Kase <manison@manison.cz>

--- a/src/plugins/checksum/help/hh/salamander_help_shared.css
+++ b/src/plugins/checksum/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/demoplug/help/hh/salamander_help_shared.css
+++ b/src/plugins/demoplug/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/filecomp/filecomp.rh2
+++ b/src/plugins/filecomp/filecomp.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
+﻿// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __FILECOMP_RH2
 #define __FILECOMP_RH2
 

--- a/src/plugins/filecomp/todo.txt
+++ b/src/plugins/filecomp/todo.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 Rework
 - Ignore differences caused by ambiguities in Unicode encoding.

--- a/src/plugins/ftp/ctrlcon.h
+++ b/src/plugins/ftp/ctrlcon.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/ctrlcon1.cpp
+++ b/src/plugins/ftp/ctrlcon1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ctrlcon2.cpp
+++ b/src/plugins/ftp/ctrlcon2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ctrlcon3.cpp
+++ b/src/plugins/ftp/ctrlcon3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ctrlcon4.cpp
+++ b/src/plugins/ftp/ctrlcon4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ctrlcon5.cpp
+++ b/src/plugins/ftp/ctrlcon5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/datacon.h
+++ b/src/plugins/ftp/datacon.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/datacon1.cpp
+++ b/src/plugins/ftp/datacon1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "spl_zlib.h"

--- a/src/plugins/ftp/datacon2.cpp
+++ b/src/plugins/ftp/datacon2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs.h
+++ b/src/plugins/ftp/dialogs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/dialogs1.cpp
+++ b/src/plugins/ftp/dialogs1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs2.cpp
+++ b/src/plugins/ftp/dialogs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs3.cpp
+++ b/src/plugins/ftp/dialogs3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs4.cpp
+++ b/src/plugins/ftp/dialogs4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs5.cpp
+++ b/src/plugins/ftp/dialogs5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs6.cpp
+++ b/src/plugins/ftp/dialogs6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs7.cpp
+++ b/src/plugins/ftp/dialogs7.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/dialogs8.cpp
+++ b/src/plugins/ftp/dialogs8.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/fs1.cpp
+++ b/src/plugins/ftp/fs1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/fs2.cpp
+++ b/src/plugins/ftp/fs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/fs3.cpp
+++ b/src/plugins/ftp/fs3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/fs4.cpp
+++ b/src/plugins/ftp/fs4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/fs5.cpp
+++ b/src/plugins/ftp/fs5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftp.cpp
+++ b/src/plugins/ftp/ftp.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftp.h
+++ b/src/plugins/ftp/ftp.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/ftp2.cpp
+++ b/src/plugins/ftp/ftp2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftp3.cpp
+++ b/src/plugins/ftp/ftp3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftp4.cpp
+++ b/src/plugins/ftp/ftp4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftputils.cpp
+++ b/src/plugins/ftp/ftputils.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ftputils.h
+++ b/src/plugins/ftp/ftputils.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/help/hh/salamander_help_shared.css
+++ b/src/plugins/ftp/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/ftp/menu.cpp
+++ b/src/plugins/ftp/menu.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats.h
+++ b/src/plugins/ftp/operats.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/operats1.cpp
+++ b/src/plugins/ftp/operats1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats2.cpp
+++ b/src/plugins/ftp/operats2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats3.cpp
+++ b/src/plugins/ftp/operats3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats4.cpp
+++ b/src/plugins/ftp/operats4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats5.cpp
+++ b/src/plugins/ftp/operats5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats6.cpp
+++ b/src/plugins/ftp/operats6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats7.cpp
+++ b/src/plugins/ftp/operats7.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats8.cpp
+++ b/src/plugins/ftp/operats8.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operats9.cpp
+++ b/src/plugins/ftp/operats9.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operatsa.cpp
+++ b/src/plugins/ftp/operatsa.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/operatsb.cpp
+++ b/src/plugins/ftp/operatsb.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/parser.h
+++ b/src/plugins/ftp/parser.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/parser1.cpp
+++ b/src/plugins/ftp/parser1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/parser2.cpp
+++ b/src/plugins/ftp/parser2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/parser3.cpp
+++ b/src/plugins/ftp/parser3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/precomp.cpp
+++ b/src/plugins/ftp/precomp.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/precomp.h
+++ b/src/plugins/ftp/precomp.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/servers/beta.txt
+++ b/src/plugins/ftp/servers/beta.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 This file contains a report about bug fixes and new features
 in Altap Salamander. A plus sign means a new feature,

--- a/src/plugins/ftp/servers/parsing.txt
+++ b/src/plugins/ftp/servers/parsing.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 Description of the rule parsing format:
 =======================================

--- a/src/plugins/ftp/servers/path_types.txt
+++ b/src/plugins/ftp/servers/path_types.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 UNIX:
 /pub/d

--- a/src/plugins/ftp/servers/proxy_script.txt
+++ b/src/plugins/ftp/servers/proxy_script.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 Description of the login script format (for proxy servers and firewalls):
 =========================================================================

--- a/src/plugins/ftp/servers/target_path_types.txt
+++ b/src/plugins/ftp/servers/target_path_types.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 OS/2:
 NOVELL/WINDOWS-NT:

--- a/src/plugins/ftp/servers/todo.txt
+++ b/src/plugins/ftp/servers/todo.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 - we keep running into users who want to save bookmarks but do not want to save
   the Salamander configuration so they do not mess anything up (a bit

--- a/src/plugins/ftp/sockets.cpp
+++ b/src/plugins/ftp/sockets.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/sockets.h
+++ b/src/plugins/ftp/sockets.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/ftp/ssl.cpp
+++ b/src/plugins/ftp/ssl.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/ftp/ssl.h
+++ b/src/plugins/ftp/ssl.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/mmviewer/ogg/oggparser.cpp
+++ b/src/plugins/mmviewer/ogg/oggparser.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/pictview/PVMessageEnvelope.cpp
+++ b/src/plugins/pictview/PVMessageEnvelope.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/pictview/help/hh/salamander_help_shared.css
+++ b/src/plugins/pictview/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/pictview/pictview.rh2
+++ b/src/plugins/pictview/pictview.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
+﻿// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __PICTVIEW_RH2
 #define __PICTVIEW_RH2
 

--- a/src/plugins/pictview/pvw32cnv.rh2
+++ b/src/plugins/pictview/pvw32cnv.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// Petr: this file exists only to generate symbols\plugins\pictview\symbols.inc using tools\export_translator\export_inc.py
+﻿// Petr: this file exists only to generate symbols\plugins\pictview\symbols.inc using tools\export_translator\export_inc.py
 
 // Petr: I added IDS_PVW32Cnv_XXXX so the quiet validation in Translator wouldn't complain.
 #define IDS_PVW32Cnv_4003          4003

--- a/src/plugins/regedt/fs5.cpp
+++ b/src/plugins/regedt/fs5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/regedt/help/hh/salamander_help_shared.css
+++ b/src/plugins/regedt/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/regedt/regedt.rh2
+++ b/src/plugins/regedt/regedt.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
+﻿// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __REGEDT_RH2
 #define __REGEDT_RH2
 

--- a/src/plugins/shared/arraylt.h
+++ b/src/plugins/shared/arraylt.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/auxtools.cpp
+++ b/src/plugins/shared/auxtools.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/auxtools.h
+++ b/src/plugins/shared/auxtools.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/dbg.cpp
+++ b/src/plugins/shared/dbg.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/dbg.h
+++ b/src/plugins/shared/dbg.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/htmlhelp.h
+++ b/src/plugins/shared/htmlhelp.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************
 *                                                                           *

--- a/src/plugins/shared/lukas/array2.h
+++ b/src/plugins/shared/lukas/array2.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/counter.h
+++ b/src/plugins/shared/lukas/counter.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/diff.h
+++ b/src/plugins/shared/lukas/diff.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/dumpmem.h
+++ b/src/plugins/shared/lukas/dumpmem.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/gdi.cpp
+++ b/src/plugins/shared/lukas/gdi.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "gdi.h"

--- a/src/plugins/shared/lukas/gdi.h
+++ b/src/plugins/shared/lukas/gdi.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/killdbg.h
+++ b/src/plugins/shared/lukas/killdbg.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/lcutils.h
+++ b/src/plugins/shared/lukas/lcutils.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/messages.cpp
+++ b/src/plugins/shared/lukas/messages.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/shared/lukas/messages.h
+++ b/src/plugins/shared/lukas/messages.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/resedit.cpp
+++ b/src/plugins/shared/lukas/resedit.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/shared/lukas/resedit.h
+++ b/src/plugins/shared/lukas/resedit.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/shared/lukas/str.cpp
+++ b/src/plugins/shared/lukas/str.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/shared/lukas/utilaux.cpp
+++ b/src/plugins/shared/lukas/utilaux.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/shared/lukas/utilbase.cpp
+++ b/src/plugins/shared/lukas/utilbase.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/shared/lukas/utildlg.cpp
+++ b/src/plugins/shared/lukas/utildlg.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/shared/mhandles.cpp
+++ b/src/plugins/shared/mhandles.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/mhandles.h
+++ b/src/plugins/shared/mhandles.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_arc.h
+++ b/src/plugins/shared/spl_arc.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_base.h
+++ b/src/plugins/shared/spl_base.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_bzip2.h
+++ b/src/plugins/shared/spl_bzip2.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_com.h
+++ b/src/plugins/shared/spl_com.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_crypt.h
+++ b/src/plugins/shared/spl_crypt.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_file.h
+++ b/src/plugins/shared/spl_file.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_fs.h
+++ b/src/plugins/shared/spl_fs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_gen.h
+++ b/src/plugins/shared/spl_gen.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_gui.h
+++ b/src/plugins/shared/spl_gui.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_menu.h
+++ b/src/plugins/shared/spl_menu.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_thum.h
+++ b/src/plugins/shared/spl_thum.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_vers.h
+++ b/src/plugins/shared/spl_vers.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_view.h
+++ b/src/plugins/shared/spl_view.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/spl_zlib.h
+++ b/src/plugins/shared/spl_zlib.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/winliblt.cpp
+++ b/src/plugins/shared/winliblt.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/shared/winliblt.h
+++ b/src/plugins/shared/winliblt.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/tar/help/hh/salamander_help_shared.css
+++ b/src/plugins/tar/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/uncab/help/hh/salamander_help_shared.css
+++ b/src/plugins/uncab/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/unchm/chmfile.cpp
+++ b/src/plugins/unchm/chmfile.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/unchm/chmlib/chm_lib.c
+++ b/src/plugins/unchm/chmlib/chm_lib.c
@@ -1,6 +1,5 @@
 /* $Id$ */
 /***************************************************************************
-// CommentsTranslationProject: TRANSLATED
  *             chm_lib.c - CHM archive manipulation routines               *
  *                           -------------------                           *
  *                                                                         *

--- a/src/plugins/unchm/chmlib/lzx.c
+++ b/src/plugins/unchm/chmlib/lzx.c
@@ -1,6 +1,5 @@
 /* $Id$ */
 /***************************************************************************
-// CommentsTranslationProject: TRANSLATED
  *                        lzx.c - LZX decompression routines               *
  *                           -------------------                           *
  *                                                                         *

--- a/src/plugins/unchm/chmlib/main.c
+++ b/src/plugins/unchm/chmlib/main.c
@@ -1,6 +1,5 @@
 //
 //
-// CommentsTranslationProject: TRANSLATED
 //
 
 #include <windows.h>

--- a/src/plugins/unchm/help/hh/salamander_help_shared.css
+++ b/src/plugins/unchm/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/unchm/unchm.cpp
+++ b/src/plugins/unchm/unchm.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/undelete/dialogs.cpp
+++ b/src/plugins/undelete/dialogs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/fs1.cpp
+++ b/src/plugins/undelete/fs1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/fs2.cpp
+++ b/src/plugins/undelete/fs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/help/hh/salamander_help_shared.css
+++ b/src/plugins/undelete/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/undelete/library/arraylt.h
+++ b/src/plugins/undelete/library/arraylt.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/undelete/library/bitmap.h
+++ b/src/plugins/undelete/library/bitmap.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/dataruns.h
+++ b/src/plugins/undelete/library/dataruns.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/exfat.h
+++ b/src/plugins/undelete/library/exfat.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/fat.cpp
+++ b/src/plugins/undelete/library/fat.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/library/fat.h
+++ b/src/plugins/undelete/library/fat.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/miscstr.cpp
+++ b/src/plugins/undelete/library/miscstr.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/library/ntfs.h
+++ b/src/plugins/undelete/library/ntfs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/snapshot.h
+++ b/src/plugins/undelete/library/snapshot.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/stream.h
+++ b/src/plugins/undelete/library/stream.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/undelete/library/volenum.cpp
+++ b/src/plugins/undelete/library/volenum.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "..\undelete.rh2"

--- a/src/plugins/undelete/restore.cpp
+++ b/src/plugins/undelete/restore.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/undelete/undelete.cpp
+++ b/src/plugins/undelete/undelete.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 // ****************************************************************************
 //

--- a/src/plugins/undelete/undelete.h
+++ b/src/plugins/undelete/undelete.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/unfat/fat.cpp
+++ b/src/plugins/unfat/fat.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/unfat/unfat.cpp
+++ b/src/plugins/unfat/unfat.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 //****************************************************************************
 //

--- a/src/plugins/uniso/BlockedFile.h
+++ b/src/plugins/uniso/BlockedFile.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/uniso/dmg.cpp
+++ b/src/plugins/uniso/dmg.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/uniso/eltorito.cpp
+++ b/src/plugins/uniso/eltorito.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/hfs.cpp
+++ b/src/plugins/uniso/hfs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/hfs.h
+++ b/src/plugins/uniso/hfs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/uniso/iso9660.cpp
+++ b/src/plugins/uniso/iso9660.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/isoimage.cpp
+++ b/src/plugins/uniso/isoimage.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/nrg.cpp
+++ b/src/plugins/uniso/nrg.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/rawfs.cpp
+++ b/src/plugins/uniso/rawfs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/udf.cpp
+++ b/src/plugins/uniso/udf.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/udfiso.cpp
+++ b/src/plugins/uniso/udfiso.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/uniso.cpp
+++ b/src/plugins/uniso/uniso.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/uniso.h
+++ b/src/plugins/uniso/uniso.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/uniso/viewer.cpp
+++ b/src/plugins/uniso/viewer.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/uniso/xdvdfs.cpp
+++ b/src/plugins/uniso/xdvdfs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include "dbg.h"

--- a/src/plugins/unlha/help/hh/salamander_help_shared.css
+++ b/src/plugins/unlha/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/unlha/lha.cpp
+++ b/src/plugins/unlha/lha.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 /*****************************************************************************************\
 **                                                                                       **

--- a/src/plugins/unlha/unlha.cpp
+++ b/src/plugins/unlha/unlha.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unmime/decoder.cpp
+++ b/src/plugins/unmime/decoder.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************************\
 **                                                                                      **

--- a/src/plugins/unmime/parser.cpp
+++ b/src/plugins/unmime/parser.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 /****************************************************************************************\
 **                                                                                      **

--- a/src/plugins/unmime/unmime.cpp
+++ b/src/plugins/unmime/unmime.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unmime/unmime.rh2
+++ b/src/plugins/unmime/unmime.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
+﻿// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __UNMIME_RH2
 #define __UNMIME_RH2
 

--- a/src/plugins/unole/unole2.cpp
+++ b/src/plugins/unole/unole2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unrar/help/hh/salamander_help_shared.css
+++ b/src/plugins/unrar/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/unrar/unrar.cpp
+++ b/src/plugins/unrar/unrar.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/unrar/unrar.rh2
+++ b/src/plugins/unrar/unrar.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
+﻿// WARNING: cannot be replaced with "#pragma once" because this file is included from a .rc file, and the resource compiler does not seem to support "#pragma once".
 #ifndef __UNRAR_RH2
 #define __UNRAR_RH2
 

--- a/src/plugins/winscp/copy-to-petr-pc.bat
+++ b/src/plugins/winscp/copy-to-petr-pc.bat
@@ -1,4 +1,3 @@
-@rem CommentsTranslationProject: TRANSLATED
 @echo off
 call :langcopy_bat english
 call :langcopy_bat czech

--- a/src/plugins/winscp/help/hh/salamander_help_shared.css
+++ b/src/plugins/winscp/help/hh/salamander_help_shared.css
@@ -1,4 +1,3 @@
-/* CommentsTranslationProject: TRANSLATED */
 /* Cascading Style Sheet for Open Salamander Help */
 /* Shared part used for both CHM and WEB */
 

--- a/src/plugins/winscp/lang/empty.txt
+++ b/src/plugins/winscp/lang/empty.txt
@@ -1,2 +1,1 @@
-CommentsTranslationProject: TRANSLATED
 Only used to keep this directory present.

--- a/src/plugins/winscp/lib/empty.txt
+++ b/src/plugins/winscp/lib/empty.txt
@@ -1,2 +1,1 @@
-CommentsTranslationProject: TRANSLATED
 Only used to keep this directory present.

--- a/src/plugins/wmobile/dialogs.cpp
+++ b/src/plugins/wmobile/dialogs.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/dialogs.h
+++ b/src/plugins/wmobile/dialogs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/wmobile/fs1.cpp
+++ b/src/plugins/wmobile/fs1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/fs2.cpp
+++ b/src/plugins/wmobile/fs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/rapi.cpp
+++ b/src/plugins/wmobile/rapi.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/wmobile.cpp
+++ b/src/plugins/wmobile/wmobile.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/wmobile/wmobile.h
+++ b/src/plugins/wmobile/wmobile.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/add.cpp
+++ b/src/plugins/zip/add.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <winioctl.h>

--- a/src/plugins/zip/bits.cpp
+++ b/src/plugins/zip/bits.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/chicon.cpp
+++ b/src/plugins/zip/chicon.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/common.cpp
+++ b/src/plugins/zip/common.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/common.h
+++ b/src/plugins/zip/common.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/crypt.cpp
+++ b/src/plugins/zip/crypt.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/deflate.cpp
+++ b/src/plugins/zip/deflate.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/deflate.h
+++ b/src/plugins/zip/deflate.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/del.cpp
+++ b/src/plugins/zip/del.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/dialogs2.cpp
+++ b/src/plugins/zip/dialogs2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/dialogs3.cpp
+++ b/src/plugins/zip/dialogs3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/explode.cpp
+++ b/src/plugins/zip/explode.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/extract.cpp
+++ b/src/plugins/zip/extract.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <tchar.h>

--- a/src/plugins/zip/inflate.cpp
+++ b/src/plugins/zip/inflate.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/inflate.h
+++ b/src/plugins/zip/inflate.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/plugins/zip/iosfxset.cpp
+++ b/src/plugins/zip/iosfxset.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/main.cpp
+++ b/src/plugins/zip/main.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <tchar.h>

--- a/src/plugins/zip/prevsfx.cpp
+++ b/src/plugins/zip/prevsfx.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/selfextr/comdefs.h
+++ b/src/plugins/zip/selfextr/comdefs.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 // WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
 #ifndef __COMDEFS_H

--- a/src/plugins/zip/selfextr/dialog.cpp
+++ b/src/plugins/zip/selfextr/dialog.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <shlobj.h>

--- a/src/plugins/zip/selfextr/extended.cpp
+++ b/src/plugins/zip/selfextr/extended.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <Tlhelp32.h>

--- a/src/plugins/zip/selfextr/extract.cpp
+++ b/src/plugins/zip/selfextr/extract.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/plugins/zip/selfextr/inflate.cpp
+++ b/src/plugins/zip/selfextr/inflate.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/plugins/zip/selfextr/language/czech/texts.h
+++ b/src/plugins/zip/selfextr/language/czech/texts.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 // text.h - Czech version
 

--- a/src/plugins/zip/selfextr/selfextr.cpp
+++ b/src/plugins/zip/selfextr/selfextr.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/plugins/zip/sfxmake/crc32.cpp
+++ b/src/plugins/zip/sfxmake/crc32.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/zip/sfxmake/sfxmake.cpp
+++ b/src/plugins/zip/sfxmake/sfxmake.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <windows.h>

--- a/src/plugins/zip/trees.cpp
+++ b/src/plugins/zip/trees.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/unreduce.cpp
+++ b/src/plugins/zip/unreduce.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/unshrink.cpp
+++ b/src/plugins/zip/unshrink.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <crtdbg.h>

--- a/src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt
+++ b/src/plugins/zip/vcxproj/selfextr/selfextr.vc.varovani.txt
@@ -1,4 +1,3 @@
-CommentsTranslationProject: TRANSLATED
 
 When moving to VC2013 (from VC2008), I changed address randomization for
 Release and ReleaseEx (enabled randomization), and from that moment

--- a/src/plugins/zip/zip2sfx/crc32.cpp
+++ b/src/plugins/zip/zip2sfx/crc32.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins/zip/zip2sfx/inflate.cpp
+++ b/src/plugins/zip/zip2sfx/inflate.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 //#include <windows.h>

--- a/src/plugins/zip/zip2sfx/zip2sfx.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 //#include <windows.h>

--- a/src/plugins/zip/zip2sfx/zip2sfx2.cpp
+++ b/src/plugins/zip/zip2sfx/zip2sfx2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 //#include <windows.h>

--- a/src/plugins1.cpp
+++ b/src/plugins1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins2.cpp
+++ b/src/plugins2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins3.cpp
+++ b/src/plugins3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/plugins4.cpp
+++ b/src/plugins4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/precomp.cpp
+++ b/src/precomp.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/precomp.h
+++ b/src/precomp.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/pwdmngr.cpp
+++ b/src/pwdmngr.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <time.h>

--- a/src/pwdmngr.h
+++ b/src/pwdmngr.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/regwork.cpp
+++ b/src/regwork.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/regwork.h
+++ b/src/regwork.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/resource.rh2
+++ b/src/resource.rh2
@@ -1,5 +1,4 @@
 ﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
-// CommentsTranslationProject: TRANSLATED
 #ifndef __RESOURCE_RH2
 #define __RESOURCE_RH2
 

--- a/src/safefile.cpp
+++ b/src/safefile.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salamand.h
+++ b/src/salamand.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/salamdr1.cpp
+++ b/src/salamdr1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <time.h>

--- a/src/salamdr2.cpp
+++ b/src/salamdr2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salamdr3.cpp
+++ b/src/salamdr3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salamdr4.cpp
+++ b/src/salamdr4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salamdr5.cpp
+++ b/src/salamdr5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salamdr6.cpp
+++ b/src/salamdr6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <Sddl.h>

--- a/src/salamdr7.cpp
+++ b/src/salamdr7.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <Ntddscsi.h>

--- a/src/salinflt.cpp
+++ b/src/salinflt.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salinflt.h
+++ b/src/salinflt.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/salmoncl.cpp
+++ b/src/salmoncl.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salmoncl.h
+++ b/src/salmoncl.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/salopen/salopen.cpp
+++ b/src/salopen/salopen.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <shlobj.h>

--- a/src/salshlib.cpp
+++ b/src/salshlib.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/salshlib.h
+++ b/src/salshlib.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/salspawn/salspawn.cpp
+++ b/src/salspawn/salspawn.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/src/shares.cpp
+++ b/src/shares.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 #include <lm.h>

--- a/src/shellib.cpp
+++ b/src/shellib.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/shellib.h
+++ b/src/shellib.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/shellsup.cpp
+++ b/src/shellsup.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/shexreg.c
+++ b/src/shexreg.c
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <shlobj.h>

--- a/src/shexreg.h
+++ b/src/shexreg.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/shiconov.cpp
+++ b/src/shiconov.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/shiconov.h
+++ b/src/shiconov.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/snooper.cpp
+++ b/src/snooper.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/snooper.h
+++ b/src/snooper.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/sort.cpp
+++ b/src/sort.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/sort.h
+++ b/src/sort.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/stswnd.cpp
+++ b/src/stswnd.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/stswnd.h
+++ b/src/stswnd.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/svg.cpp
+++ b/src/svg.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/svg.h
+++ b/src/svg.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/tasklist.cpp
+++ b/src/tasklist.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/tasklist.h
+++ b/src/tasklist.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/texts.rh2
+++ b/src/texts.rh2
@@ -1,5 +1,4 @@
-﻿// CommentsTranslationProject: TRANSLATED
-// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
+﻿// WARNING: cannot be replaced by "#pragma once" because it is included from .rc file and it seems resource compiler does not support "#pragma once"
 #ifndef __TEXTS_RH2
 #define __TEXTS_RH2
 

--- a/src/thumbnl.cpp
+++ b/src/thumbnl.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/thumbnl.h
+++ b/src/thumbnl.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/toolbar.h
+++ b/src/toolbar.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/toolbar1.cpp
+++ b/src/toolbar1.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar2.cpp
+++ b/src/toolbar2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar3.cpp
+++ b/src/toolbar3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar4.cpp
+++ b/src/toolbar4.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar5.cpp
+++ b/src/toolbar5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar6.cpp
+++ b/src/toolbar6.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar7.cpp
+++ b/src/toolbar7.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/toolbar8.cpp
+++ b/src/toolbar8.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/tooltip.cpp
+++ b/src/tooltip.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/tooltip.h
+++ b/src/tooltip.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/usermenu.h
+++ b/src/usermenu.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/versinfo.cpp
+++ b/src/versinfo.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/versinfo.h
+++ b/src/versinfo.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/viewer.cpp
+++ b/src/viewer.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/viewer.h
+++ b/src/viewer.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/viewer2.cpp
+++ b/src/viewer2.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/viewer3.cpp
+++ b/src/viewer3.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/worker.cpp
+++ b/src/worker.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/worker.h
+++ b/src/worker.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/src/zip.cpp
+++ b/src/zip.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "precomp.h"
 

--- a/src/zip.h
+++ b/src/zip.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/tools/salbreak/md5.cpp
+++ b/tools/salbreak/md5.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include "md5.h"
 

--- a/tools/salbreak/salbreak.cpp
+++ b/tools/salbreak/salbreak.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 #include <Sddl.h>

--- a/tools/salbreak/salbreak.h
+++ b/tools/salbreak/salbreak.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 

--- a/tools/salbreak/tasklist.cpp
+++ b/tools/salbreak/tasklist.cpp
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #include <windows.h>
 

--- a/tools/salbreak/tasklist.h
+++ b/tools/salbreak/tasklist.h
@@ -1,6 +1,5 @@
 ﻿// SPDX-FileCopyrightText: 2023 Open Salamander Authors
 // SPDX-License-Identifier: GPL-2.0-or-later
-// CommentsTranslationProject: TRANSLATED
 
 #pragma once
 


### PR DESCRIPTION
## Summary
- remove obsolete `CommentsTranslationProject: TRANSLATED` marker lines after the comment translation work was completed
- cover all marker spellings used in source, help CSS, text, and batch files
- preserve existing BOM/EOL/formatting; no unrelated normalization changes are included

## Validation
- ran `normalize.ps1`; then removed unrelated clang-format normalization from the PR scope
- `git diff --check upstream/main`
- verified `rg "CommentsTranslationProject:\\s*TRANSLATED" .` no longer finds marker lines
- verified at Git blob/index level that every changed file equals the upstream blob with only the marker line removed, preserving BOM where present
